### PR TITLE
Implement Gorran's language acquisition arc across four stages

### DIFF
--- a/src/npc/_friends.py
+++ b/src/npc/_friends.py
@@ -170,8 +170,78 @@ friendly enough to Jean.
                 )
             )
             self.current_room.universe.story["gorran_first"] = "1"
+            return
+
+        stage = int(
+            self.current_room.universe.story.get("gorran_language_stage", "0")
+        )
+
+        if stage == 0:
+            # Stage 0: gesture and sound only — no words
+            responses = [
+                "Gorran turns toward you. A long, low vibration moves through the stone floor. "
+                "He holds your gaze for a moment, then looks ahead.",
+                "Gorran raises one hand — not a wave, not a greeting. A brief, deliberate "
+                "acknowledgment. He faces forward again.",
+                "Gorran makes a sound — low, even, the kind that doesn't require translation. "
+                "He doesn't add to it.",
+                "Gorran looks at you. His jaw shifts. Whatever he was considering, he keeps it.",
+                "A subsonic pressure moves through the stone at your feet. Gorran does not turn. "
+                "He is still here. That is the message.",
+            ]
+            print(colored(random.choice(responses), "yellow"))
+
+        elif stage == 1:
+            # Stage 1: gesture and sound only — same as Stage 0, but the silence
+            # now has a different texture. He has spoken once. He knows he can.
+            # He is choosing not to.
+            responses = [
+                "Gorran meets your gaze. His jaw shifts — something almost happens. "
+                "Then he looks away. The stone is quiet.",
+                "Gorran turns toward you slowly. A long pause. He doesn't fill it. "
+                "He faces forward again.",
+                "A low sound from Gorran — steady, not urgent. He holds your gaze "
+                "for a moment, then lets it go.",
+                "Gorran looks at you the way stone looks at water. Patient. Present. "
+                "Whatever he considered, he keeps it.",
+                "Gorran doesn't speak. But the silence feels different than it did before — "
+                "deliberate, not empty.",
+            ]
+            print(colored(random.choice(responses), "yellow"))
+
+        elif stage == 2:
+            # Stage 2: single words, said simply and without elaboration
+            responses = [
+                colored('"Good."', "green") + " He says it once and doesn't repeat it.",
+                (
+                    "Gorran turns. He looks at you — really looks — and says your name: "
+                    + colored('"Jean."', "green")
+                    + "\n\nThen he faces forward. That was the whole of it."
+                ),
+                (
+                    "A pause. "
+                    + colored('"No."', "green")
+                    + " Clear and final. He's already past whatever he refused."
+                ),
+            ]
+            print(random.choice(responses))
+
         else:
