### PR TITLE
Include allies in combat beat state serialization

### DIFF
--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -882,7 +882,8 @@ class ApiCombatAdapter:
                 beat_state = CombatStateSerializer.serialize_combat_state(
                     self.player,
                     self.player.combat_list,
-                    round_number=self.player.combat_beat
+                    round_number=self.player.combat_beat,
+                    allies=self.player.combat_list_allies[1:],
                 )
                 
                 # Add log to beat state (snapshot of log at this point)


### PR DESCRIPTION
## Summary
Updated the combat beat state serialization to include ally information when executing moves in combat.

## Key Changes
- Modified `_execute_move()` method in `combat_adapter.py` to pass `allies` parameter to `CombatStateSerializer.serialize_combat_state()`
- The allies list is populated from `self.player.combat_list_allies[1:]`, excluding the first element (likely the player themselves)

## Implementation Details
- The allies parameter is now included in the beat state snapshot, providing visibility into allied units during combat state serialization
- This change ensures that combat state captures the complete party composition for proper game state representation

https://claude.ai/code/session_01RGnXRJnucPqePtH9RcA61c