### PR TITLE
feat(world): add four explorable Grondia building interiors

### DIFF
--- a/src/resources/maps/grondia-conclave-archive.json
+++ b/src/resources/maps/grondia-conclave-archive.json
@@ -1,0 +1,184 @@
+{
+    "metadata": {
+        "bgm": "mineral_pools"
+    },
+    "(2, 2)": {
+        "id": "tile_2_2",
+        "title": "Conclave Archive — Reading Hall",
+        "description": "A high-ceilinged chamber lined with stone tablet-shelves, their contents arranged in sequences Jean cannot read. The stone here is a warmer, darker grey than the concourse outside — different mineral composition, or simply more carefully dressed. A low plinth at the centre is polished to a bright ring where hands have rested on it over many years. The air is noticeably still.",
+        "exits": [
+            "east",
+            "north"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [
+            {
+                "__class__": "GronditeMarkToken",
+                "__module__": "items",
+                "props": {}
+            }
+        ],
+        "npcs": [
+            {
+                "__class__": "GronditeConclaveElder",
+                "__module__": "npc",
+                "props": {}
+            }
+        ],
+        "objects": [
+            {
+                "__class__": "WallInscription",
+                "__module__": "objects",
+                "props": {
+                    "name": "Stone Tablets",
+                    "description": "Dense Golemite script carved into stone tablets along the wall. The lettering is smaller and more formal than Jean has seen elsewhere in the city.",
+                    "idle_message": "Dense script is carved into stone tablets along the wall.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "dense script carved into the wall tablets!",
+                    "announce": "Dense script is carved into stone tablets along the wall.",
+                    "keywords": ["read", "examine", "inspect", "view", "check"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "text": "[Dense Golemite script on stone tablets. Jean cannot read most of it. At the base of the nearest slab, a single line in trade tongue has been scratched — a translation note in a different hand: 'Before stone: weight. From weight: us. The pool is the first gift.']"
+                }
+            },
+            {
+                "__class__": "Passageway",
+                "__module__": "objects",
+                "props": {
+                    "name": "Archive Door",
+                    "description": "A low stone archway leads back out to the Conclave annex.",
+                    "idle_message": "The archive door leads back to the Conclave annex.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "the archive door leading back to the Conclave annex!",
+                    "announce": "The archive door leads back to the Conclave annex.",
+                    "keywords": ["leave", "exit", "go", "outside", "door"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "events_before": [],
+                    "events_after": [],
+                    "teleport_map": "grondia",
+                    "teleport_tile": [11, 3],
+                    "persist": true
+                }
+            }
+        ]
+    },
+    "(3, 2)": {
+        "id": "tile_3_2",
+        "title": "Conclave Archive — Deep Stacks",
+        "description": "Narrow aisles between floor-to-ceiling tablet racks, the upper reaches accessible only by iron handholds set into the stone. The organization follows a system Jean cannot parse — marks and sigils, not an alphabet. The tablets are well-maintained; some carry small clay seals at their bases. A sealed stone plate is mortared into the far wall at knee height.",
+        "exits": [
+            "west"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [],
+        "npcs": [],
+        "objects": [
+            {
+                "__class__": "Container",
+                "__module__": "objects",
+                "props": {
+                    "nickname": "sealed stone plate",
+                    "possible_states": ["closed", "opened"],
+                    "revealed": false,
+                    "locked": false,
+                    "state": "closed",
+                    "merchant": "",
+                    "allowed_item_types": [{"__class_type__": "items:Item"}],
+                    "stock_count": 10,
+                    "inventory": [
+                        {
+                            "__class__": "Book",
+                            "__module__": "items",
+                            "props": {
+                                "name": "The Grondelith Concordat",
+                                "description": "A flat stone tablet, its face engraved with dense formal script. A stamp at the top reads 'Office of Exchange' in trade tongue.",
+                                "value": 20,
+                                "weight": 1.5,
+                                "maintype": "Book",
+                                "subtype": "Book",
+                                "type": "Book",
+                                "interactions": ["drop", "read"],
+                                "merchandise": false,
+                                "hidden": false,
+                                "hide_factor": 0,
+                                "discovery_message": "an engraved stone tablet!",
+                                "announce": "A flat engraved stone tablet rests here.",
+                                "text": "GRONDELITH CONCORDAT. Office of Exchange, trade-speech rendering.\n\nEighth Conclave. All present: agreed.\n\nPools: held by all. No one commands. No one takes alone. The pools feed the living. The pools take back the dead.\n\nIf pools are spoiled — infection, overflow, damage — address before all other work. All capable bodies respond.\n\nSignatories held in Archive. Not for copying."
+                            }
+                        },
+                        {"__class__": "Gold", "__module__": "items", "props": {"amt": 30}},
+                        {"__class__": "Restorative", "__module__": "items", "props": {}}
+                    ],
+                    "name": "Sealed Stone Plate",
+                    "description": "A flat stone plate mortared into the base of the far wall, its face flush with the surrounding stone. The edge shows signs of occasional opening.",
+                    "idle_message": "A sealed stone plate is set into the base of the far wall.",
+                    "hidden": true,
+                    "hide_factor": 4,
+                    "discovery_message": "a sealed stone plate set into the base of the wall!",
+                    "announce": "A sealed stone plate is set into the base of the far wall.",
+                    "keywords": ["open", "loot", "check", "examine"],
+                    "events": [],
+                    "tile": null,
+                    "player": null
+                }
+            }
+        ]
+    },
+    "(2, 1)": {
+        "id": "tile_2_1",
+        "title": "Conclave Archive — Relic Alcove",
+        "description": "A small side chamber barely wide enough for two people, its walls incised with a repeating geometric border — concentric rings interrupted by radial lines, the same pattern Jean has seen on the archive door. A stone plinth stands at the centre, bare; the surface discolouration shows where something rested on it for a long time. One wall holds a deeply carved niche sealed with a fitted stone panel, its edge worn where fingers have tested it.",
+        "exits": [
+            "south"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [
+            {
+                "__class__": "GronditeMarkToken",
+                "__module__": "items",
+                "props": {}
+            }
+        ],
+        "npcs": [],
+        "objects": [
+            {
+                "__class__": "Container",
+                "__module__": "objects",
+                "props": {
+                    "nickname": "carved niche",
+                    "possible_states": ["closed", "opened"],
+                    "revealed": false,
+                    "locked": false,
+                    "state": "closed",
+                    "merchant": "",
+                    "allowed_item_types": [{"__class_type__": "items:Item"}],
+                    "stock_count": 10,
+                    "inventory": [
+                        {"__class__": "PaleGreyFragment", "__module__": "items", "props": {}},
+                        {"__class__": "Gold", "__module__": "items", "props": {"amt": 20}}
+                    ],
+                    "name": "Carved Niche",
+                    "description": "A deep recess in the wall sealed by a fitted stone panel. The niche is carved with greater care than the surrounding alcove.",
+                    "idle_message": "A fitted stone panel seals a niche in the wall.",
+                    "hidden": true,
+                    "hide_factor": 5,
+                    "discovery_message": "a fitted stone panel concealing a deep niche in the wall!",
+                    "announce": "A fitted stone panel seals a niche in the wall.",
+                    "keywords": ["open", "loot", "check", "examine"],
+                    "events": [],
+                    "tile": null,
+                    "player": null
+                }
+            }
+        ]
+    }
+}

--- a/src/resources/maps/grondia-fabricarium-forge.json
+++ b/src/resources/maps/grondia-fabricarium-forge.json
@@ -1,0 +1,188 @@
+{
+    "metadata": {
+        "bgm": "mineral_pools"
+    },
+    "(2, 2)": {
+        "id": "tile_2_2",
+        "title": "Fabricarium Forge — Workshop Floor",
+        "description": "A broad workshop floor of dark, worn stone, its surface ingrained with mineral dust and the scorch marks of long forge-work. Heavy stone benches occupy both side walls; iron tool racks are fixed at intervals. Two heating channels run beneath floor grates toward the north wall, where the forge bloom hangs above a deep fire pit. The smell is hot metal and something compound — the specific odour of processed mineral that Jean has not encountered anywhere else in the city.",
+        "exits": [
+            "east",
+            "north"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [],
+        "npcs": [
+            {
+                "__class__": "GronditeWorker",
+                "__module__": "npc",
+                "props": {}
+            },
+            {
+                "__class__": "GronditeWorker",
+                "__module__": "npc",
+                "props": {}
+            }
+        ],
+        "objects": [
+            {
+                "__class__": "WallInscription",
+                "__module__": "objects",
+                "props": {
+                    "name": "Allocation Board",
+                    "description": "A stone board fixed to the workshop wall, its face covered in production marks — columns of symbols, quantities, classification glyphs.",
+                    "idle_message": "A stone production board is mounted to the workshop wall.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a stone production board mounted to the wall!",
+                    "announce": "A stone production board is mounted to the workshop wall.",
+                    "keywords": ["read", "examine", "inspect", "view", "check"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "text": "[A stone board covered in Golemite production marks — columns of symbols, quantities, classification glyphs. Jean cannot read most of it. In the margin, two words have been scratched in trade tongue by a different hand: 'pool. closed.' Below that, a single symbol Jean does not recognise, circled twice.]"
+                }
+            },
+            {
+                "__class__": "Passageway",
+                "__module__": "objects",
+                "props": {
+                    "name": "Forge Entrance",
+                    "description": "A wide rectangular doorway leads back out to the Fabricarium workshop gallery.",
+                    "idle_message": "The forge entrance leads back to the workshop gallery.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "the doorway leading back to the workshop gallery!",
+                    "announce": "The forge entrance leads back to the workshop gallery.",
+                    "keywords": ["leave", "exit", "go", "outside"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "events_before": [],
+                    "events_after": [],
+                    "teleport_map": "grondia",
+                    "teleport_tile": [10, 6],
+                    "persist": true
+                }
+            }
+        ]
+    },
+    "(3, 2)": {
+        "id": "tile_3_2",
+        "title": "Fabricarium Forge — Materials Store",
+        "description": "A storage chamber off the main workshop, its walls fitted with deep shelf-cuts holding crates, sacks, and sealed stone bins of processed material. The floor is dusted with mineral powder ground fine. Labels in Golemite script are carved above each section. Two open crates near the door hold surplus stock, their lids propped aside.",
+        "exits": [
+            "west"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [],
+        "npcs": [],
+        "objects": [
+            {
+                "__class__": "Container",
+                "__module__": "objects",
+                "props": {
+                    "nickname": "materials crate",
+                    "possible_states": ["closed", "opened"],
+                    "revealed": false,
+                    "locked": false,
+                    "state": "opened",
+                    "merchant": "",
+                    "allowed_item_types": [{"__class_type__": "items:Item"}],
+                    "stock_count": 10,
+                    "inventory": [
+                        {"__class__": "MineralFragment", "__module__": "items", "props": {}},
+                        {"__class__": "MineralFragment", "__module__": "items", "props": {}},
+                        {"__class__": "MineralPowder", "__module__": "items", "props": {}},
+                        {"__class__": "Gold", "__module__": "items", "props": {"amt": 40}}
+                    ],
+                    "name": "Materials Crate",
+                    "description": "A large stone-sided crate of standard Fabricarium issue, its label marking it as processed mineral stock.",
+                    "idle_message": "A large materials crate stands open near the shelves.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a large materials crate standing open!",
+                    "announce": "A large materials crate stands open near the shelves.",
+                    "keywords": ["open", "loot", "check", "examine"],
+                    "events": [],
+                    "tile": null,
+                    "player": null
+                }
+            },
+            {
+                "__class__": "Container",
+                "__module__": "objects",
+                "props": {
+                    "nickname": "open crate",
+                    "possible_states": ["closed", "opened"],
+                    "revealed": false,
+                    "locked": false,
+                    "state": "opened",
+                    "merchant": "",
+                    "allowed_item_types": [{"__class_type__": "items:Item"}],
+                    "stock_count": 10,
+                    "inventory": [
+                        {"__class__": "MineralFragment", "__module__": "items", "props": {}}
+                    ],
+                    "name": "Open Crate",
+                    "description": "A smaller crate with its lid propped against the wall. The contents are accessible.",
+                    "idle_message": "A smaller open crate rests against the wall.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a smaller open crate against the wall!",
+                    "announce": "A smaller open crate rests against the wall.",
+                    "keywords": ["open", "loot", "check", "examine"],
+                    "events": [],
+                    "tile": null,
+                    "player": null
+                }
+            }
+        ]
+    },
+    "(2, 1)": {
+        "id": "tile_2_1",
+        "title": "Fabricarium Forge — Master's Bench",
+        "description": "A raised alcove at the north end of the workshop, separated from the main floor by a low stone step. A long, wide bench of dressed stone occupies most of the space, its surface covered in fine parallel scratches from decades of tool-work. Above it, a wall mount holds empty brackets where larger tools once hung. An iron lockbox is mortared into the base of the bench, its face flush with the stone.",
+        "exits": [
+            "south"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [],
+        "npcs": [],
+        "objects": [
+            {
+                "__class__": "Container",
+                "__module__": "objects",
+                "props": {
+                    "nickname": "iron lockbox",
+                    "possible_states": ["closed", "opened"],
+                    "revealed": false,
+                    "locked": false,
+                    "state": "closed",
+                    "merchant": "",
+                    "allowed_item_types": [{"__class_type__": "items:Item"}],
+                    "stock_count": 10,
+                    "inventory": [
+                        {"__class__": "DriedCrystalSap", "__module__": "items", "props": {}},
+                        {"__class__": "Gold", "__module__": "items", "props": {"amt": 25}},
+                        {"__class__": "Restorative", "__module__": "items", "props": {}}
+                    ],
+                    "name": "Iron Lockbox",
+                    "description": "A small iron lockbox mortared into the base of the master's bench. The lock has been forced at some point and no longer holds.",
+                    "idle_message": "An iron lockbox is mortared into the base of the bench.",
+                    "hidden": true,
+                    "hide_factor": 3,
+                    "discovery_message": "an iron lockbox mortared into the base of the bench!",
+                    "announce": "An iron lockbox is mortared into the base of the bench.",
+                    "keywords": ["open", "loot", "check", "examine"],
+                    "events": [],
+                    "tile": null,
+                    "player": null
+                }
+            }
+        ]
+    }
+}

--- a/src/resources/maps/grondia-guesthold.json
+++ b/src/resources/maps/grondia-guesthold.json
@@ -1,0 +1,206 @@
+{
+    "metadata": {
+        "bgm": "mineral_pools"
+    },
+    "(2, 2)": {
+        "id": "tile_2_2",
+        "title": "The Guesthold",
+        "description": "A low-ceilinged common space warmed by a channel of vented heat running beneath the floor. Stone benches line two walls, each with a woven fiber mat and a shallow indent for a rolled sleeping mat. A carved stone counter divides the room. The smell is warm mineral and something faintly resinous — incense, or sealing compound.",
+        "exits": [
+            "north",
+            "east"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [
+            {
+                "__class__": "Restorative",
+                "__module__": "items",
+                "props": {}
+            }
+        ],
+        "npcs": [
+            {
+                "__class__": "GronditePasserby",
+                "__module__": "npc",
+                "props": {}
+            }
+        ],
+        "objects": [
+            {
+                "__class__": "Fountain",
+                "__module__": "objects",
+                "props": {
+                    "name": "Stone Basin",
+                    "description": "A low stone basin fed by a thin trickle from a wall spout. The water is clear and slightly warm. You could DRINK from it.",
+                    "idle_message": "A low stone basin trickles quietly near the entrance.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a trickling stone basin near the entrance!",
+                    "announce": "A low stone basin trickles quietly near the entrance.",
+                    "keywords": ["drink", "listen", "admire", "use"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "event": null
+                }
+            },
+            {
+                "__class__": "NoticeBoard",
+                "__module__": "objects",
+                "props": {
+                    "name": "Notice Board",
+                    "description": "A flat stone panel fixed to the wall near the entrance, its face smoothed. Two notes in different hands are pinned to it.",
+                    "idle_message": "A flat notice panel is fixed to the wall.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a notice panel fixed to the wall!",
+                    "announce": "A flat notice panel is fixed to the wall.",
+                    "keywords": ["read", "use"],
+                    "notes": [
+                        "[Golemite symbols. Three trade-tongue words marked in a different hand: 'pool. closed. elder.']",
+                        "Beds free if you behave. Strange city. Warm though. — M."
+                    ],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "event": null
+                }
+            },
+            {
+                "__class__": "Passageway",
+                "__module__": "objects",
+                "props": {
+                    "name": "Guesthold Entrance",
+                    "description": "A broad doorway leads back out to the Ecumerium arcade.",
+                    "idle_message": "The entrance to the Guesthold leads back to the arcade.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "the entrance leading back to the arcade!",
+                    "announce": "The entrance to the Guesthold leads back to the arcade.",
+                    "keywords": ["leave", "exit", "go", "outside"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "events_before": [],
+                    "events_after": [],
+                    "teleport_map": "grondia",
+                    "teleport_tile": [11, 5],
+                    "persist": true
+                }
+            }
+        ]
+    },
+    "(2, 1)": {
+        "id": "tile_2_1",
+        "title": "The Guesthold — Sleeping Quarters",
+        "description": "A long alcove fitted with four sleeping niches cut directly into the stone, each with a shallow mat-channel and a small carved ledge at head height. The ceiling is lower here; the walls have been smoothed and sealed with a pale grey compound that still carries faint tool marks. Names and tally marks scratched at one niche — the record of someone's stay, counted out in nights.",
+        "exits": [
+            "south"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [],
+        "npcs": [],
+        "objects": [
+            {
+                "__class__": "Container",
+                "__module__": "objects",
+                "props": {
+                    "nickname": "ledge niche",
+                    "possible_states": ["closed", "opened"],
+                    "revealed": false,
+                    "locked": false,
+                    "state": "closed",
+                    "merchant": "",
+                    "allowed_item_types": [{"__class_type__": "items:Item"}],
+                    "stock_count": 10,
+                    "inventory": [
+                        {"__class__": "Restorative", "__module__": "items", "props": {}},
+                        {"__class__": "Gold", "__module__": "items", "props": {"amt": 35}},
+                        {"__class__": "SilverRing", "__module__": "items", "props": {}}
+                    ],
+                    "name": "Ledge Niche",
+                    "description": "A narrow recess cut into the stone wall at shoulder height, masked by a fitted stone panel. Whatever was left here has been here for some time.",
+                    "idle_message": "A stone panel covers a recess in the wall.",
+                    "hidden": true,
+                    "hide_factor": 3,
+                    "discovery_message": "a recess in the wall, hidden behind a fitted stone panel!",
+                    "announce": "A stone panel covers a recess in the wall.",
+                    "keywords": ["open", "loot", "check", "examine"],
+                    "events": [],
+                    "tile": null,
+                    "player": null
+                }
+            }
+        ]
+    },
+    "(3, 2)": {
+        "id": "tile_3_2",
+        "title": "The Guesthold — Proprietor's Corner",
+        "description": "A recessed alcove behind the main counter, its walls lined with stone shelves and a broad work surface worn level by long use. Small carved bins hold supplies in ordered rows. A board of hooks on one wall holds iron ring loops, the kind used to secure provisions. The back wall bears a shallow carved relief: a figure at rest, one hand open — cut with more care than the utilitarian surroundings might suggest.",
+        "exits": [
+            "west"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [],
+        "npcs": [
+            {
+                "__class__": "GronditeElder",
+                "__module__": "npc",
+                "props": {}
+            }
+        ],
+        "objects": [
+            {
+                "__class__": "Container",
+                "__module__": "objects",
+                "props": {
+                    "nickname": "stone counter shelf",
+                    "possible_states": ["closed", "opened"],
+                    "revealed": false,
+                    "locked": false,
+                    "state": "opened",
+                    "merchant": "",
+                    "allowed_item_types": [{"__class_type__": "items:Item"}],
+                    "stock_count": 10,
+                    "inventory": [
+                        {
+                            "__class__": "Book",
+                            "__module__": "items",
+                            "props": {
+                                "name": "A Traveller's Record",
+                                "description": "A slim journal in a plain leather cover, its spine well worn. The handwriting inside is small and cramped.",
+                                "value": 10,
+                                "weight": 0.5,
+                                "maintype": "Book",
+                                "subtype": "Book",
+                                "type": "Book",
+                                "interactions": ["drop", "read"],
+                                "merchandise": false,
+                                "hidden": false,
+                                "hide_factor": 0,
+                                "discovery_message": "a slim traveller's journal!",
+                                "announce": "A slim leather-bound journal rests here.",
+                                "text": "Day twelve in Grondia. The stone holds heat differently here than I expected — not cold like a cave, but warm, almost like sleeping near an oven that never goes out. One of the Golemites brought food without being asked — mineral broth, which is precisely what it sounds like, but warming. The city runs on an unspoken schedule. Movement, then stillness. Work, then gathering. No bells — they seem to know. I asked my host how. He touched his chest and said nothing I could translate. The mineral pools are closed. Posted at every passage leading to them: flat stone slabs with the same inscription. Jambo translated it as 'passage withdrawn pending restoration.' No one will say more than that."
+                            }
+                        },
+                        {"__class__": "Gold", "__module__": "items", "props": {"amt": 20}}
+                    ],
+                    "name": "Stone Counter Shelf",
+                    "description": "A broad stone shelf behind the counter, its surface worn flat by years of use. Several items rest on it within reach.",
+                    "idle_message": "A broad stone shelf stands behind the counter.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a broad stone shelf behind the counter!",
+                    "announce": "A broad stone shelf stands behind the counter.",
+                    "keywords": ["open", "loot", "check", "examine"],
+                    "events": [],
+                    "tile": null,
+                    "player": null
+                }
+            }
+        ]
+    }
+}

--- a/src/resources/maps/grondia-vacated-dwelling.json
+++ b/src/resources/maps/grondia-vacated-dwelling.json
@@ -1,0 +1,110 @@
+{
+    "metadata": {
+        "bgm": "mineral_pools"
+    },
+    "(2, 2)": {
+        "id": "tile_2_2",
+        "title": "Vacated Dwelling — Main Chamber",
+        "description": "A single-room dwelling of dressed stone, its proportions compact but not cramped. Stone sleeping niches are built into one wall, their mat-channels empty. A low hearth cut into the floor is cold and clean — the ash removed, the grate stacked neatly to one side. A shallow depression near the entrance holds the ghost of a worn mat, its outline visible in the slightly different shade of stone beneath. The dwelling is tidy in the way of someone who left intending to return.",
+        "exits": [
+            "north"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [
+            {
+                "__class__": "Book",
+                "__module__": "items",
+                "props": {
+                    "name": "Urrath's Record",
+                    "description": "A flat piece of mineral-paper with dense, careful script. The hand is not human.",
+                    "value": 5,
+                    "weight": 0.2,
+                    "maintype": "Book",
+                    "subtype": "Book",
+                    "type": "Book",
+                    "interactions": ["drop", "read"],
+                    "merchandise": false,
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a piece of mineral-paper with writing on it!",
+                    "announce": "A piece of mineral-paper with writing lies on the floor.",
+                    "text": "I write in trade speech. For who finds this.\n\nWe are Urrath and Pelb his son. We left when the smell changed. Lower pipes. Sour. Means pool is wrong.\n\nPelb was heavy in sleep. Slow to wake. Conclave said: pool-water in the pipes. We left.\n\nWe are in upper Arcology. Pelb is better.\n\nThis place is empty now. Take what is here. Better used than dark.\n\nUrrath — son of Kellath — Forty-Second Rising"
+                }
+            },
+            {
+                "__class__": "Antidote",
+                "__module__": "items",
+                "props": {}
+            }
+        ],
+        "npcs": [],
+        "objects": [
+            {
+                "__class__": "Passageway",
+                "__module__": "objects",
+                "props": {
+                    "name": "Dwelling Door",
+                    "description": "A narrow stone door leads back out to the residential lane.",
+                    "idle_message": "A narrow stone door leads back to the residential lane.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "the dwelling door leading back to the residential lane!",
+                    "announce": "A narrow stone door leads back to the residential lane.",
+                    "keywords": ["leave", "exit", "go", "outside", "door"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "events_before": [],
+                    "events_after": [],
+                    "teleport_map": "grondia",
+                    "teleport_tile": [9, 6],
+                    "persist": true
+                }
+            }
+        ]
+    },
+    "(2, 1)": {
+        "id": "tile_2_1",
+        "title": "Vacated Dwelling — Inner Room",
+        "description": "A small inner chamber off the main room, its entrance framed by a carved lintel bearing a stylized wave pattern. Stone shelves hold only the impressions where objects once rested. The floor has been swept. One flagstone near the north wall sits slightly higher than the rest — its edge is cleaner than the surrounding stone, as if it has been lifted and reset.",
+        "exits": [
+            "south"
+        ],
+        "block_exit": [],
+        "events": [],
+        "items": [],
+        "npcs": [],
+        "objects": [
+            {
+                "__class__": "Container",
+                "__module__": "objects",
+                "props": {
+                    "nickname": "loose floor stone",
+                    "possible_states": ["closed", "opened"],
+                    "revealed": false,
+                    "locked": false,
+                    "state": "closed",
+                    "merchant": "",
+                    "allowed_item_types": [{"__class_type__": "items:Item"}],
+                    "stock_count": 10,
+                    "inventory": [
+                        {"__class__": "GronditeMarkToken", "__module__": "items", "props": {}},
+                        {"__class__": "Gold", "__module__": "items", "props": {"amt": 65}}
+                    ],
+                    "name": "Loose Floor Stone",
+                    "description": "A flagstone that lifts free from the floor, revealing a shallow recess beneath. Whatever was hidden here was left deliberately.",
+                    "idle_message": "One flagstone near the north wall sits slightly higher than the rest.",
+                    "hidden": true,
+                    "hide_factor": 4,
+                    "discovery_message": "a flagstone that sits slightly proud of the floor, its edge clean!",
+                    "announce": "One flagstone near the north wall sits slightly higher than the rest.",
+                    "keywords": ["open", "loot", "check", "examine", "lift", "pry"],
+                    "events": [],
+                    "tile": null,
+                    "player": null
+                }
+            }
+        ]
+    }
+}

--- a/src/resources/maps/grondia.json
+++ b/src/resources/maps/grondia.json
@@ -294,6 +294,28 @@
                     "tile": null,
                     "player": null
                 }
+            },
+            {
+                "__class__": "Passageway",
+                "__module__": "objects",
+                "props": {
+                    "name": "Archive Door",
+                    "description": "A low archway sealed by a heavy stone door on iron pivot hinges, currently open. The door's face bears an inlaid geometric design — concentric circles interrupted by radial lines.",
+                    "idle_message": "A low stone archway leads into the Conclave Archive.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a stone archway leading into the Conclave Archive!",
+                    "announce": "A low stone archway into the Conclave Archive is here.",
+                    "keywords": ["enter", "archive", "go", "door", "inside"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "events_before": [],
+                    "events_after": [],
+                    "teleport_map": "grondia-conclave-archive",
+                    "teleport_tile": [2, 2],
+                    "persist": true
+                }
             }
         ]
     },
@@ -1034,6 +1056,28 @@
                     "event_on": null,
                     "event_off": null
                 }
+            },
+            {
+                "__class__": "Passageway",
+                "__module__": "objects",
+                "props": {
+                    "name": "The Guesthold",
+                    "description": "A broad doorway cut into the arcade's inner wall, framed by carved relief showing a line of figures in various states of rest. A worn stone step descends slightly into the interior, polished bright by use.",
+                    "idle_message": "A broad doorway leads into The Guesthold.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a broad doorway leading into The Guesthold!",
+                    "announce": "The entrance to The Guesthold is cut into the arcade wall here.",
+                    "keywords": ["enter", "go", "guesthold", "inn", "inside"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "events_before": [],
+                    "events_after": [],
+                    "teleport_map": "grondia-guesthold",
+                    "teleport_tile": [2, 2],
+                    "persist": true
+                }
             }
         ]
     },
@@ -1342,7 +1386,30 @@
         ],
         "items": [],
         "npcs": [],
-        "objects": []
+        "objects": [
+            {
+                "__class__": "Passageway",
+                "__module__": "objects",
+                "props": {
+                    "name": "Dwelling Door",
+                    "description": "A narrow stone door set into a recessed frame, its lower edge worn to a concave depression from decades of passage. The door stands ajar, held open by a wedge of stone jammed beneath it.",
+                    "idle_message": "A narrow stone door in the lane wall stands ajar.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a narrow stone door standing ajar in the lane wall!",
+                    "announce": "A narrow dwelling door stands ajar in the lane wall here.",
+                    "keywords": ["enter", "door", "dwelling", "go", "inside"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "events_before": [],
+                    "events_after": [],
+                    "teleport_map": "grondia-vacated-dwelling",
+                    "teleport_tile": [2, 2],
+                    "persist": true
+                }
+            }
+        ]
     },
     "(10, 6)": {
         "id": "tile_10_6",
@@ -1409,6 +1476,28 @@
                     "events": [],
                     "tile": null,
                     "player": null
+                }
+            },
+            {
+                "__class__": "Passageway",
+                "__module__": "objects",
+                "props": {
+                    "name": "Forge Entrance",
+                    "description": "A wide rectangular doorway in the workshop's outer wall, edged with iron plate set flush to the stone. The floor just inside is darker from mineral staining, and the smell of hot stone and compound drifts outward.",
+                    "idle_message": "A wide workshop doorway leads into the Fabricarium Forge.",
+                    "hidden": false,
+                    "hide_factor": 0,
+                    "discovery_message": "a wide doorway leading into the Fabricarium Forge!",
+                    "announce": "The entrance to the Fabricarium Forge is here.",
+                    "keywords": ["enter", "forge", "workshop", "go", "inside"],
+                    "events": [],
+                    "tile": null,
+                    "player": null,
+                    "events_before": [],
+                    "events_after": [],
+                    "teleport_map": "grondia-fabricarium-forge",
+                    "teleport_tile": [2, 2],
+                    "persist": true
                 }
             }
         ]


### PR DESCRIPTION
Adds The Guesthold (inn), Conclave Archive (library), Fabricarium Forge
(workshop), and a Vacated Dwelling to Grondia. Each is a small interior
map connected to the city via Passageway objects on tiles (11,5), (11,3),
(10,6), and (9,6). Every building has lore-appropriate Golemite NPCs,
readable objects (WallInscriptions, NoticeBoard, Books), and discoverable
loot. Written text follows Golemite language rules: workers produce
1-3 word fragments, Elders render terse declarative trade-tongue, only
human-authored text uses full prose.

https://claude.ai/code/session_01A5UNj97CSM4DgYP3xB7sJy