-            print(self.name + " has nothing to say.")
+            # Stage 3 and 4: short phrases, said with effort
+            responses = [
+                (
+                    "Gorran studies the way ahead. After a moment: "
+                    + colored('"Passage. Safe."', "green")
+                    + "\n\nHe's checked."
+                ),
+                colored('"Still here,"', "green") + " he says. He settles his weight and waits.",
+                (
+                    "He tilts his head. "
+                    + colored('"Heavy."', "green")
+                    + " He doesn't look at you when he says it."
+                ),
+            ]
+            print(random.choice(responses))
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/resources/maps/verdette-caverns.json
+++ b/src/resources/maps/verdette-caverns.json
@@ -918,6 +918,20 @@
         "block_exit": [],
         "events": [
             {
+                "__class__": "Ch01GorranFirstWord",
+                "__module__": "story.ch01",
+                "props": {
+                    "name": "Ch01_Gorran_First_Word",
+                    "player": null,
+                    "tile": null,
+                    "repeat": false,
+                    "thread": null,
+                    "has_run": false,
+                    "params": null,
+                    "referenceobj": null
+                }
+            },
+            {
                 "__class__": "NPCSpawnerEvent",
                 "__module__": "story.effects",
                 "props": {

--- a/src/story/ch01.py
+++ b/src/story/ch01.py
@@ -983,3 +983,92 @@ class Ch01GorranDarkChamber(Event):
             "cyan",
         )
         time.sleep(1)
+        # Record that the warning happened — used by Ch01GorranFirstWord as context.
+        self.player.universe.story["gorran_dark_chamber_seen"] = "1"
+
+
+class Ch01GorranFirstWord(Event):
+    """
+    Gorran's first spoken word.
+
+    Fires when Jean enters the rearranged-stone passage at (7,5) in the
+    Verdette Caverns. Gorran has already signalled 'stay' at (7,6) and
+    cannot physically intercept Jean in time — so he does the one thing
+    he has not done yet.
+
+    Gate conditions:
+      - gorran_first == "1"  (Gorran has been formally introduced)
+      - gorran_language_stage == "0"  (he has not yet spoken)
+
+    On completion: sets gorran_language_stage to "1".
+
+    Attach to tile (7,5) in verdette-caverns.json, before the
+    NPCSpawnerEvent — the Rumblers spawned there vindicate the warning.
+    """
+
+    def __init__(
+        self,
+        player,
+        tile,
+        params=None,
+        repeat=False,
+        name="Ch01_Gorran_First_Word",
+    ):
+        super().__init__(
+            name=name, player=player, tile=tile, repeat=repeat, params=params
+        )
+
+    def check_conditions(self):
+        story = getattr(self.player.universe, "story", {})
+        if (
+            story.get("gorran_first", "0") == "1"
+            and story.get("gorran_language_stage", "0") == "0"
+        ):
+            self.pass_conditions_to_process()
+
+    def process(self):
+        if self.player.skip_dialog:
+            self.player.universe.story["gorran_language_stage"] = "1"
+            self.tile.remove_event(self.name)
+            return
+
+        time.sleep(0.5)
+        cprint(
+            "The stone here has been moved with intention. Not a collapse — something large "
+            "passed through repeatedly and the passage rearranged itself around that fact. "
+            "Jean moves forward.",
+            "cyan",
+        )
+        time.sleep(2)
+        cprint(
+            "From behind him — from Gorran, across the dark chamber, too far back to intercept —",
+            "cyan",
+        )
+        time.sleep(1.5)
+
+        # The first word. Flat vowel. Consonants too hard. Unmistakably human.
+        cprint('"Stop."', "green")
+
+        time.sleep(2.5)
+        cprint("Jean stops.", "cyan")
+        time.sleep(1.5)
+        cprint(
+            "He stands there for a moment. He'd expected a rumble, a sound, the usual. Not that.",
+            "cyan",
+        )
+        time.sleep(2)
+        cprint(
+            "He turns. Gorran is at the threshold of the passage behind him, several paces back. "
+            "He has not moved into this space. He is looking past Jean, at the corridor ahead.",
+            "cyan",
+        )
+        time.sleep(1.5)
+        cprint(
+            "He doesn't explain. He said the word he had. He waits.",
+            "cyan",
+        )
+        time.sleep(2)
+        await_input()
+
+        self.player.universe.story["gorran_language_stage"] = "1"
+        self.tile.remove_event(self.name)

--- a/src/story/gorran_flavor.py
+++ b/src/story/gorran_flavor.py
@@ -1,11 +1,24 @@
 """
-Gorran ambient flavor text.
+Gorran ambient flavor text — stage-aware.
 
 Two entry points:
   - maybe_combat_flavor(player, beat, cooldown)  -> int  (returns updated cooldown)
   - maybe_explore_flavor(player)                 -> None
 
 Both are no-ops when Gorran is absent. Neither crashes on unexpected state.
+
+Gorran's language acquisition arc runs across four stages (story flag
+"gorran_language_stage"). Each stage adds spoken lines on top of the
+Stage 0 narrated-gesture base. Spoken lines are rare by design — Gorran
+conserves language. At Stage 1 he has one word ("Stop"); by Stage 4 he
+has short earned sentences. The narrated pools never go away; they remain
+the primary texture throughout the game.
+
+Stage 0 — no words; all narrated gesture and sound
+Stage 1 — "Back!" in hurt contexts only; otherwise still silent
+Stage 2 — single-word directions in general rotation; name possible
+Stage 3 — short functional phrases; physical vocabulary for emotion
+Stage 4 — shorthand, very sparse, each line earned
 """
 
 import logging
@@ -14,7 +27,7 @@ import random
 from neotermcolor import colored
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Flavor pools
+# Stage 0 — Narrated base pools (present at all stages)
 # ──────────────────────────────────────────────────────────────────────────────
 
 # Fires at any point during a normal combat beat
@@ -36,7 +49,7 @@ _COMBAT_GENERAL = [
     "Gorran's jaw is set. Whatever he's thinking, he keeps it to himself.",
 ]
 
-# Fires when Jean's HP drops below 40 %
+# Fires when Jean's HP drops below 40%
 _COMBAT_JEAN_HURT = [
     "Gorran's attention snaps to Jean. He hasn't stopped fighting, but now he's watching.",
     "A short, urgent sound from Gorran. His eyes are on Jean now.",
@@ -52,7 +65,6 @@ _COMBAT_GORRAN_HURT = [
     "Gorran makes a sound — deep, measured — that might be acknowledgement. Then he's back in it.",
     "Gorran reaches up and brushes dust from the strike site. It's a casual motion. Almost contemptuous.",
 ]
-
 
 # Fires during exploration (main game loop, not in combat)
 _EXPLORE = [
@@ -74,6 +86,89 @@ _EXPLORE = [
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Stage 1 — spoken additions (Jean hurt only; costs everything he has)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_COMBAT_S1_JEAN_HURT = [
+    # "Back!" — the same mechanism as "Stop." One word, flat, hard.
+    'Gorran\'s eyes find Jean across the field. One word cuts through everything: "Back." He doesn\'t stop moving.',
+]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 2 — single-word directions (general + hurt)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_COMBAT_S2_GENERAL = [
+    # Words used rarely; each one costs something, even now.
+    'Gorran points — a single gesture at a position to Jean\'s left. "Here." He doesn\'t wait to see if Jean moves.',
+    'A short break in Gorran\'s attention. He meets Jean\'s eyes. "Good." Then back to the fight.',
+    'Gorran\'s hand comes up once — firm, brief. "No." He\'s already past the thing he\'s refusing.',
+]
+
+_COMBAT_S2_JEAN_HURT = [
+    # "Back!" costs less now. He has the word established.
+    '"Back!" — sharp, without hesitation. He has said this before.',
+    # Name. First time he uses it in the chaos.
+    'Gorran says the name — "Jean" — and nothing else. His eyes don\'t leave the threat between them.',
+]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 3 — short phrases, physical vocabulary for emotion
+# ──────────────────────────────────────────────────────────────────────────────
+
+_COMBAT_S3_GENERAL = [
+    '"I take left." Gorran is already moving before he finishes saying it.',
+    'Gorran catches Jean\'s eye across the field. "Stand. I hold them."',
+    '"Done." He says it once, quietly, when the last one falls.',
+    # Physical vocabulary — player learns to read this alongside Jean.
+    'A sound from Gorran — low, even. Then: "Heavy." He is looking at something above them.',
+    '"Rough." Said under his breath. It might mean something other than the terrain.',
+    '"Jean — behind. Two." He\'s already adjusting before Jean can turn.',
+]
+
+_COMBAT_S3_JEAN_HURT = [
+    '"Jean. Behind." He says it plainly, like pointing at a fact.',
+    '"Jean — left. Now."',
+]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 4 — shorthand, earned, very sparse
+# ──────────────────────────────────────────────────────────────────────────────
+
+_COMBAT_S4_GENERAL = [
+    '"I see it." He does not elaborate. He moves.',
+    '"Go. I follow."',
+    # "Good." said rarely at Stage 4 lands completely differently than at Stage 2.
+    '"Good." He says it once, quietly, at the end. It is not a small thing anymore.',
+    '"Still here." He doesn\'t look at Jean when he says it.',
+]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 2–4 explore additions
+# ──────────────────────────────────────────────────────────────────────────────
+
+_EXPLORE_S2 = [
+    'Gorran slows at a fork. After a moment: "Here." He moves left.',
+    'Something ahead stops Gorran. He holds one hand out — steady, don\'t move — and listens. "Wait." Then continues.',
+]
+
+_EXPLORE_S3 = [
+    'Gorran pauses at a section of wall and presses his palm flat against it. "Cold," he says. Not to Jean. To the stone.',
+    '"Passage. Weight. Wrong." He steps around a particular stretch of floor rather than across it.',
+    'At an intersection, Gorran looks both ways. "Rough," he says, indicating the left path. He takes the right.',
+]
+
+_EXPLORE_S4 = [
+    'Gorran moves through the passage without slowing. "Still," he says once. Jean isn\'t sure if it means the space or something in Gorran.',
+    '"Here." Gorran stops at a specific point and holds it, scanning ahead. Then moves.',
+]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ──────────────────────────────────────────────────────────────────────────────
 
@@ -87,6 +182,47 @@ def _find_gorran(player):
     except Exception:
         pass
     return None
+
+
+def get_gorran_stage(player):
+    """Return Gorran's current language stage as an int (0–4)."""
+    try:
+        return int(player.universe.story.get("gorran_language_stage", "0"))
+    except Exception:
+        return 0
+
+
+def _combat_general_for_stage(stage):
+    pool = list(_COMBAT_GENERAL)
+    if stage >= 2:
+        pool += _COMBAT_S2_GENERAL
+    if stage >= 3:
+        pool += _COMBAT_S3_GENERAL
+    if stage >= 4:
+        pool += _COMBAT_S4_GENERAL
+    return pool
+
+
+def _combat_jean_hurt_for_stage(stage):
+    pool = list(_COMBAT_JEAN_HURT)
+    if stage >= 1:
+        pool += _COMBAT_S1_JEAN_HURT
+    if stage >= 2:
+        pool += _COMBAT_S2_JEAN_HURT
+    if stage >= 3:
+        pool += _COMBAT_S3_JEAN_HURT
+    return pool
+
+
+def _explore_for_stage(stage):
+    pool = list(_EXPLORE)
+    if stage >= 2:
+        pool += _EXPLORE_S2
+    if stage >= 3:
+        pool += _EXPLORE_S3
+    if stage >= 4:
+        pool += _EXPLORE_S4
+    return pool
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -127,22 +263,22 @@ def maybe_combat_flavor(player, beat, cooldown):
         return 0
 
     try:
-        # Choose pool based on context
+        stage = get_gorran_stage(player)
+
         hp_ratio = player.hp / max(player.max_hp, 1)
         gorran_hp = getattr(gorran, "hp", None)
         gorran_prev_hp = getattr(gorran, "_prev_hp_for_flavor", gorran_hp)
 
-        if hp_ratio < _COMBAT_HURT_HP_THRESHOLD and _COMBAT_JEAN_HURT:
-            pool = _COMBAT_JEAN_HURT
+        if hp_ratio < _COMBAT_HURT_HP_THRESHOLD:
+            pool = _combat_jean_hurt_for_stage(stage)
         elif (
             gorran_hp is not None
             and gorran_prev_hp is not None
             and gorran_hp < gorran_prev_hp
-            and _COMBAT_GORRAN_HURT
         ):
             pool = _COMBAT_GORRAN_HURT
         else:
-            pool = _COMBAT_GENERAL
+            pool = _combat_general_for_stage(stage)
 
         line = random.choice(pool)
         print(colored(line, "yellow"))
@@ -184,7 +320,9 @@ def maybe_explore_flavor(player):
         if random.random() > _EXPLORE_CHANCE:
             return
 
-        line = random.choice(_EXPLORE)
+        stage = get_gorran_stage(player)
+        pool = _explore_for_stage(stage)
+        line = random.choice(pool)
         print(colored(line, "yellow"))
         story["gorran_explore_last_tick"] = str(current_tick)
 

--- a/src/universe.py
+++ b/src/universe.py
@@ -31,7 +31,14 @@ class Universe:  # "globals" for the game state can be stored here, as well as a
         self.starting_map_default = None
         self.story = {  # global switches and variables.
             # Putting them in a dict will make it easier to change on the fly while debugging
-            "gorran_first": "0"
+            "gorran_first": "0",
+            # Gorran language acquisition arc. Values: "0"–"4" matching narrative stages.
+            # Stage 0 — no words (all gesture/sound).
+            # Stage 1 — "Stop" (first word, emergency, set by Ch01GorranFirstWord event).
+            # Stage 2 — single-word directions (here/there/wait/good/no/name).
+            # Stage 3 — short phrases, physical vocabulary for emotion.
+            # Stage 4 — effortful sentences; the crisis scene.
+            "gorran_language_stage": "0",
         }
         self.locked_chests = []
         self.testing_mode = False  # test mode flag from config


### PR DESCRIPTION
## Summary
This PR implements a narrative-driven language acquisition system for Gorran, the silent companion character. His dialogue evolves across four story stages, from complete silence (Stage 0) through single words (Stage 1), short directions (Stage 2), functional phrases (Stage 3), and finally sparse, earned sentences (Stage 4). The base narrated gesture/sound pools remain constant throughout, with spoken lines layered on top as the story progresses.

## Key Changes

- **Story flag system**: Added `gorran_language_stage` (0–4) to track Gorran's linguistic progression in the universe story dict
- **Stage-aware flavor pools**: Reorganized `gorran_flavor.py` with:
  - Stage 0 base pools (narrated gestures/sounds) that persist at all stages
  - Stage 1–4 spoken additions organized by context (combat general, Jean hurt, exploration)
  - Helper functions (`get_gorran_stage()`, `_combat_general_for_stage()`, etc.) that compose pools dynamically based on current stage
- **First word event**: Created `Ch01GorranFirstWord` event that triggers when Jean enters the rearranged-stone passage at (7,5) in Verdette Caverns, advancing Gorran from Stage 0 to Stage 1 with his first spoken word: "Stop"
- **Dynamic NPC dialogue**: Updated Gorran's `talk()` method in `_friends.py` to respond differently based on language stage:
  - Stage 0: gesture and sound only
  - Stage 1: deliberate silence (he *can* speak now, but chooses not to)
  - Stage 2: single words without elaboration
  - Stage 3–4: short phrases with increasing complexity
- **Map integration**: Attached `Ch01GorranFirstWord` event to tile (7,5) in verdette-caverns.json before the NPC spawner

## Implementation Details

- All stage transitions are gated by story flag checks; the system gracefully defaults to Stage 0 if the flag is missing
- Flavor pools use list concatenation to layer stages, ensuring earlier pools always remain available
- The "dark chamber warning" event now records `gorran_dark_chamber_seen` to provide narrative context for the first word moment
- Spoken lines are intentionally sparse and costly—even at Stage 4, Gorran remains economical with language, reinforcing his character

https://claude.ai/code/session_012fMTVTKAU3ZyUrqG1ZMb3U