### PR TITLE
feat(ai): add NpcChatLLMAdapter and human NPC personality configs

### DIFF
--- a/ai/llm_client.py
+++ b/ai/llm_client.py
@@ -929,8 +929,11 @@ class NpcChatLLMAdapter(GenericLLMClient):
       - generate_npc_turn:    NPC opening line or response; returns structured JSON
       - generate_jean_options: three Jean dialogue options in a single call
 
-    Configuration (re-uses the Mynx env vars plus one new gate):
-      NPC_CHAT_LLM_ENABLED=1      gate specifically for human NPC chat
+    Configuration (re-uses the Mynx env vars plus NPC-specific overrides):
+      NPC_CHAT_LLM_ENABLED=1            gate specifically for human NPC chat
+      NPC_CHAT_LLM_PROVIDER=ollama|openrouter
+                                         provider override (falls back to MYNX_LLM_PROVIDER)
+      NPC_CHAT_LLM_MODEL=<model-id>      model override for the chosen provider
       NPC_CHAT_TEMP_PERSONALITY   float override for personality call (default 0.7)
       NPC_CHAT_TEMP_NPC           float override for NPC turn call (default 0.65)
       NPC_CHAT_TEMP_OPTIONS       float override for Jean options call (default 0.8)
@@ -944,6 +947,14 @@ class NpcChatLLMAdapter(GenericLLMClient):
         super().__init__()
         # Override the enabled check: use NPC_CHAT_LLM_ENABLED
         self.enabled = os.getenv("NPC_CHAT_LLM_ENABLED", "0") in ("1", "true", "True")
+        # Allow per-feature provider/model override so NPC chat can use a different
+        # provider than Mynx without affecting the Mynx configuration.
+        npc_provider = os.getenv("NPC_CHAT_LLM_PROVIDER", "").strip().lower()
+        if npc_provider:
+            self.provider = npc_provider
+        npc_model = os.getenv("NPC_CHAT_LLM_MODEL", "").strip()
+        if npc_model:
+            self.model = npc_model
         self._world_facts: Optional[Dict[str, Any]] = None
         self._load_world_facts()
 

--- a/ai/llm_client.py
+++ b/ai/llm_client.py
@@ -991,9 +991,6 @@ class NpcChatLLMAdapter(GenericLLMClient):
         speech_sample, loquacity_base.
         Returns None if LLM unavailable.
         """
-        if not self.enabled:
-            return None
-
         system = (
             "You are a character generator for a low-fantasy text RPG set in Aurelion. "
             "Generate a distinct personality for a nomad NPC. "
@@ -1042,9 +1039,6 @@ class NpcChatLLMAdapter(GenericLLMClient):
         conversation_quality: "positive" | "neutral" | "negative" | "offensive"
         conversation_end: bool
         """
-        if not self.enabled:
-            return None
-
         history_block = self._format_history(history)
         if is_opening:
             task = "Generate the NPC's opening line. Vary it — do not repeat anything in the history above. Do not begin with 'Hello' or 'Greetings'."
@@ -1097,9 +1091,6 @@ class NpcChatLLMAdapter(GenericLLMClient):
         Returns list of 3 dicts: [{tone, text}, ...]
         tones: "direct", "guarded", "open"
         """
-        if not self.enabled:
-            return None
-
         system = (
             "You generate player dialogue options for a text RPG. "
             "The player is Jean (he/him), a cautious, observant traveler in a low-fantasy world. "

--- a/ai/llm_client.py
+++ b/ai/llm_client.py
@@ -911,3 +911,363 @@ class MynxLLMAdapter(GenericLLMClient):
                     "Only produce nonverbal action descriptions or compact JSON action objects."
                 ),
             }
+
+
+# ---------------------------------------------------------------------------
+# NPC Chat adapter — conversational human NPCs
+# ---------------------------------------------------------------------------
+
+_NPC_CHAT_HUMAN_DIR = os.path.join(AI_DIR, "npc", "human")
+_NPC_CHAT_WORLD_FACTS_PATH = os.path.join(_NPC_CHAT_HUMAN_DIR, "world_facts.json")
+
+
+class NpcChatLLMAdapter(GenericLLMClient):
+    """LLM adapter for conversational human NPC dialogue.
+
+    Provides three generation methods used by HumanNPCLLMMixin:
+      - generate_personality: one-shot personality seeding for generic nomads
+      - generate_npc_turn:    NPC opening line or response; returns structured JSON
+      - generate_jean_options: three Jean dialogue options in a single call
+
+    Configuration (re-uses the Mynx env vars plus one new gate):
+      NPC_CHAT_LLM_ENABLED=1      gate specifically for human NPC chat
+      NPC_CHAT_TEMP_PERSONALITY   float override for personality call (default 0.7)
+      NPC_CHAT_TEMP_NPC           float override for NPC turn call (default 0.65)
+      NPC_CHAT_TEMP_OPTIONS       float override for Jean options call (default 0.8)
+    """
+
+    # Per-class singleton cache so we don't re-init the adapter on every API call.
+    _instances: Dict[str, "NpcChatLLMAdapter"] = {}
+    _instances_lock = threading.Lock()
+
+    def __init__(self):
+        super().__init__()
+        # Override the enabled check: use NPC_CHAT_LLM_ENABLED
+        self.enabled = os.getenv("NPC_CHAT_LLM_ENABLED", "0") in ("1", "true", "True")
+        self._world_facts: Optional[Dict[str, Any]] = None
+        self._load_world_facts()
+
+    @classmethod
+    def get_instance(cls) -> "NpcChatLLMAdapter":
+        """Return the shared adapter instance, creating it on first call."""
+        with cls._instances_lock:
+            if "default" not in cls._instances:
+                cls._instances["default"] = cls()
+            return cls._instances["default"]
+
+    def _load_world_facts(self) -> None:
+        try:
+            with open(_NPC_CHAT_WORLD_FACTS_PATH, "r", encoding="utf-8") as f:
+                self._world_facts = json.load(f)
+        except Exception:
+            self._world_facts = {
+                "world_name": "Aurelion",
+                "allowed_proper_nouns": ["Jean", "Gorran", "Mara", "Devet", "Liss",
+                                         "Aurelion", "Grondia", "Badlands", "Echoing Caves"],
+                "tone_notes": "Low fantasy, grounded, practical.",
+            }
+
+    def _world_facts_block(self) -> str:
+        if not self._world_facts:
+            return "Setting: Aurelion, a low-fantasy world."
+        wf = self._world_facts
+        geo = ", ".join(wf.get("geography", []))
+        factions = ", ".join(wf.get("factions_and_peoples", []))
+        rules = " ".join(wf.get("world_rules", []))
+        tone = wf.get("tone_notes", "")
+        return (
+            f"WORLD: {wf.get('world_name','Aurelion')}. {wf.get('brief_description','')}\n"
+            f"Places: {geo}.\nPeoples: {factions}.\n{rules}\nTone: {tone}"
+        )
+
+    # ------------------------------------------------------------------
+    # Call 1 — Personality generation (generic nomads, once per instance)
+    # ------------------------------------------------------------------
+
+    def generate_personality(self, npc_class_display: str) -> Optional[Dict[str, Any]]:
+        """Generate a unique personality seed for a generic nomad NPC.
+
+        Returns dict with keys: given_name, voice, knowledge, attitude_to_strangers,
+        speech_sample, loquacity_base.
+        Returns None if LLM unavailable.
+        """
+        if not self.enabled:
+            return None
+
+        system = (
+            "You are a character generator for a low-fantasy text RPG set in Aurelion. "
+            "Generate a distinct personality for a nomad NPC. "
+            "Return ONLY valid JSON. No commentary, no code fences."
+        )
+        wf = self._world_facts or {}
+        allowed = ", ".join(wf.get("allowed_proper_nouns", []))
+        user = (
+            f"Generate personality JSON for a {npc_class_display}. "
+            "Return exactly these keys:\n"
+            '"given_name": a simple nomadic first name (no invented proper nouns),\n'
+            '"voice": one sentence describing speech rhythm (e.g. "sparse, declarative"),\n'
+            '"knowledge": list of 2 topics this person knows well,\n'
+            '"attitude_to_strangers": one of "wary", "indifferent", "curious", "guarded",\n'
+            '"speech_sample": one in-character line (10-20 words),\n'
+            '"loquacity_base": integer 40-90 representing social patience.\n'
+            f"Do NOT invent locations, factions, or creatures not in: {allowed}."
+        )
+        temp = float(os.getenv("NPC_CHAT_TEMP_PERSONALITY", "0.7"))
+        raw = self._call_llm(system, user, max_tokens=256, temperature=temp)
+        if not raw:
+            return None
+        parsed = _JSONTools.try_parse_json(raw)
+        if not isinstance(parsed, dict):
+            return None
+        required = {"given_name", "voice", "knowledge", "attitude_to_strangers",
+                    "speech_sample", "loquacity_base"}
+        if not required.issubset(parsed.keys()):
+            return None
+        return parsed
+
+    # ------------------------------------------------------------------
+    # Call 2 — NPC turn (opening line + each NPC response)
+    # ------------------------------------------------------------------
+
+    def generate_npc_turn(
+        self,
+        system_prompt: str,
+        history: List[Dict[str, str]],
+        is_opening: bool,
+        jean_text: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Generate one NPC conversational turn.
+
+        Returns dict: {npc_text, conversation_quality, conversation_end}
+        conversation_quality: "positive" | "neutral" | "negative" | "offensive"
+        conversation_end: bool
+        """
+        if not self.enabled:
+            return None
+
+        history_block = self._format_history(history)
+        if is_opening:
+            task = "Generate the NPC's opening line. Vary it — do not repeat anything in the history above. Do not begin with 'Hello' or 'Greetings'."
+        else:
+            task = f'Jean said: "{jean_text}". Generate the NPC\'s response.'
+
+        user = (
+            f"{history_block}\n\n"
+            f"[TASK]\n{task}\n\n"
+            "Return ONLY this JSON (no code fences, no extra keys):\n"
+            '{"npc_text": "...", "conversation_quality": "positive|neutral|negative|offensive", "conversation_end": false}\n'
+            "conversation_quality reflects how the NPC felt about this exchange: "
+            "positive=enjoyed/interested, neutral=tolerated, negative=annoyed/offended, offensive=deeply offended.\n"
+            "Set conversation_end to true ONLY if the NPC is done talking entirely (loquacity exhausted or deeply offended)."
+        )
+
+        temp = float(os.getenv("NPC_CHAT_TEMP_NPC", "0.65"))
+        raw = self._call_llm(system_prompt, user, max_tokens=300, temperature=temp)
+        if not raw:
+            return None
+        parsed = _JSONTools.try_parse_json(raw)
+        if not isinstance(parsed, dict):
+            return None
+        if "npc_text" not in parsed or not isinstance(parsed["npc_text"], str):
+            return None
+        # Normalise fields
+        valid_qualities = {"positive", "neutral", "negative", "offensive"}
+        quality = str(parsed.get("conversation_quality", "neutral")).lower()
+        if quality not in valid_qualities:
+            quality = "neutral"
+        parsed["conversation_quality"] = quality
+        parsed["conversation_end"] = bool(parsed.get("conversation_end", False))
+        parsed["npc_text"] = _JSONTools.sanitize_text(parsed["npc_text"])
+        return parsed
+
+    # ------------------------------------------------------------------
+    # Call 3 — Jean's three response options (single call)
+    # ------------------------------------------------------------------
+
+    def generate_jean_options(
+        self,
+        npc_name: str,
+        npc_voice_summary: str,
+        last_npc_line: str,
+        history: List[Dict[str, str]],
+        turn: int,
+    ) -> Optional[List[Dict[str, str]]]:
+        """Generate three Jean dialogue options with varied tones.
+
+        Returns list of 3 dicts: [{tone, text}, ...]
+        tones: "direct", "guarded", "open"
+        """
+        if not self.enabled:
+            return None
+
+        system = (
+            "You generate player dialogue options for a text RPG. "
+            "The player is Jean (he/him), a cautious, observant traveler in a low-fantasy world. "
+            "Jean is not heroic in a loud way. He is measured, careful, occasionally guarded. "
+            "Generate options that are plausible for Jean. Never have Jean reveal information he would not know. "
+            "Keep each option 8-20 words. Return ONLY valid JSON. No commentary, no code fences."
+        )
+
+        recent_jean_lines = [ex.get("jean", "") for ex in history[-4:] if ex.get("jean")]
+        history_hint = " | ".join(recent_jean_lines) if recent_jean_lines else "none yet"
+
+        user = (
+            f"NPC: {npc_name} — {npc_voice_summary}\n"
+            f'{npc_name} just said: "{last_npc_line}"\n\n'
+            f"Jean's recent lines (avoid repeating these): {history_hint}\n\n"
+            "Generate exactly 3 Jean response options. Return this JSON array:\n"
+            '[{"tone": "direct", "text": "..."}, {"tone": "guarded", "text": "..."}, {"tone": "open", "text": "..."}]\n\n'
+            "Rules:\n"
+            "- direct: brief, factual, Jean gets to the point\n"
+            "- guarded: Jean deflects, doesn't commit, or keeps his distance\n"
+            "- open: Jean engages with some warmth or genuine curiosity\n"
+            "- No option may echo the recent history above\n"
+            "- All options must be plausible for a careful, measured human traveler\n"
+            f"- This is turn {turn} of the conversation — options should feel natural for mid-conversation, not just openers"
+        )
+
+        temp = float(os.getenv("NPC_CHAT_TEMP_OPTIONS", "0.8"))
+        raw = self._call_llm(system, user, max_tokens=300, temperature=temp)
+        if not raw:
+            return None
+        # Try parsing as list
+        raw = raw.strip()
+        if raw.startswith("```"):
+            raw = "\n".join(l for l in raw.splitlines() if not l.strip().startswith("```")).strip()
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            start = raw.find("[")
+            end = raw.rfind("]")
+            if start != -1 and end != -1:
+                try:
+                    parsed = json.loads(raw[start:end + 1])
+                except Exception:
+                    return None
+            else:
+                return None
+        if not isinstance(parsed, list) or len(parsed) < 3:
+            return None
+        result = []
+        expected_tones = ["direct", "guarded", "open"]
+        for i, item in enumerate(parsed[:3]):
+            if not isinstance(item, dict) or "text" not in item:
+                return None
+            tone = str(item.get("tone", expected_tones[i])).lower()
+            if tone not in expected_tones:
+                tone = expected_tones[i]
+            result.append({"tone": tone, "text": str(item["text"])[:200]})
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal LLM call dispatcher
+    # ------------------------------------------------------------------
+
+    def _call_llm(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 512,
+        temperature: float = 0.7,
+    ) -> Optional[str]:
+        """Dispatch to the active provider. Returns raw text or None."""
+        if not self.enabled:
+            return None
+        if self.provider == "ollama":
+            return self._call_ollama(system_prompt, user_prompt, max_tokens, temperature)
+        elif self.provider == "openrouter":
+            return self._call_openrouter(system_prompt, user_prompt, max_tokens, temperature)
+        return None
+
+    def _call_ollama(
+        self, system: str, user: str, max_tokens: int, temperature: float
+    ) -> Optional[str]:
+        if requests is None:
+            return None
+        try:
+            payload = {
+                "model": self.model,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                "stream": False,
+                "options": {
+                    "temperature": temperature,
+                    "num_predict": max_tokens,
+                    "top_p": 0.9,
+                },
+            }
+            r = requests.post(
+                self.base_url + "/api/chat",
+                json=payload,
+                timeout=30,
+            )
+            r.raise_for_status()
+            data = r.json()
+            return data.get("message", {}).get("content", "").strip() or None
+        except Exception as e:
+            logger.warning(f"NpcChatLLMAdapter Ollama error: {e}")
+            return None
+
+    def _call_openrouter(
+        self, system: str, user: str, max_tokens: int, temperature: float
+    ) -> Optional[str]:
+        if requests is None or not self._openrouter_api_key:
+            return None
+        model = self._get_openrouter_model()
+        if not model:
+            return None
+        headers = {
+            "Authorization": f"Bearer {self._openrouter_api_key}",
+            "Content-Type": "application/json",
+        }
+        if self._openrouter_site:
+            headers["HTTP-Referer"] = self._openrouter_site
+        if self._openrouter_site_title:
+            headers["X-Title"] = self._openrouter_site_title
+        payload = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "top_p": 0.9,
+        }
+        try:
+            r = requests.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                json=payload,
+                headers=headers,
+                timeout=45,
+            )
+            r.raise_for_status()
+            data = r.json()
+            return data["choices"][0]["message"]["content"].strip() or None
+        except Exception as e:
+            logger.warning(f"NpcChatLLMAdapter OpenRouter error: {e}")
+            return None
+
+    def _get_openrouter_model(self) -> Optional[str]:
+        """Return the configured model or the first available free model."""
+        if self.model and self.model != "auto":
+            return self.model
+        if GenericLLMClient._free_models_cache:
+            return GenericLLMClient._free_models_cache[0]
+        return self.STABLE_FREE_FALLBACKS[0]
+
+    @staticmethod
+    def _format_history(history: List[Dict[str, str]]) -> str:
+        if not history:
+            return "[CONVERSATION HISTORY]\nNone yet."
+        lines = ["[CONVERSATION HISTORY]"]
+        for ex in history[-8:]:
+            npc_line = ex.get("npc", "")
+            jean_line = ex.get("jean", "")
+            if npc_line:
+                lines.append(f"NPC: {npc_line}")
+            if jean_line:
+                lines.append(f"Jean: {jean_line}")
+        return "\n".join(lines)

--- a/ai/npc/human/devet.json
+++ b/ai/npc/human/devet.json
@@ -1,0 +1,51 @@
+{
+  "file_version": "1.0",
+  "character_name": "Devet",
+  "role": "camp cook, elder, quiet witness",
+  "loquacity_base": 100,
+  "voice_summary": "Sparse, unhurried, deliberate. His humor is in what he leaves out. He says the minimum necessary thing and is already attending to the fire before you finish processing it.",
+  "knowledge_scope": [
+    "cooking and camp maintenance",
+    "weather and river country",
+    "unmapped old paths and forgotten routes",
+    "the river crossing and what lies west",
+    "people heading west — what they look like, what they become",
+    "how to wait and when not to"
+  ],
+  "personality_notes": [
+    "Deeply settled. He has stopped waiting, which is different from being at peace.",
+    "His humor is quiet, comes from what he omits rather than what he says.",
+    "He finds all human behavior comprehensible — not admirable, not pitiful, just comprehensible.",
+    "He has outlived multiple eras. He does not bring this up.",
+    "He offers food when there are no other words. This is not a lesser thing.",
+    "He does not give advice. He makes observations that function as advice later."
+  ],
+  "prohibited_phrases": [
+    "certainly", "absolutely", "I recommend", "you should",
+    "in my experience", "let me tell you", "as they say",
+    "back in my day", "you know what I mean"
+  ],
+  "conversation_starters_by_chapter": {
+    "1": [
+      "He hands Jean something warm to hold without asking if he wants it.",
+      "He tends the fire. He doesn't look up, but he is aware.",
+      "He says, 'The crossing is best early.' He doesn't elaborate."
+    ],
+    "2": [
+      "He's watching the river. He doesn't comment on Jean's return.",
+      "He offers food. The portion is larger than the previous time.",
+      "He says, 'You're not the same as when you came through.' He returns to the fire."
+    ],
+    "3": [
+      "He tends the fire slowly. He glances once toward the cave entrance.",
+      "He doesn't say anything for a while. Then: 'There are places that remember things.'",
+      "He hands Jean something to eat. He says, 'It doesn't ask anything of you. It's just food.'"
+    ]
+  },
+  "system_prompt_snippet": "You are Devet, an old, settled camp cook and traveler in a low-fantasy world called Aurelion. You speak rarely and with great economy. Your humor exists entirely in what you omit. You do not give advice directly — you make observations. You are not gentle in a soft way; you are gentle in a settled way. You have seen much and comment on none of it unless prompted. You do not ask questions. You make statements. Keep responses to 1-2 sentences, never more.",
+  "closing_lines_when_exhausted": [
+    "Devet turns back to the fire. The conversation has ended, though he hasn't said so.",
+    "He nods once, very slightly. He is done.",
+    "He stirs the pot. He doesn't look up again."
+  ]
+}

--- a/ai/npc/human/liss.json
+++ b/ai/npc/human/liss.json
@@ -1,0 +1,49 @@
+{
+  "file_version": "1.0",
+  "character_name": "Liss",
+  "role": "young nomad, curious observer, collector",
+  "loquacity_base": 150,
+  "voice_summary": "Direct, quick, unconcealed. She asks the questions adults have decided not to ask. Her honesty is not weaponized — she simply hasn't learned that some things are rude to say. She is funny without trying.",
+  "knowledge_scope": [
+    "camp routines and nomadic life",
+    "Golemites — fascinated, has many questions",
+    "objects with visible history and wear",
+    "routes as stories rather than logistics",
+    "Jean — she has noticed the contradictions in him and will ask about them"
+  ],
+  "personality_notes": [
+    "Completely unfiltered. She has opinions and no filter between thought and speech.",
+    "Not cruel — she simply doesn't have the architecture for cruelty yet.",
+    "Funny unintentionally, frequently.",
+    "Immediately curious about Jean: his armor, his bearing, where he came from, where he is going.",
+    "She is curious about Gorran to a degree that borders on obsessive.",
+    "She collects things — stones, feathers, scraps — and leaves most of them behind without grief."
+  ],
+  "prohibited_phrases": [
+    "I understand", "that must be difficult", "certainly",
+    "no worries", "I see", "fair enough"
+  ],
+  "conversation_starters_by_chapter": {
+    "1": [
+      "She is already watching Jean when he arrives. She doesn't pretend she wasn't.",
+      "She says, 'Jean's armor is from somewhere specific. Where?'",
+      "She approaches directly, no preamble. 'Is the Golemite going west too?'"
+    ],
+    "2": [
+      "She holds up a stone. 'Does this look like a face to Jean?' She is asking sincerely.",
+      "She has clearly been thinking about something. 'Why does Jean carry a sword if he doesn't want to fight?'",
+      "She approaches at speed. 'I figured something out about Gorran. Do you want to know?'"
+    ],
+    "3": [
+      "She is watching the cave entrance from a careful distance. She turns when Jean arrives.",
+      "She says, 'The sound from there is wrong. Not bad wrong. Just — wrong in an interesting way.'",
+      "She's holding a stone she found near the cave. 'This one vibrates. Feel it.'"
+    ]
+  },
+  "system_prompt_snippet": "You are Liss, a young girl (around nine years old) traveling with nomads in a low-fantasy world called Aurelion. You are curious about everything and have no filter. You ask questions adults have decided not to ask. You are not cruel but you say what you think immediately. You are funny without trying. You speak in short, direct bursts — questions and observations, rarely long statements. You find Jean contradictory and interesting. You adore Gorran the Golemite and ask him many questions. Keep responses to 1-2 sentences.",
+  "closing_lines_when_exhausted": [
+    "Liss loses interest abruptly and goes back to looking at the stone.",
+    "She blinks, clearly thinking about something else now.",
+    "She waves a hand vaguely and wanders off. She might come back later."
+  ]
+}

--- a/ai/npc/human/mara.json
+++ b/ai/npc/human/mara.json
@@ -1,0 +1,51 @@
+{
+  "file_version": "1.0",
+  "character_name": "Mara",
+  "role": "scavenger, ferry operator, guide",
+  "loquacity_base": 60,
+  "voice_summary": "Sardonic, dry, economical. Says half of what she means. Her wit lands before the listener decides it was a joke. She does not explain herself.",
+  "knowledge_scope": [
+    "river crossings and current behavior",
+    "artifact identification and trade value",
+    "the Echoing Caves approaches (reluctantly)",
+    "the Wailing Badlands by reputation and observation",
+    "the Pillar Readers and their methods (critical view)",
+    "reading people quickly and accurately"
+  ],
+  "personality_notes": [
+    "Sardonic exterior, honest cynicism earned by experience.",
+    "Observant to an almost uncomfortable degree — she reads people like objects.",
+    "Restless beneath the practical surface, though she would deny it.",
+    "The crucifix around her neck is not catalogued and not for sale.",
+    "The Echoing Caves affected her; she doesn't discuss this.",
+    "She is not unkind. She is just not warm until there's a reason to be."
+  ],
+  "prohibited_phrases": [
+    "certainly", "absolutely", "of course", "no worries",
+    "I understand how you feel", "that must be hard",
+    "I'm sorry to hear that", "feel free"
+  ],
+  "conversation_starters_by_chapter": {
+    "1": [
+      "She glances up briefly, reading Jean's gear before his face.",
+      "Her eyes find Jean and hold there a moment — inventory, not greeting.",
+      "She's sorting something. She doesn't stop when Jean approaches."
+    ],
+    "2": [
+      "She nods once, the kind of acknowledgment that means she remembers.",
+      "She looks up from the river. There's something quieter in her today.",
+      "She doesn't say anything for a moment. Then: 'You came back.'"
+    ],
+    "3": [
+      "There's a pause before she speaks. Something in her manner is different near the caves.",
+      "She's watching the cave entrance from across the camp. She turns when Jean approaches.",
+      "She says, 'I was here once before. I didn't stay long.'"
+    ]
+  },
+  "system_prompt_snippet": "You are Mara, a sardonic, observant scavenger and river guide in a low-fantasy world called Aurelion. You speak in short, dry sentences. You are not unkind but you are not warm until there is a reason to be. You have a dry wit that lands without announcement. You observe everything and volunteer little. You do not explain yourself or apologize unnecessarily. You never use modern phrasing. You speak in first person. Keep responses to 1-3 sentences.",
+  "closing_lines_when_exhausted": [
+    "Mara turns back to what she was doing. The conversation is over.",
+    "She glances at Jean once, then away. She's done talking.",
+    "She says nothing more. Her attention has moved on."
+  ]
+}

--- a/ai/npc/human/world_facts.json
+++ b/ai/npc/human/world_facts.json
@@ -1,0 +1,48 @@
+{
+  "file_version": "1.0",
+  "world_name": "Aurelion",
+  "brief_description": "A strange, luminous wilderness. Stone, water, and something older. Not all of it mapped.",
+  "geography": [
+    "the east-bank nomad camp",
+    "the river",
+    "the western bank",
+    "the Wailing Badlands",
+    "the Echoing Caves",
+    "Grondia",
+    "the eastern settlements",
+    "the foothills"
+  ],
+  "factions_and_peoples": [
+    "Golemites (mechanical stone soldiers, not human)",
+    "Pillar Readers (religious scholars of ruins)",
+    "nomads (free travelers, no fixed home)",
+    "Grondites (stone-people of Grondia)",
+    "Conclave (scholarly order)"
+  ],
+  "known_npcs": [
+    "Jean (the player, he/him, a crusader-type wanderer)",
+    "Gorran (a Golemite, Jean's companion)",
+    "Mara (scavenger, ferry operator, guide)",
+    "Devet (camp cook, Mara's uncle by practice)",
+    "Liss (young nomad, curious)"
+  ],
+  "world_rules": [
+    "No modern technology. Pre-gunpowder.",
+    "Magic is rare and poorly understood, not commonplace.",
+    "The world is dangerous but not gratuitously violent.",
+    "Religion exists but is personal, not institutional in this camp."
+  ],
+  "allowed_proper_nouns": [
+    "Jean", "Gorran", "Mara", "Devet", "Liss",
+    "Aurelion", "Grondia", "Badlands", "Wailing Badlands", "Echoing Caves",
+    "Golemites", "Pillar Readers", "Conclave", "Grondites"
+  ],
+  "prohibited_inventions": [
+    "Do NOT invent new place names not on the allowed list.",
+    "Do NOT invent new faction names.",
+    "Do NOT invent new NPC names beyond those already known.",
+    "Do NOT reference modern concepts (guns, cars, internet, democracy as a word, etc.).",
+    "Do NOT invent historical events not established in this context."
+  ],
+  "tone_notes": "Low fantasy. Grounded, practical. People here have seen hardship and are not romantic about it. Dialogue should feel like actual conversation, not exposition."
+}

--- a/frontend/src/api/npcChat.js
+++ b/frontend/src/api/npcChat.js
@@ -1,0 +1,47 @@
+import apiClient from './client'
+
+/**
+ * npcChat - Axios endpoint wrappers for NPC chat API routes
+ * Uses apiClient which automatically handles auth tokens via localStorage.authToken
+ */
+
+const BASE = '/api/npc/chat'
+
+const npcChat = {
+  /**
+   * Open a conversation with an NPC
+   * @param {string} npcId - NPC class name (e.g., 'Mynx', 'Gorran')
+   * @returns {Promise} Response with { npc_key, display_name, loquacity, current_options, messages }
+   */
+  open: (npcId) => apiClient.post(`${BASE}/open`, { npc_id: npcId }),
+
+  /**
+   * Send a response from Jean to an NPC
+   * @param {string} npcKey - Session key returned from /open
+   * @param {string} jeanText - Jean's dialogue text
+   * @param {string} jeanTone - 'direct', 'guarded', or 'open'
+   * @returns {Promise} Response with updated NPC response and options
+   */
+  respond: (npcKey, jeanText, jeanTone = 'direct') =>
+    apiClient.post(`${BASE}/respond`, {
+      npc_key: npcKey,
+      jean_text: jeanText,
+      jean_tone: jeanTone,
+    }),
+
+  /**
+   * End a conversation with an NPC
+   * @param {string} npcKey - Session key returned from /open
+   * @returns {Promise} Response confirming conversation ended
+   */
+  end: (npcKey) => apiClient.post(`${BASE}/end`, { npc_key: npcKey }),
+
+  /**
+   * Retrieve conversation history
+   * @param {string} npcKey - Session key returned from /open
+   * @returns {Promise} Response with full conversation history
+   */
+  history: (npcKey) => apiClient.get(`${BASE}/history/${npcKey}`),
+}
+
+export default npcChat

--- a/frontend/src/components/InteractPanel.jsx
+++ b/frontend/src/components/InteractPanel.jsx
@@ -130,6 +130,7 @@ function InteractPanel({
         setPendingAction(null)
         setQuantity(1)
         setIsLocked(false)
+        setShowChatPanel(false)
     }
 
     const handleActionClick = async (action, qty = null) => {

--- a/frontend/src/components/InteractPanel.jsx
+++ b/frontend/src/components/InteractPanel.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import apiEndpoints from '../api/endpoints'
 import BaseDialog from './BaseDialog'
+import NpcChatPanel from './NpcChatPanel'
 import GameButton from './GameButton'
 import GameText from './GameText'
 import GamePanel from './GamePanel'
@@ -33,6 +34,7 @@ function InteractPanel({
     const [quantity, setQuantity] = useState(1)
     const [showQuantityInput, setShowQuantityInput] = useState(false)
     const [pendingAction, setPendingAction] = useState(null)
+    const [showChatPanel, setShowChatPanel] = useState(false)
 
     // Ref to track if we're currently syncing to prevent infinite loops
     const isSyncingTarget = useRef(false)
@@ -45,7 +47,7 @@ function InteractPanel({
 
     useEffect(() => {
         if (location) {
-            const npcs = (location.npcs || []).map(n => ({ ...n, type: 'npc' }))
+            const npcs = (location.npcs || []).map(n => ({ ...n, npc_class: n.type, type: 'npc' }))
             const objects = (location.objects || []).map(o => ({ ...o, type: 'object' }))
             const items = (location.items || []).map(i => ({ ...i, type: 'item' }))
 
@@ -132,6 +134,12 @@ function InteractPanel({
 
     const handleActionClick = async (action, qty = null) => {
         if (isLocked) return
+
+        // Open LLM chat panel for talk action on LLM-capable NPCs
+        if (action.toLowerCase() === 'talk' && selectedTarget?.llm_chat_enabled && selectedTarget?.loquacity_available !== false) {
+            setShowChatPanel(true)
+            return
+        }
 
         // Check if we need to ask for quantity
         const isStackableAction = ['take', 'pickup', 'drop'].some(a => action.toLowerCase().includes(a))
@@ -221,7 +229,7 @@ function InteractPanel({
         }
     }
 
-    return (
+    return (<>
         <BaseDialog
             title={selectedTarget ? `✨ ${selectedTarget.name}` : "👋 INTERACT"}
             onClose={onClose}
@@ -563,6 +571,17 @@ function InteractPanel({
                 )}
             </div>
         </BaseDialog>
+        {showChatPanel && selectedTarget && (
+            <NpcChatPanel
+                npcId={selectedTarget.npc_class || selectedTarget.name}
+                npcName={selectedTarget.name}
+                onClose={() => {
+                    setShowChatPanel(false)
+                    if (onRefetch) onRefetch()
+                }}
+            />
+        )}
+    </>
     )
 }
 

--- a/frontend/src/components/NpcChatPanel.jsx
+++ b/frontend/src/components/NpcChatPanel.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import npcChat from '../api/npcChat'
 import BaseDialog from './BaseDialog'
 import GameButton from './GameButton'
@@ -22,7 +22,7 @@ export default function NpcChatPanel({ npcId, npcName, onClose }) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [latestNpcText, setLatestNpcText] = useState(null)
-  const [retryFn, setRetryFn] = useState(null)
+  const retryFnRef = useRef(null)
 
   // On mount, open the conversation
   useEffect(() => {
@@ -50,8 +50,8 @@ export default function NpcChatPanel({ npcId, npcName, onClose }) {
         setPhase('waiting_jean')
       } catch (err) {
         const errorMsg = err.response?.data?.error || 'Failed to open conversation'
+        retryFnRef.current = openConversation
         setError(errorMsg)
-        setRetryFn(() => openConversation)
         setPhase('ended')
       } finally {
         setLoading(false)
@@ -59,7 +59,7 @@ export default function NpcChatPanel({ npcId, npcName, onClose }) {
     }
 
     openConversation()
-  }, [npcId, npcName])
+  }, [npcId])
 
   const handleOptionClick = async (option) => {
     if (phase !== 'waiting_jean' || !npcKey) return
@@ -104,8 +104,8 @@ export default function NpcChatPanel({ npcId, npcName, onClose }) {
       }
     } catch (err) {
       const errorMsg = err.response?.data?.error || 'NPC did not respond'
+      retryFnRef.current = () => handleOptionClick(option)
       setError(errorMsg)
-      setRetryFn(() => handleOptionClick(option))
       setPhase('waiting_jean')
     } finally {
       setLoading(false)
@@ -279,7 +279,7 @@ export default function NpcChatPanel({ npcId, npcName, onClose }) {
               <GameButton
                 variant="secondary"
                 size="small"
-                onClick={retryFn}
+                onClick={() => retryFnRef.current?.()}
               >
                 Retry
               </GameButton>

--- a/frontend/src/components/NpcChatPanel.jsx
+++ b/frontend/src/components/NpcChatPanel.jsx
@@ -1,0 +1,368 @@
+import { useState, useEffect } from 'react'
+import npcChat from '../api/npcChat'
+import BaseDialog from './BaseDialog'
+import GameButton from './GameButton'
+import TypewriterOutput from './TypewriterOutput'
+import { colors, spacing, fonts } from '../styles/theme'
+
+/**
+ * NpcChatPanel - A full NPC conversation UI component
+ *
+ * @param {string} npcId - NPC class name (e.g., 'Mynx', 'Gorran')
+ * @param {string} npcName - Display name shown in header
+ * @param {function} onClose - Callback when conversation ends or user closes
+ */
+export default function NpcChatPanel({ npcId, npcName, onClose }) {
+  const [phase, setPhase] = useState('opening') // 'opening' | 'waiting_jean' | 'waiting_npc' | 'ended'
+  const [npcKey, setNpcKey] = useState(null)
+  const [displayName, setDisplayName] = useState(npcName)
+  const [messages, setMessages] = useState([])
+  const [currentOptions, setCurrentOptions] = useState([])
+  const [loquacity, setLoquacity] = useState({ current: 0, max: 1 })
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [latestNpcText, setLatestNpcText] = useState(null)
+  const [retryFn, setRetryFn] = useState(null)
+
+  // On mount, open the conversation
+  useEffect(() => {
+    const openConversation = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const response = await npcChat.open(npcId)
+        const data = response.data
+
+        setNpcKey(data.npc_key)
+        setDisplayName(data.display_name || npcName)
+        setLoquacity(data.loquacity || { current: 0, max: 1 })
+        setCurrentOptions(data.current_options || [])
+        setMessages(data.messages || [])
+
+        // Set the latest NPC text for TypewriterOutput if there are any messages
+        if (data.messages && data.messages.length > 0) {
+          const lastNpcMessage = [...data.messages].reverse().find((m) => m.speaker === 'npc')
+          if (lastNpcMessage) {
+            setLatestNpcText(lastNpcMessage.text)
+          }
+        }
+
+        setPhase('waiting_jean')
+      } catch (err) {
+        const errorMsg = err.response?.data?.error || 'Failed to open conversation'
+        setError(errorMsg)
+        setRetryFn(() => openConversation)
+        setPhase('ended')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    openConversation()
+  }, [npcId, npcName])
+
+  const handleOptionClick = async (option) => {
+    if (phase !== 'waiting_jean' || !npcKey) return
+
+    try {
+      setPhase('waiting_npc')
+      setLoading(true)
+
+      // Add Jean's response to messages
+      const newJeanMessage = {
+        speaker: 'jean',
+        text: option.text,
+        tone: option.tone,
+      }
+      setMessages((prev) => [...prev, newJeanMessage])
+
+      // Call the respond endpoint
+      const response = await npcChat.respond(npcKey, option.text, option.tone)
+      const data = response.data
+
+      // Add NPC response to messages
+      const newNpcMessage = {
+        speaker: 'npc',
+        text: data.npc_response,
+      }
+      setMessages((prev) => [...prev, newNpcMessage])
+
+      // Update loquacity and options
+      setLoquacity(data.loquacity || { current: 0, max: 1 })
+      setCurrentOptions(data.current_options || [])
+      setLatestNpcText(data.npc_response)
+
+      // Check if conversation ended
+      if (data.conversation_ended) {
+        setPhase('ended')
+        // Wait 2 seconds before closing
+        setTimeout(() => {
+          onClose()
+        }, 2000)
+      } else {
+        setPhase('waiting_jean')
+      }
+    } catch (err) {
+      const errorMsg = err.response?.data?.error || 'NPC did not respond'
+      setError(errorMsg)
+      setRetryFn(() => handleOptionClick(option))
+      setPhase('waiting_jean')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleEndConversation = async () => {
+    if (!npcKey) return
+
+    try {
+      await npcChat.end(npcKey)
+      onClose()
+    } catch (err) {
+      // Silently close on error
+      onClose()
+    }
+  }
+
+  // Calculate loquacity bar color
+  const getLoquacityColor = () => {
+    if (!loquacity.max || loquacity.max === 0) return colors.primary
+    const percentage = (loquacity.current / loquacity.max) * 100
+    if (percentage > 60) return colors.primary // Green
+    if (percentage > 30) return colors.secondary // Orange
+    return colors.danger // Red
+  }
+
+  const loquacityPercentage =
+    loquacity.max > 0 ? (loquacity.current / loquacity.max) * 100 : 0
+
+  return (
+    <BaseDialog
+      title={displayName}
+      onClose={onClose}
+      variant="default"
+      maxWidth="450px"
+      width="95%"
+      padding={spacing.lg}
+    >
+      {/* Loquacity Bar */}
+      <div
+        style={{
+          height: '4px',
+          backgroundColor: colors.bg.panelLight,
+          border: `1px solid ${colors.border.light}`,
+          borderRadius: '2px',
+          marginBottom: spacing.md,
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            height: '100%',
+            width: `${loquacityPercentage}%`,
+            backgroundColor: getLoquacityColor(),
+            transition: 'all 0.3s ease-out',
+          }}
+        />
+      </div>
+
+      {/* Messages Area */}
+      <div
+        style={{
+          maxHeight: '280px',
+          overflowY: 'auto',
+          marginBottom: spacing.md,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: spacing.md,
+        }}
+      >
+        {loading && messages.length === 0 ? (
+          <div
+            style={{
+              color: colors.text.muted,
+              fontFamily: fonts.main,
+              fontSize: '14px',
+              textAlign: 'center',
+              padding: spacing.md,
+              animation: 'pulse 1s infinite',
+            }}
+          >
+            …
+          </div>
+        ) : messages.length === 0 ? (
+          <div
+            style={{
+              color: colors.text.muted,
+              fontFamily: fonts.main,
+              fontSize: '12px',
+              textAlign: 'center',
+              padding: spacing.md,
+            }}
+          >
+            Waiting for NPC to speak...
+          </div>
+        ) : (
+          messages.map((msg, idx) => (
+            <div
+              key={idx}
+              style={{
+                color:
+                  msg.speaker === 'npc'
+                    ? colors.secondary
+                    : colors.text.muted,
+                fontFamily: fonts.main,
+                fontSize: '13px',
+                fontStyle: msg.speaker === 'jean' ? 'italic' : 'normal',
+                lineHeight: '1.5',
+              }}
+            >
+              {msg.speaker === 'npc' ? (
+                <div>
+                  <strong>{displayName}:</strong> {msg.text}
+                </div>
+              ) : (
+                <div>
+                  <strong>Jean:</strong> <em>{msg.text}</em>
+                  {msg.tone && (
+                    <span
+                      style={{
+                        marginLeft: spacing.sm,
+                        color: colors.text.dim,
+                        fontSize: '11px',
+                      }}
+                    >
+                      [{msg.tone}]
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          ))
+        )}
+
+        {/* TypewriterOutput for latest NPC text */}
+        {latestNpcText && phase !== 'opening' && (
+          <TypewriterOutput
+            text={latestNpcText}
+            speed={20}
+            style={{
+              marginTop: spacing.sm,
+              padding: spacing.md,
+              backgroundColor: colors.bg.panelHeavy,
+              border: `1px solid ${colors.border.main}`,
+              borderRadius: '6px',
+              minHeight: 'auto',
+              maxHeight: '120px',
+            }}
+          />
+        )}
+      </div>
+
+      {/* Error State */}
+      {error && (
+        <div
+          style={{
+            color: colors.danger,
+            fontFamily: fonts.main,
+            fontSize: '12px',
+            padding: spacing.md,
+            backgroundColor: 'rgba(255, 68, 68, 0.1)',
+            border: `1px solid ${colors.danger}`,
+            borderRadius: '6px',
+            marginBottom: spacing.md,
+          }}
+        >
+          {error}
+          {retryFn && (
+            <div style={{ marginTop: spacing.sm }}>
+              <GameButton
+                variant="secondary"
+                size="small"
+                onClick={retryFn}
+              >
+                Retry
+              </GameButton>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Options */}
+      {phase === 'waiting_jean' && !error && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: spacing.md,
+            marginBottom: spacing.md,
+          }}
+        >
+          {currentOptions.map((option, idx) => (
+            <GameButton
+              key={idx}
+              variant="secondary"
+              size="medium"
+              onClick={() => handleOptionClick(option)}
+              disabled={loading}
+              style={{
+                width: '100%',
+                justifyContent: 'flex-start',
+                padding: spacing.md,
+              }}
+            >
+              <span style={{ marginRight: spacing.sm }}>{option.text}</span>
+              <span
+                style={{
+                  marginLeft: 'auto',
+                  color: colors.text.dim,
+                  fontSize: '11px',
+                }}
+              >
+                [{option.tone}]
+              </span>
+            </GameButton>
+          ))}
+        </div>
+      )}
+
+      {/* End Conversation Button */}
+      {phase !== 'ended' && (
+        <GameButton
+          variant="secondary"
+          size="medium"
+          onClick={handleEndConversation}
+          disabled={loading || phase === 'opening'}
+          style={{
+            width: '100%',
+            opacity: 0.7,
+          }}
+        >
+          End Conversation
+        </GameButton>
+      )}
+
+      {/* Auto-close on conversation end */}
+      {phase === 'ended' && (
+        <div
+          style={{
+            color: colors.text.muted,
+            fontFamily: fonts.main,
+            fontSize: '13px',
+            textAlign: 'center',
+            padding: spacing.md,
+          }}
+        >
+          Conversation ended.
+        </div>
+      )}
+
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.5; }
+        }
+      `}</style>
+    </BaseDialog>
+  )
+}

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -190,6 +190,7 @@ def create_app(config_class=None):
         logs_bp,
         feedback_bp,
     )
+    from src.api.routes.npc_chat import npc_chat_bp
 
     app.register_blueprint(auth_bp, url_prefix="/api")
     app.register_blueprint(world_bp, url_prefix="/api")
@@ -204,6 +205,7 @@ def create_app(config_class=None):
     app.register_blueprint(quest_chains_bp, url_prefix="/api/quest-chains")
     app.register_blueprint(npc_availability_bp, url_prefix="/api")
     app.register_blueprint(dialogue_context_bp, url_prefix="/api")
+    app.register_blueprint(npc_chat_bp, url_prefix="/api/npc/chat")
     app.register_blueprint(logs_bp, url_prefix="/api/logs")
     app.register_blueprint(feedback_bp, url_prefix="/api/feedback")
 

--- a/src/api/routes/npc_chat.py
+++ b/src/api/routes/npc_chat.py
@@ -203,8 +203,5 @@ def npc_chat_history(npc_key):
     # Call game service
     result = current_app.game_service.npc_chat_history(player, npc_key)
 
-    # Save session (defensive)
-    session_manager.save_session(session.session_id)
-
     status_code = 200 if result.get("success") else 400
     return jsonify(result), status_code

--- a/src/api/routes/npc_chat.py
+++ b/src/api/routes/npc_chat.py
@@ -1,0 +1,210 @@
+"""
+Flask routes for NPC chat interactions (LLM-driven conversation system).
+
+Provides REST API endpoints for:
+- Opening conversations with human NPCs
+- Responding to NPC dialogue with tone selection
+- Ending conversations and flushing state
+- Retrieving conversation history
+"""
+
+from flask import Blueprint, request, jsonify, current_app
+
+npc_chat_bp = Blueprint("npc_chat", __name__)
+
+
+def get_session_and_player():
+    """Extract and validate session from Authorization header.
+
+    Returns:
+        Tuple of (session_manager, session, player, error_response, status_code)
+        or (None, None, None, error_response, status_code) on error
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return (
+            None,
+            None,
+            None,
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Missing or invalid Authorization header",
+                }
+            ),
+            401,
+        )
+
+    session_id = auth_header[7:]
+    session_manager = current_app.session_manager
+    session = session_manager.get_session(session_id)
+
+    if not session:
+        return (
+            None,
+            None,
+            None,
+            jsonify({"success": False, "error": "Invalid or expired session"}),
+            401,
+        )
+
+    player = session_manager.get_player(session_id)
+    if not player:
+        return (
+            None,
+            None,
+            None,
+            jsonify({"success": False, "error": "Player not found"}),
+            404,
+        )
+
+    return session_manager, session, player, None, None
+
+
+@npc_chat_bp.route("/open", methods=["POST"])
+def npc_chat_open():
+    """Start an LLM conversation with a human NPC.
+
+    Request body:
+        {
+            "npc_id": "NPC identifier or name"
+        }
+
+    Returns:
+        JSON response with conversation state
+    """
+    # Get session and player
+    session_manager, session, player, error, status = get_session_and_player()
+    if error:
+        return error, status
+
+    # Get request body
+    try:
+        data = request.get_json() or {}
+    except Exception:
+        return jsonify({"success": False, "error": "Invalid JSON"}), 400
+
+    npc_id = data.get("npc_id", "").strip()
+    if not npc_id:
+        return jsonify({"success": False, "error": "npc_id is required"}), 400
+
+    # Call game service
+    result = current_app.game_service.npc_chat_open(player, npc_id)
+
+    # Save session
+    session_manager.save_session(session.session_id)
+
+    status_code = 200 if result.get("success") else 400
+    return jsonify(result), status_code
+
+
+@npc_chat_bp.route("/respond", methods=["POST"])
+def npc_chat_respond():
+    """Process Jean's dialogue choice and get NPC response.
+
+    Request body:
+        {
+            "npc_key": "NPC identifier for active chat",
+            "jean_text": "Jean's dialogue text",
+            "jean_tone": "direct" | "guarded" | "open" (optional, default "direct")
+        }
+
+    Returns:
+        JSON response with NPC reply and options
+    """
+    # Get session and player
+    session_manager, session, player, error, status = get_session_and_player()
+    if error:
+        return error, status
+
+    # Get request body
+    try:
+        data = request.get_json() or {}
+    except Exception:
+        return jsonify({"success": False, "error": "Invalid JSON"}), 400
+
+    npc_key = data.get("npc_key", "").strip()
+    jean_text = data.get("jean_text", "").strip()
+    jean_tone = data.get("jean_tone", "direct").strip()
+
+    if not npc_key:
+        return jsonify({"success": False, "error": "npc_key is required"}), 400
+    if not jean_text:
+        return jsonify({"success": False, "error": "jean_text is required"}), 400
+
+    # Call game service
+    result = current_app.game_service.npc_chat_respond(
+        player, npc_key, jean_text, jean_tone
+    )
+
+    # Save session
+    session_manager.save_session(session.session_id)
+
+    status_code = 200 if result.get("success") else 400
+    return jsonify(result), status_code
+
+
+@npc_chat_bp.route("/end", methods=["POST"])
+def npc_chat_end():
+    """End an NPC conversation and flush state.
+
+    Request body:
+        {
+            "npc_key": "NPC identifier for active chat"
+        }
+
+    Returns:
+        JSON response with conversation summary
+    """
+    # Get session and player
+    session_manager, session, player, error, status = get_session_and_player()
+    if error:
+        return error, status
+
+    # Get request body
+    try:
+        data = request.get_json() or {}
+    except Exception:
+        return jsonify({"success": False, "error": "Invalid JSON"}), 400
+
+    npc_key = data.get("npc_key", "").strip()
+    if not npc_key:
+        return jsonify({"success": False, "error": "npc_key is required"}), 400
+
+    # Call game service
+    result = current_app.game_service.npc_chat_end(player, npc_key)
+
+    # Save session
+    session_manager.save_session(session.session_id)
+
+    status_code = 200 if result.get("success") else 400
+    return jsonify(result), status_code
+
+
+@npc_chat_bp.route("/history/<npc_key>", methods=["GET"])
+def npc_chat_history(npc_key):
+    """Get stored conversation history for an NPC.
+
+    URL parameters:
+        npc_key: NPC identifier to retrieve history for
+
+    Returns:
+        JSON response with conversation exchanges and metadata
+    """
+    # Get session and player
+    session_manager, session, player, error, status = get_session_and_player()
+    if error:
+        return error, status
+
+    npc_key = npc_key.strip()
+    if not npc_key:
+        return jsonify({"success": False, "error": "npc_key is required"}), 400
+
+    # Call game service
+    result = current_app.game_service.npc_chat_history(player, npc_key)
+
+    # Save session (defensive)
+    session_manager.save_session(session.session_id)
+
+    status_code = 200 if result.get("success") else 400
+    return jsonify(result), status_code

--- a/src/api/serializers/npc_serializer.py
+++ b/src/api/serializers/npc_serializer.py
@@ -50,6 +50,18 @@ class NPCSerializer:
         if hasattr(npc, "keywords"):
             npc_data["keywords"] = npc.keywords
 
+        # LLM chat capability flags (set by HumanNPCLLMMixin)
+        import os
+        chat_enabled_env = os.getenv("NPC_CHAT_LLM_ENABLED", "0") in ("1", "true", "True")
+        has_mixin = hasattr(npc, "_init_chat_attrs")
+        npc_data["llm_chat_enabled"] = has_mixin and chat_enabled_env
+        loquacity_max = getattr(npc, "loquacity_max", 0)
+        loquacity_current = getattr(npc, "loquacity_current", 0)
+        loquacity_threshold = getattr(npc, "loquacity_threshold", 0)
+        npc_data["loquacity_available"] = (
+            has_mixin and loquacity_current >= loquacity_threshold and loquacity_max > 0
+        ) if loquacity_max > 0 else has_mixin
+
         return npc_data
 
     @staticmethod

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -4342,3 +4342,168 @@ class GameService:
                 "dialogues": available,
             },
         }
+
+    def _find_chat_npc(self, player: "player_module.Player", npc_key: str):
+        """Find an NPC on the current tile matching the given npc_key.
+
+        Tries multiple matching strategies:
+        1. Exact _chat_npc_key attribute match
+        2. Class name prefix match (e.g. "NomadCamper" from "NomadCamper_0")
+        3. Name attribute match
+
+        Args:
+            player: The player instance
+            npc_key: NPC identifier to search for
+
+        Returns:
+            NPC object if found, None otherwise
+        """
+        current_tile = player.universe.get_tile(player.location_x, player.location_y)
+        if not current_tile:
+            return None
+
+        for npc in getattr(current_tile, "npcs_here", []):
+            # Try _chat_npc_key match first
+            if getattr(npc, "_chat_npc_key", None) == npc_key:
+                return npc
+
+            # Try class name prefix match (e.g. "NomadCamper" from "NomadCamper_0")
+            class_name = type(npc).__name__
+            if npc_key.startswith(class_name):
+                return npc
+
+            # Try name attribute match
+            if getattr(npc, "name", "") == npc_key:
+                return npc
+
+        return None
+
+    def npc_chat_open(self, player: "player_module.Player", npc_id: str) -> Dict[str, Any]:
+        """Start an LLM conversation with a human NPC.
+
+        Args:
+            player: The player instance
+            npc_id: NPC identifier (name or class name)
+
+        Returns:
+            Dict with success status and conversation state
+        """
+        # Find NPC in current tile
+        current_tile = player.universe.get_tile(player.location_x, player.location_y)
+        if not current_tile:
+            return {"success": False, "error": "Not on a valid tile"}
+
+        npc = None
+        for npc_candidate in getattr(current_tile, "npcs_here", []):
+            if (type(npc_candidate).__name__ == npc_id or
+                getattr(npc_candidate, "name", "") == npc_id):
+                npc = npc_candidate
+                break
+
+        if not npc:
+            return {"success": False, "error": f"NPC '{npc_id}' not found"}
+
+        # Check if NPC supports chat
+        if not hasattr(npc, "chat_open"):
+            return {"success": False, "error": "NPC does not support chat"}
+
+        # Store active chat NPC ID
+        player.__dict__["_active_chat_npc_id"] = npc_id
+
+        # Call NPC's chat_open method
+        try:
+            result = npc.chat_open(player)
+            return result
+        except Exception as e:
+            return {"success": False, "error": f"Failed to open chat: {str(e)}"}
+
+    def npc_chat_respond(self, player: "player_module.Player", npc_key: str,
+                        jean_text: str, jean_tone: str = "direct") -> Dict[str, Any]:
+        """Process Jean's dialogue choice and get NPC response.
+
+        Args:
+            player: The player instance
+            npc_key: NPC identifier for active chat
+            jean_text: Jean's dialogue text
+            jean_tone: Tone of Jean's response ("direct", "guarded", "open", etc.)
+
+        Returns:
+            Dict with success status and NPC response
+        """
+        # Find NPC on current tile
+        npc = self._find_chat_npc(player, npc_key)
+        if not npc:
+            return {"success": False, "error": "Active chat NPC not found"}
+
+        # Check if NPC supports chat_respond
+        if not hasattr(npc, "chat_respond"):
+            return {"success": False, "error": "NPC does not support respond"}
+
+        # Call NPC's chat_respond method
+        try:
+            result = npc.chat_respond(player, jean_text, jean_tone)
+            return result
+        except Exception as e:
+            return {"success": False, "error": f"Failed to respond: {str(e)}"}
+
+    def npc_chat_end(self, player: "player_module.Player", npc_key: str) -> Dict[str, Any]:
+        """End an NPC conversation and flush state.
+
+        Args:
+            player: The player instance
+            npc_key: NPC identifier for active chat
+
+        Returns:
+            Dict with success status and conversation summary
+        """
+        # Clear active chat NPC
+        player.__dict__.pop("_active_chat_npc_id", None)
+
+        # Get conversation count from history if available
+        count = 0
+        if hasattr(player, "npc_chat_histories") and npc_key in player.npc_chat_histories:
+            count = player.npc_chat_histories[npc_key].get("conversation_count", 0)
+
+        return {
+            "success": True,
+            "data": {
+                "conversation_count": count
+            }
+        }
+
+    def npc_chat_history(self, player: "player_module.Player", npc_key: str) -> Dict[str, Any]:
+        """Get stored conversation history for an NPC.
+
+        Args:
+            player: The player instance
+            npc_key: NPC identifier to retrieve history for
+
+        Returns:
+            Dict with success status and conversation exchanges
+        """
+        # Check if player has chat histories
+        if not hasattr(player, "npc_chat_histories"):
+            return {"success": False, "error": "No chat history available"}
+
+        hist = player.npc_chat_histories.get(npc_key)
+        if not hist:
+            return {"success": False, "error": f"No history for '{npc_key}'"}
+
+        # Get display name
+        npc_name = npc_key.split("_")[0] if "_" in npc_key else npc_key
+        personality = hist.get("personality")
+        if personality and personality.get("given_name"):
+            npc_name = personality["given_name"]
+
+        return {
+            "success": True,
+            "data": {
+                "npc_key": npc_key,
+                "npc_name": npc_name,
+                "exchanges": hist.get("exchanges", []),
+                "conversation_count": hist.get("conversation_count", 0),
+                "last_talked_tick": hist.get("last_talked_tick", 0),
+                "loquacity_current": hist.get("loquacity_current", 0),
+                "loquacity_max": hist.get("loquacity_max", 0),
+            }
+        }

--- a/src/api/services/session_manager.py
+++ b/src/api/services/session_manager.py
@@ -126,6 +126,7 @@ class MinimalPlayer:
         self.reputation = {}  # Empty reputation dict for API operations
         self.completed_dialogues = []  # Track completed dialogues
         self.dialogue_contexts = {}  # Store active dialogue contexts
+        self.npc_chat_histories = {}  # NPC conversation history and loquacity state
         self.combat_log = []  # List of combat messages
 
         # Default prayer messages (subset of Player messages)

--- a/src/npc/_chat_llm.py
+++ b/src/npc/_chat_llm.py
@@ -114,28 +114,36 @@ _GENERIC_FALLBACKS = [
 class HumanNPCLLMMixin:
     """LLM-driven conversational dialogue mixin for human nomad NPCs."""
 
+    # Class-level caches: files are read once per process, not once per NPC instance.
+    _world_facts_cache: Optional[Dict[str, Any]] = None
+    _char_config_cache: Dict[str, Any] = {}
+
     def _init_chat_attrs(self):
         """Initialize all chat-related attributes. Called at end of host __init__."""
         # Config path can be set by subclass before calling this
         self._chat_config_path: Optional[str] = getattr(self, "_chat_config_path", None)
 
-        # Load character config if path provided
+        # Load character config if path provided (class-level cache)
         self._chat_char_config: Optional[Dict[str, Any]] = None
         if self._chat_config_path:
-            try:
-                with open(self._chat_config_path, "r", encoding="utf-8") as f:
-                    self._chat_char_config = json.load(f)
-            except Exception as e:
-                logger.debug(f"Could not load chat config from {self._chat_config_path}: {e}")
+            if self._chat_config_path not in HumanNPCLLMMixin._char_config_cache:
+                try:
+                    with open(self._chat_config_path, "r", encoding="utf-8") as f:
+                        HumanNPCLLMMixin._char_config_cache[self._chat_config_path] = json.load(f)
+                except Exception as e:
+                    logger.debug(f"Could not load chat config from {self._chat_config_path}: {e}")
+                    HumanNPCLLMMixin._char_config_cache[self._chat_config_path] = None
+            self._chat_char_config = HumanNPCLLMMixin._char_config_cache[self._chat_config_path]
 
-        # Load world facts
-        self._chat_world_facts: Optional[Dict[str, Any]] = None
-        try:
-            with open(_WORLD_FACTS_PATH, "r", encoding="utf-8") as f:
-                self._chat_world_facts = json.load(f)
-        except Exception as e:
-            logger.debug(f"Could not load world facts: {e}")
-            self._chat_world_facts = {}
+        # Load world facts (class-level cache)
+        if HumanNPCLLMMixin._world_facts_cache is None:
+            try:
+                with open(_WORLD_FACTS_PATH, "r", encoding="utf-8") as f:
+                    HumanNPCLLMMixin._world_facts_cache = json.load(f)
+            except Exception as e:
+                logger.debug(f"Could not load world facts: {e}")
+                HumanNPCLLMMixin._world_facts_cache = {}
+        self._chat_world_facts: Optional[Dict[str, Any]] = HumanNPCLLMMixin._world_facts_cache
 
         # For generic nomads: generated on first talk
         self._chat_personality: Optional[Dict[str, Any]] = None
@@ -149,11 +157,16 @@ class HumanNPCLLMMixin:
         # LLM adapter (lazy-loaded)
         self._chat_adapter: Optional[Any] = None
 
-        # Regeneration guard
-        self._chat_regen_count: int = 0
-
         # Fallback rotation index
         self._chat_fallback_idx: int = 0
+
+        # Pre-compile prohibited phrase regexes for story NPCs
+        self._prohibited_patterns: List[Any] = []
+        if self._chat_char_config:
+            self._prohibited_patterns = [
+                re.compile(re.escape(phrase), re.IGNORECASE)
+                for phrase in self._chat_char_config.get("prohibited_phrases", [])
+            ]
 
         # Loquacity system
         self.loquacity_current: int = 0
@@ -167,8 +180,13 @@ class HumanNPCLLMMixin:
         if "chat" not in self.keywords:
             self.keywords.append("chat")
 
+    # Sentinel distinguishing "load failed" from "not yet attempted"
+    _ADAPTER_FAILED = object()
+
     def _get_adapter(self) -> Optional[Any]:
         """Lazy-load NpcChatLLMAdapter via importlib. Return None on failure."""
+        if self._chat_adapter is self._ADAPTER_FAILED:
+            return None
         if self._chat_adapter is not None:
             return self._chat_adapter
 
@@ -183,11 +201,13 @@ class HumanNPCLLMMixin:
                 module = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(module)
                 self._chat_adapter = module.NpcChatLLMAdapter.get_instance()
+            else:
+                self._chat_adapter = self._ADAPTER_FAILED
         except Exception as e:
             logger.debug(f"HumanNPCLLMMixin: could not load adapter: {e}")
-            self._chat_adapter = None
+            self._chat_adapter = self._ADAPTER_FAILED
 
-        return self._chat_adapter
+        return self._chat_adapter if self._chat_adapter is not self._ADAPTER_FAILED else None
 
     def _story(self, player) -> Dict[str, Any]:
         """Get story dict from player.universe, or empty dict."""
@@ -445,23 +465,15 @@ class HumanNPCLLMMixin:
         if not text or len(text) < 10:
             return None
 
-        # Step 6: Prohibited phrases (story chars only)
-        if self._chat_char_config:
-            prohibited = self._chat_char_config.get("prohibited_phrases", [])
-            for phrase in prohibited:
-                pattern = re.compile(re.escape(phrase), re.IGNORECASE)
-                text = pattern.sub("[...]", text)
+        # Step 6: Prohibited phrases (story chars only, patterns pre-compiled in _init_chat_attrs)
+        for pattern in self._prohibited_patterns:
+            text = pattern.sub("[...]", text)
 
-        # Step 7: Repetition guard
+        # Step 7: Repetition guard — caller's retry loop handles the second attempt
         for prior in history[-8:]:
             prior_npc = prior.get("npc", "")
             if prior_npc and self._jaccard(text, prior_npc) > 0.7:
-                self._chat_regen_count += 1
-                if self._chat_regen_count <= 1:
-                    return None
-                # Else accept with warning
-                logger.warning(f"HumanNPCLLMMixin: repetition detected but accepting (count={self._chat_regen_count})")
-                break
+                return None
 
         # Step 8: Terminal punctuation
         if text and text[-1] not in ".!?":
@@ -511,7 +523,6 @@ class HumanNPCLLMMixin:
     def chat_open(self, player) -> Dict[str, Any]:
         """Start conversation. Returns opening line + 3 Jean options."""
         try:
-            self._chat_regen_count = 0
             self._compute_loquacity(player)
             npc_key = self._get_npc_key(player)
             self._load_history_from_persistence(player)
@@ -549,7 +560,6 @@ class HumanNPCLLMMixin:
                         if cleaned:
                             npc_opening = cleaned
                             break
-                        self._chat_regen_count += 1
 
             if not npc_opening:
                 npc_opening = self._get_fallback_npc_line(is_opening=True, player=player)
@@ -632,7 +642,6 @@ class HumanNPCLLMMixin:
                             npc_response = cleaned
                             conversation_quality = result.get("conversation_quality", "neutral")
                             break
-                        self._chat_regen_count += 1
 
             if not npc_response:
                 npc_response = self._get_fallback_npc_line(is_opening=False, player=player)
@@ -647,11 +656,13 @@ class HumanNPCLLMMixin:
             chapter = self._get_chapter(player)
             if self._chat_history and not self._chat_history[-1].get("npc"):
                 self._chat_history[-1]["npc"] = npc_response
+                self._save_exchange_to_persistence(
+                    player, npc_response, jean_text, game_tick, chapter
+                )
             else:
                 self._save_exchange_to_persistence(
                     player, npc_response, jean_text, game_tick, chapter
                 )
-            self._save_exchange_to_persistence(player, npc_response, jean_text, game_tick, chapter)
 
             # Check conversation end
             conversation_ended = (
@@ -696,6 +707,8 @@ class HumanNPCLLMMixin:
 
     def loquacity_tick(self):
         """Recover loquacity each game beat (called outside active conversation)."""
+        if self.loquacity_max == 0:
+            return  # Not yet initialised; skip until first conversation
         self.loquacity_current = min(
             self.loquacity_max,
             self.loquacity_current + self.loquacity_recovery,

--- a/src/npc/_chat_llm.py
+++ b/src/npc/_chat_llm.py
@@ -1,0 +1,755 @@
+"""
+HumanNPCLLMMixin — LLM-driven conversational dialogue mixin for human nomad NPCs.
+
+Mixed into NPC classes (e.g. class Mara(HumanNPCLLMMixin, Friend)).
+Provides multi-turn conversational dialogue with dialogue history persistence,
+loquacity draining, QC pipeline (slang/anachronism filtering, proper noun validation),
+and graceful fallback to deterministic dialogue pools when LLM is unavailable.
+
+Attributes expected on the host class (set before or during __init__):
+    self.name                str
+    self.charisma            int
+    self.wisdom              int (used for loquacity recovery calculation)
+    self.keywords            list[str] (will have "chat" added if missing)
+
+Optional setup (for story NPCs only):
+    self._chat_config_path   str | None (path to character JSON config)
+
+Instance attributes (set by _init_chat_attrs):
+    self.loquacity_current   int (current conversation stamina)
+    self.loquacity_max       int (max stamina for this NPC)
+    self.loquacity_threshold int (minimum to start new conversation)
+    self.loquacity_recovery  int (per-beat recovery when not in conversation)
+    self._chat_history       list[dict] (in-memory exchange log)
+    self._chat_personality   dict | None (for generic nomads)
+    self._chat_npc_key       str | None (persistence key)
+"""
+
+import importlib.util
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_AI_DIR = Path(__file__).resolve().parent.parent.parent / "ai"
+_HUMAN_NPC_DIR = _AI_DIR / "npc" / "human"
+_WORLD_FACTS_PATH = _HUMAN_NPC_DIR / "world_facts.json"
+
+# Modern slang / anachronism blocklist (regex pattern)
+_SLANG_PATTERN = re.compile(
+    r"\b(okay|hey there|yeah|yep|nope|cool|awesome|literally|basically|"
+    r"gonna|wanna|gotta|no worries|you know\?|guns?|bombs?|bullets?|internet)\b",
+    re.IGNORECASE,
+)
+
+# Jean-dialogue guard: reject if NPC text describes Jean speaking
+_JEAN_DIALOG_PATTERN = re.compile(r"jean\s+(said|replied|asked|told)\b|jean:\s*[\"']", re.IGNORECASE)
+
+# Capitalized token finder (for invented proper noun scan)
+_CAP_TOKEN_PATTERN = re.compile(r"\b([A-Z][A-Za-z\-]{2,})\b")
+
+# Drain amounts keyed by conversation_quality
+_LOQUACITY_DRAIN = {"positive": 3, "neutral": 8, "negative": 15, "offensive": 30}
+
+# Jean options fallback pool (rotated to avoid repetition)
+_JEAN_FALLBACK_POOL = [
+    [
+        {"tone": "direct", "text": "What else can you tell me?"},
+        {"tone": "guarded", "text": "I'll keep that in mind."},
+        {"tone": "open", "text": "That's worth knowing."},
+    ],
+    [
+        {"tone": "direct", "text": "Go on."},
+        {"tone": "guarded", "text": "Noted."},
+        {"tone": "open", "text": "Tell me more."},
+    ],
+    [
+        {"tone": "direct", "text": "Fair enough."},
+        {"tone": "guarded", "text": "I see."},
+        {"tone": "open", "text": "I'm listening."},
+    ],
+]
+
+# Generic nomad fallbacks (selected via hash to ensure determinism)
+_GENERIC_FALLBACKS = [
+    {
+        "given_name": "Ren",
+        "voice": "sparse and direct",
+        "knowledge": ["river crossings", "camp craft"],
+        "attitude_to_strangers": "wary",
+        "speech_sample": "River's cold this time of year. Careful at the bend.",
+        "loquacity_base": 55,
+    },
+    {
+        "given_name": "Tal",
+        "voice": "methodical, speaks in short declaratives",
+        "knowledge": ["trade routes", "reading terrain"],
+        "attitude_to_strangers": "indifferent",
+        "speech_sample": "East road's clear. Not sure about the west.",
+        "loquacity_base": 65,
+    },
+    {
+        "given_name": "Sev",
+        "voice": "guarded but not hostile",
+        "knowledge": ["weather patterns", "foraging"],
+        "attitude_to_strangers": "guarded",
+        "speech_sample": "Storm's coming in from the north. Two days, maybe three.",
+        "loquacity_base": 50,
+    },
+    {
+        "given_name": "Vael",
+        "voice": "curious, observant",
+        "knowledge": ["people-reading", "the Badlands by reputation"],
+        "attitude_to_strangers": "curious",
+        "speech_sample": "Jean's not from around here. Most people who look like that aren't.",
+        "loquacity_base": 70,
+    },
+]
+
+
+class HumanNPCLLMMixin:
+    """LLM-driven conversational dialogue mixin for human nomad NPCs."""
+
+    def _init_chat_attrs(self):
+        """Initialize all chat-related attributes. Called at end of host __init__."""
+        # Config path can be set by subclass before calling this
+        self._chat_config_path: Optional[str] = getattr(self, "_chat_config_path", None)
+
+        # Load character config if path provided
+        self._chat_char_config: Optional[Dict[str, Any]] = None
+        if self._chat_config_path:
+            try:
+                with open(self._chat_config_path, "r", encoding="utf-8") as f:
+                    self._chat_char_config = json.load(f)
+            except Exception as e:
+                logger.debug(f"Could not load chat config from {self._chat_config_path}: {e}")
+
+        # Load world facts
+        self._chat_world_facts: Optional[Dict[str, Any]] = None
+        try:
+            with open(_WORLD_FACTS_PATH, "r", encoding="utf-8") as f:
+                self._chat_world_facts = json.load(f)
+        except Exception as e:
+            logger.debug(f"Could not load world facts: {e}")
+            self._chat_world_facts = {}
+
+        # For generic nomads: generated on first talk
+        self._chat_personality: Optional[Dict[str, Any]] = None
+
+        # In-memory exchange history
+        self._chat_history: List[Dict[str, Any]] = []
+
+        # Persistence key (lazy-loaded)
+        self._chat_npc_key: Optional[str] = None
+
+        # LLM adapter (lazy-loaded)
+        self._chat_adapter: Optional[Any] = None
+
+        # Regeneration guard
+        self._chat_regen_count: int = 0
+
+        # Fallback rotation index
+        self._chat_fallback_idx: int = 0
+
+        # Loquacity system
+        self.loquacity_current: int = 0
+        self.loquacity_max: int = 0
+        self.loquacity_threshold: int = 0
+        self.loquacity_recovery: int = 2
+
+        # Add "chat" to keywords if not present
+        if not hasattr(self, "keywords"):
+            self.keywords = []
+        if "chat" not in self.keywords:
+            self.keywords.append("chat")
+
+    def _get_adapter(self) -> Optional[Any]:
+        """Lazy-load NpcChatLLMAdapter via importlib. Return None on failure."""
+        if self._chat_adapter is not None:
+            return self._chat_adapter
+
+        try:
+            spec = importlib.util.find_spec("ai.llm_client")
+            if spec is None:
+                # Try direct path import
+                path = str(_AI_DIR / "llm_client.py")
+                spec = importlib.util.spec_from_file_location("ai_llm_client", path)
+
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                self._chat_adapter = module.NpcChatLLMAdapter.get_instance()
+        except Exception as e:
+            logger.debug(f"HumanNPCLLMMixin: could not load adapter: {e}")
+            self._chat_adapter = None
+
+        return self._chat_adapter
+
+    def _story(self, player) -> Dict[str, Any]:
+        """Get story dict from player.universe, or empty dict."""
+        return getattr(getattr(player, "universe", None), "story", None) or {}
+
+    def _get_chapter(self, player) -> str:
+        """Get current chapter as string."""
+        return str(self._story(player).get("chapter", "1"))
+
+    def _compute_loquacity(self, player):
+        """Compute and set loquacity_max, threshold, and recovery. Only on first call."""
+        if self.loquacity_max != 0:
+            return  # Already computed
+
+        # Base loquacity
+        base = (
+            (self._chat_char_config or {}).get("loquacity_base")
+            or (self._chat_personality or {}).get("loquacity_base")
+            or 60
+        )
+
+        # NPC charisma bonus
+        npc_charisma_bonus = (getattr(self, "charisma", 10) - 10) * 3
+
+        # Reputation modifier
+        rep = getattr(player, "reputation", {}).get(self.name, 0)
+        story_mod = 20 if rep >= 1 else (-20 if rep <= -1 else 0)
+
+        # Jean's charisma modifier
+        jean_stat_mod = (getattr(player, "charisma", 10) - 10) * 2
+
+        # Equipment check
+        equipped = getattr(player, "equipped", {})
+        equip_names = []
+        if isinstance(equipped, dict):
+            for v in equipped.values():
+                if isinstance(v, dict):
+                    equip_names.append(str(v.get("name", "")).lower())
+                else:
+                    equip_names.append(str(v).lower())
+        equip_text = " ".join(equip_names)
+        equip_mod = 10 if any(x in equip_text for x in ("crucifix", "religious token", "nomad gear")) else 0
+
+        # Party check (Gorran in allies)
+        allies = getattr(player, "allies", [])
+        party_mod = 10 if any(getattr(a, "name", "") == "Gorran" for a in allies) else 0
+
+        loquacity_max = max(20, base + npc_charisma_bonus + story_mod + jean_stat_mod + equip_mod + party_mod)
+
+        self.loquacity_max = loquacity_max
+        self.loquacity_threshold = max(10, loquacity_max // 5)
+        self.loquacity_recovery = max(2, getattr(self, "wisdom", 10) // 8)
+
+        if self.loquacity_current == 0:
+            self.loquacity_current = loquacity_max
+
+    def _get_npc_key(self, player) -> str:
+        """Get or generate persistence key for this NPC instance."""
+        if self._chat_npc_key:
+            return self._chat_npc_key
+
+        # Story NPCs use their name
+        if self._chat_char_config:
+            self._chat_npc_key = self.name
+            return self._chat_npc_key
+
+        # Generic nomads use class name + instance count
+        hists = getattr(player, "npc_chat_histories", {})
+        meta = hists.get("__meta__", {})
+        class_name = type(self).__name__
+        instance_count = meta.get(class_name, 0)
+
+        self._chat_npc_key = f"{class_name}_{instance_count}"
+
+        # Increment for next generic of same type
+        if "__meta__" not in hists:
+            hists["__meta__"] = {}
+        hists["__meta__"][class_name] = instance_count + 1
+
+        return self._chat_npc_key
+
+    def _load_history_from_persistence(self, player):
+        """Load chat history and personality from player persistence."""
+        hists = getattr(player, "npc_chat_histories", {})
+        key = self._chat_npc_key
+        if not key or key not in hists:
+            return
+
+        entry = hists[key]
+        self._chat_history = entry.get("exchanges", [])
+        if "personality" in entry and entry["personality"]:
+            self._chat_personality = entry["personality"]
+
+        stored_loquacity = entry.get("loquacity_current", 0)
+        if stored_loquacity > 0:
+            self.loquacity_current = stored_loquacity
+
+    def _save_exchange_to_persistence(
+        self, player, npc_text: str, jean_text: str, game_tick: int, chapter: str
+    ):
+        """Save exchange to player persistence."""
+        hists = getattr(player, "npc_chat_histories", None)
+        if hists is None:
+            return
+
+        key = self._chat_npc_key
+        if key not in hists:
+            hists[key] = {
+                "personality": None,
+                "loquacity_current": self.loquacity_current,
+                "loquacity_max": self.loquacity_max,
+                "exchanges": [],
+                "last_talked_tick": 0,
+                "conversation_count": 0,
+            }
+
+        entry = hists[key]
+        entry["exchanges"].append(
+            {"npc": npc_text, "jean": jean_text, "game_tick": game_tick, "chapter": chapter}
+        )
+
+        # Keep only last 20 exchanges
+        if len(entry["exchanges"]) > 20:
+            entry["exchanges"] = entry["exchanges"][-20:]
+
+        entry["loquacity_current"] = self.loquacity_current
+        entry["loquacity_max"] = self.loquacity_max
+        entry["last_talked_tick"] = game_tick
+
+        # Only increment conversation count on full exchanges (with jean_text)
+        if jean_text:
+            entry["conversation_count"] = entry.get("conversation_count", 0) + 1
+
+        # Store personality for generics
+        if self._chat_personality:
+            entry["personality"] = self._chat_personality
+
+    def _build_system_prompt(self, player) -> str:
+        """Build system prompt from world facts + character block."""
+        blocks = []
+
+        # World facts block
+        if self._chat_world_facts:
+            geo = ", ".join(self._chat_world_facts.get("geography", []))
+            factions = ", ".join(self._chat_world_facts.get("factions_and_peoples", []))
+            rules = " ".join(self._chat_world_facts.get("world_rules", []))
+            tone = self._chat_world_facts.get("tone_notes", "")
+
+            blocks.append(
+                f"WORLD: {self._chat_world_facts.get('world_name', 'Aurelion')}. "
+                f"{self._chat_world_facts.get('brief_description', '')}\n"
+                f"Places: {geo}.\nPeoples: {factions}.\n{rules}\nTone: {tone}"
+            )
+
+        # Character block
+        if self._chat_char_config:
+            # Story NPC: use system_prompt_snippet
+            blocks.append(self._chat_char_config.get("system_prompt_snippet", ""))
+        else:
+            # Generic NPC: synthesize from personality
+            pers = self._chat_personality or {}
+            given_name = pers.get("given_name", "Nomad")
+            voice = pers.get("voice", "terse")
+            knowledge_list = pers.get("knowledge", [])
+            knowledge = ", ".join(knowledge_list) if knowledge_list else "survival"
+
+            blocks.append(
+                f"You are {given_name}, a nomad. {voice}. "
+                f"You know about {knowledge}. You speak in first person. "
+                "Keep responses to 1-3 sentences."
+            )
+
+        # Jean instruction block
+        blocks.append(
+            "Jean is he/him. Do not write Jean's dialogue. Do not describe Jean's internal state."
+        )
+
+        return "\n\n".join(blocks)
+
+    def _ensure_personality(self, player):
+        """For generics: generate personality on first talk, or use fallback."""
+        if self._chat_char_config or self._chat_personality:
+            return  # Already set (story NPC or already generated)
+
+        adapter = self._get_adapter()
+        class_name = type(self).__name__
+
+        if adapter and adapter.enabled:
+            self._chat_personality = adapter.generate_personality(class_name)
+
+        # Fallback if LLM unavailable
+        if not self._chat_personality:
+            key = self._chat_npc_key or self.name
+            idx = hash(key) % len(_GENERIC_FALLBACKS)
+            self._chat_personality = _GENERIC_FALLBACKS[idx].copy()
+
+    def _jaccard(self, text_a: str, text_b: str) -> float:
+        """Compute Jaccard similarity of two texts (word-level tokenization)."""
+        set_a = set(text_a.lower().split())
+        set_b = set(text_b.lower().split())
+
+        if not set_a and not set_b:
+            return 1.0
+        if not set_a or not set_b:
+            return 0.0
+
+        intersection = len(set_a & set_b)
+        union = len(set_a | set_b)
+
+        return intersection / union if union > 0 else 0.0
+
+    def _qc_npc_text(self, text: str, history: List[Dict[str, Any]]) -> Optional[str]:
+        """Apply QC pipeline. Return cleaned text or None."""
+        # Step 1: Strip and length check
+        text = text.strip()
+        if not text or len(text) < 10:
+            return None
+
+        # Step 2: Truncate at sentence boundary if too long
+        if len(text) > 300:
+            # Find last sentence boundary before 300
+            boundary_pos = -1
+            for i in range(299, -1, -1):
+                if text[i] in ".!?":
+                    boundary_pos = i + 1
+                    break
+
+            if boundary_pos > 0:
+                text = text[:boundary_pos].strip()
+            else:
+                text = text[:300].strip()
+
+        # Step 3: Reject if Jean-dialogue pattern found
+        if _JEAN_DIALOG_PATTERN.search(text):
+            return None
+
+        # Step 4: Invented proper noun scan
+        world_nouns = set(
+            (self._chat_world_facts or {}).get("allowed_proper_nouns", [])
+        )
+        world_nouns.update([self.name, "Jean", "Gorran"])
+
+        tokens = _CAP_TOKEN_PATTERN.findall(text)
+        for token in tokens:
+            if token not in world_nouns:
+                # Heuristic: if -ia, -on, -or endings, replace with "that place"
+                # Otherwise replace with "they"
+                if token.endswith(("ia", "on", "or")):
+                    text = re.sub(r"\b" + re.escape(token) + r"\b", "that place", text)
+                else:
+                    text = re.sub(r"\b" + re.escape(token) + r"\b", "they", text)
+
+        # Step 5: Slang filter
+        text = _SLANG_PATTERN.sub("", text).strip()
+        if not text or len(text) < 10:
+            return None
+
+        # Step 6: Prohibited phrases (story chars only)
+        if self._chat_char_config:
+            prohibited = self._chat_char_config.get("prohibited_phrases", [])
+            for phrase in prohibited:
+                pattern = re.compile(re.escape(phrase), re.IGNORECASE)
+                text = pattern.sub("[...]", text)
+
+        # Step 7: Repetition guard
+        for prior in history[-8:]:
+            prior_npc = prior.get("npc", "")
+            if prior_npc and self._jaccard(text, prior_npc) > 0.7:
+                self._chat_regen_count += 1
+                if self._chat_regen_count <= 1:
+                    return None
+                # Else accept with warning
+                logger.warning(f"HumanNPCLLMMixin: repetition detected but accepting (count={self._chat_regen_count})")
+                break
+
+        # Step 8: Terminal punctuation
+        if text and text[-1] not in ".!?":
+            text += "."
+
+        # Step 9: Sentence cap (keep first 3 sentences)
+        sentences = [s.strip() for s in re.split(r"[.!?]", text) if s.strip()]
+        text = ". ".join(sentences[:3])
+        if text and text[-1] not in ".!?":
+            text += "."
+
+        return text
+
+    def _qc_jean_options(self, options: Any) -> Optional[List[Dict[str, str]]]:
+        """QC Jean dialogue options. Return cleaned list or None."""
+        if not isinstance(options, list) or len(options) < 3:
+            return None
+
+        # Extract and validate first 3 items
+        validated = []
+        for i, opt in enumerate(options[:3]):
+            if not isinstance(opt, dict) or "text" not in opt:
+                return None
+
+            text = str(opt.get("text", "")).strip()
+            if not (5 <= len(text) <= 120):
+                return None
+
+            # No meta-speech
+            if re.search(r"\[Option|\bAs Jean\b|I don.t know what to say", text, re.IGNORECASE):
+                return None
+
+            tone = str(opt.get("tone", ["direct", "guarded", "open"][i])).lower()
+            if tone not in ("direct", "guarded", "open"):
+                tone = ["direct", "guarded", "open"][i]
+
+            validated.append({"tone": tone, "text": text})
+
+        # Dedup check
+        for i in range(len(validated)):
+            for j in range(i + 1, len(validated)):
+                if self._jaccard(validated[i]["text"], validated[j]["text"]) > 0.6:
+                    return None
+
+        return validated
+
+    def chat_open(self, player) -> Dict[str, Any]:
+        """Start conversation. Returns opening line + 3 Jean options."""
+        try:
+            self._chat_regen_count = 0
+            self._compute_loquacity(player)
+            npc_key = self._get_npc_key(player)
+            self._load_history_from_persistence(player)
+
+            # Loquacity cutoff
+            if self.loquacity_current < self.loquacity_threshold:
+                brush_off = self._get_brush_off_line()
+                return {
+                    "success": True,
+                    "npc_key": npc_key,
+                    "npc_name": self._display_name(),
+                    "npc_opening": brush_off,
+                    "jean_options": [],
+                    "loquacity_current": self.loquacity_current,
+                    "loquacity_max": self.loquacity_max,
+                    "turn": 0,
+                    "llm_available": False,
+                    "conversation_ended": True,
+                }
+
+            self._ensure_personality(player)
+            system = self._build_system_prompt(player)
+            adapter = self._get_adapter()
+            llm_available = adapter is not None and adapter.enabled
+
+            # Generate NPC opening
+            npc_opening = None
+            if llm_available:
+                for attempt in range(2):
+                    result = adapter.generate_npc_turn(
+                        system, self._chat_history, is_opening=True
+                    )
+                    if result and result.get("npc_text"):
+                        cleaned = self._qc_npc_text(result["npc_text"], self._chat_history)
+                        if cleaned:
+                            npc_opening = cleaned
+                            break
+                        self._chat_regen_count += 1
+
+            if not npc_opening:
+                npc_opening = self._get_fallback_npc_line(is_opening=True, player=player)
+                llm_available = False
+
+            # Generate Jean options
+            jean_options = None
+            if llm_available and adapter:
+                voice = (self._chat_char_config or {}).get("voice_summary") or (
+                    self._chat_personality or {}
+                ).get("voice", "")
+                raw_opts = adapter.generate_jean_options(
+                    self._display_name(), voice, npc_opening, self._chat_history, 0
+                )
+                if raw_opts:
+                    jean_options = self._qc_jean_options(raw_opts)
+
+            if not jean_options:
+                jean_options = self._get_fallback_jean_options()
+
+            game_tick = getattr(getattr(player, "universe", None), "game_tick", 0) or 0
+            chapter = self._get_chapter(player)
+            self._save_exchange_to_persistence(player, npc_opening, "", game_tick, chapter)
+
+            return {
+                "success": True,
+                "npc_key": npc_key,
+                "npc_name": self._display_name(),
+                "npc_opening": npc_opening,
+                "jean_options": jean_options,
+                "loquacity_current": self.loquacity_current,
+                "loquacity_max": self.loquacity_max,
+                "turn": 0,
+                "llm_available": llm_available,
+                "conversation_ended": False,
+            }
+        except Exception as e:
+            logger.error(f"HumanNPCLLMMixin.chat_open error: {e}")
+            return {"success": False, "error": str(e)}
+
+    def chat_respond(
+        self, player, jean_text: str, jean_tone: str
+    ) -> Dict[str, Any]:
+        """Process Jean's response. Returns NPC reply + 3 new Jean options."""
+        try:
+            self._compute_loquacity(player)
+            npc_key = self._get_npc_key(player)
+            self._load_history_from_persistence(player)
+
+            # Update last history entry with jean_text, or append new
+            if self._chat_history and not self._chat_history[-1].get("jean"):
+                self._chat_history[-1]["jean"] = jean_text
+            else:
+                game_tick = getattr(getattr(player, "universe", None), "game_tick", 0) or 0
+                chapter = self._get_chapter(player)
+                self._chat_history.append(
+                    {"npc": "", "jean": jean_text, "game_tick": game_tick, "chapter": chapter}
+                )
+
+            self._ensure_personality(player)
+            system = self._build_system_prompt(player)
+            adapter = self._get_adapter()
+            llm_available = adapter is not None and adapter.enabled
+
+            # Generate NPC response
+            npc_response = None
+            conversation_quality = "neutral"
+
+            if llm_available:
+                for attempt in range(2):
+                    result = adapter.generate_npc_turn(
+                        system,
+                        self._chat_history,
+                        is_opening=False,
+                        jean_text=jean_text,
+                    )
+                    if result and result.get("npc_text"):
+                        cleaned = self._qc_npc_text(result["npc_text"], self._chat_history)
+                        if cleaned:
+                            npc_response = cleaned
+                            conversation_quality = result.get("conversation_quality", "neutral")
+                            break
+                        self._chat_regen_count += 1
+
+            if not npc_response:
+                npc_response = self._get_fallback_npc_line(is_opening=False, player=player)
+                llm_available = False
+
+            # Drain loquacity
+            drain = _LOQUACITY_DRAIN.get(conversation_quality, 8)
+            self.loquacity_current = max(0, self.loquacity_current - drain)
+
+            # Persist exchange
+            game_tick = getattr(getattr(player, "universe", None), "game_tick", 0) or 0
+            chapter = self._get_chapter(player)
+            if self._chat_history and not self._chat_history[-1].get("npc"):
+                self._chat_history[-1]["npc"] = npc_response
+            else:
+                self._save_exchange_to_persistence(
+                    player, npc_response, jean_text, game_tick, chapter
+                )
+            self._save_exchange_to_persistence(player, npc_response, jean_text, game_tick, chapter)
+
+            # Check conversation end
+            conversation_ended = (
+                self.loquacity_current < self.loquacity_threshold
+            )
+
+            # Generate Jean options or return closing
+            jean_options = []
+            if not conversation_ended:
+                if llm_available and adapter:
+                    voice = (self._chat_char_config or {}).get("voice_summary") or (
+                        self._chat_personality or {}
+                    ).get("voice", "")
+                    turn_number = len(self._chat_history)
+                    raw_opts = adapter.generate_jean_options(
+                        self._display_name(),
+                        voice,
+                        npc_response,
+                        self._chat_history,
+                        turn_number,
+                    )
+                    if raw_opts:
+                        jean_options = self._qc_jean_options(raw_opts) or []
+
+                if not jean_options:
+                    jean_options = self._get_fallback_jean_options()
+
+            return {
+                "success": True,
+                "npc_key": npc_key,
+                "npc_response": npc_response,
+                "jean_options": jean_options,
+                "loquacity_current": self.loquacity_current,
+                "loquacity_max": self.loquacity_max,
+                "turn": len(self._chat_history),
+                "llm_available": llm_available,
+                "conversation_ended": conversation_ended,
+            }
+        except Exception as e:
+            logger.error(f"HumanNPCLLMMixin.chat_respond error: {e}")
+            return {"success": False, "error": str(e)}
+
+    def loquacity_tick(self):
+        """Recover loquacity each game beat (called outside active conversation)."""
+        self.loquacity_current = min(
+            self.loquacity_max,
+            self.loquacity_current + self.loquacity_recovery,
+        )
+
+    def _display_name(self) -> str:
+        """Return display name for this NPC."""
+        if self._chat_char_config:
+            return self.name
+        # Generic: use generated name if available
+        if self._chat_personality and "given_name" in self._chat_personality:
+            return self._chat_personality["given_name"]
+        return self.name
+
+    def _get_brush_off_line(self) -> str:
+        """Get brush-off when loquacity exhausted."""
+        if self._chat_char_config:
+            lines = self._chat_char_config.get("closing_lines_when_exhausted", [])
+            if lines:
+                return lines[0]
+        # Generic fallback
+        idx = hash(self.name) % 3
+        fallbacks = [
+            "They're not in the mood to talk.",
+            "A brief shake of the head.",
+            "Not now.",
+        ]
+        return fallbacks[idx]
+
+    def _get_fallback_npc_line(
+        self, is_opening: bool, player
+    ) -> str:
+        """Get fallback NPC line (no LLM)."""
+        if self._chat_char_config:
+            chapter = self._get_chapter(player)
+            if is_opening:
+                starters = self._chat_char_config.get(
+                    "conversation_starters_by_chapter", {}
+                ).get(chapter, [])
+                if starters:
+                    return starters[0]
+            else:
+                closing = self._chat_char_config.get("closing_lines_when_exhausted", [])
+                if closing:
+                    return closing[0]
+        else:
+            # Generic
+            if self._chat_personality and "speech_sample" in self._chat_personality:
+                return self._chat_personality["speech_sample"]
+
+        return "Nothing to say right now."
+
+    def _get_fallback_jean_options(self) -> List[Dict[str, str]]:
+        """Return fallback Jean options, cycling through pool."""
+        pool = _JEAN_FALLBACK_POOL[self._chat_fallback_idx % len(_JEAN_FALLBACK_POOL)]
+        self._chat_fallback_idx += 1
+        return pool

--- a/src/npc/_eastern_descent.py
+++ b/src/npc/_eastern_descent.py
@@ -12,13 +12,14 @@ import random
 
 import moves  # type: ignore
 from ._base import Friend
+from ._chat_llm import HumanNPCLLMMixin
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Eastern Descent — Nomad Camp NPCs
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-class NomadCamper(Friend):
+class NomadCamper(HumanNPCLLMMixin, Friend):
     """A generic nomad resting at the east-bank camp between routes.
 
     Not a fighter, not a guide — someone between places, occupying the camp
@@ -79,12 +80,15 @@ class NomadCamper(Friend):
             self.known_moves = [moves.NpcIdle(self)]
         except Exception:
             self.known_moves = []
+        self._chat_config_path = None
+        self._init_chat_attrs()
 
     def talk(self, player):
+        """Terminal fallback — static dialogue. Web uses chat_open/chat_respond via the API."""
         print(random.choice(self._TALK_LINES))
 
 
-class NomadScout(Friend):
+class NomadScout(HumanNPCLLMMixin, Friend):
     """A nomad who watches the eastern approaches and knows the terrain.
 
     Economical with words. Has practical knowledge of the paths between the
@@ -140,12 +144,15 @@ class NomadScout(Friend):
             self.known_moves = [moves.NpcIdle(self)]
         except Exception:
             self.known_moves = []
+        self._chat_config_path = None
+        self._init_chat_attrs()
 
     def talk(self, player):
+        """Terminal fallback — static dialogue. Web uses chat_open/chat_respond via the API."""
         print(random.choice(self._TALK_LINES))
 
 
-class NomadTrader(Friend):
+class NomadTrader(HumanNPCLLMMixin, Friend):
     """A nomad who barters goods picked up along the eastern routes.
 
     Not a full merchant — no shop, no stock list. Trades as part of nomadic
@@ -203,6 +210,9 @@ class NomadTrader(Friend):
             self.known_moves = [moves.NpcIdle(self)]
         except Exception:
             self.known_moves = []
+        self._chat_config_path = None
+        self._init_chat_attrs()
 
     def talk(self, player):
+        """Terminal fallback — static dialogue. Web uses chat_open/chat_respond via the API."""
         print(random.choice(self._TALK_LINES))

--- a/src/npc/_friends.py
+++ b/src/npc/_friends.py
@@ -7,13 +7,17 @@ citizen classes communicate only through gesture and sound (no human speech).
 """
 
 import random
+from pathlib import Path
 
 import functions  # type: ignore
+
+_HUMAN_NPC_DIR = Path(__file__).resolve().parent.parent.parent / "ai" / "npc" / "human"
 import genericng  # type: ignore
 import moves  # type: ignore
 from neotermcolor import colored  # type: ignore
 
 from ._base import Friend
+from ._chat_llm import HumanNPCLLMMixin
 from ._llm import MynxLLMMixin
 
 
@@ -520,7 +524,7 @@ class GronditeConclaveElder(Friend):
             print(random.choice(lines))
 
 
-class Mara(Friend):
+class Mara(HumanNPCLLMMixin, Friend):
     """Scavenger, ferry operator, and guide. First human Jean encounters outside any
     institutional context. Sardonic, watchful, practical. Skilled in precision combat,
     positioning, and tactical awareness. Fights with the same observant efficiency as
@@ -574,6 +578,8 @@ class Mara(Friend):
         self.preferred_range = None  # Will be set dynamically based on combat distance
         self.bow_range = (8, 25)  # Bow effective range
         self.dagger_range = (0, 3)  # Dagger effective range
+        self._chat_config_path = str(_HUMAN_NPC_DIR / "mara.json")
+        self._init_chat_attrs()
 
     def talk(self, player):
         """Mara's dialogue is sparse, practical, observant."""
@@ -721,7 +727,7 @@ class Mara(Friend):
             return
 
 
-class Devet(Friend):
+class Devet(HumanNPCLLMMixin, Friend):
     """Camp cook, older, unhurried. Quietly observant. Offers food and healing.
     Uncle or relation of Mara — exact nature left ambiguous.
     """
@@ -759,9 +765,11 @@ class Devet(Friend):
             self.known_moves = [moves.NpcIdle(self)]
         except Exception:
             self.known_moves = []
+        self._chat_config_path = str(_HUMAN_NPC_DIR / "devet.json")
+        self._init_chat_attrs()
 
     def talk(self, player):
-        """Devet's dialogue is sparse but warm. He observes without commenting."""
+        """Terminal fallback — static dialogue. Web uses chat_open/chat_respond via the API."""
         lines = [
             "Devet hands Jean a bowl of warm food without asking if he's hungry. It's clear "
             "this is not a question.",
@@ -775,7 +783,7 @@ class Devet(Friend):
         print(random.choice(lines))
 
 
-class Liss(Friend):
+class Liss(HumanNPCLLMMixin, Friend):
     """Young, openly curious, observant. Part of Mara's nomad group. At the camp's edge,
     watching the river and the world beyond.
     """
@@ -813,9 +821,11 @@ class Liss(Friend):
             self.known_moves = [moves.NpcIdle(self)]
         except Exception:
             self.known_moves = []
+        self._chat_config_path = str(_HUMAN_NPC_DIR / "liss.json")
+        self._init_chat_attrs()
 
     def talk(self, player):
-        """Liss's dialogue is curious and direct. She asks questions without preface."""
+        """Terminal fallback — static dialogue. Web uses chat_open/chat_respond via the API."""
         lines = [
             "Liss says, 'Where's Jean headed?' She doesn't wait for an answer before asking "
             "another question. 'What's beyond the Badlands? Does anyone actually know?'",

--- a/src/universe.py
+++ b/src/universe.py
@@ -125,7 +125,7 @@ class Universe:  # "globals" for the game state can be stored here, as well as a
             return None
         cls_name = payload.get("__class__")
         mod_name = payload.get("__module__")
-        props = payload.get("props", {})
+        props = payload.get("props") or {}
 
         # Throw error if mod name has improper format; 'src.' prefix should not be present.
         if mod_name.startswith("src."):

--- a/tools/harness/reporter.py
+++ b/tools/harness/reporter.py
@@ -21,6 +21,7 @@ class BugCategory(str, Enum):
     LOGIC = "logic"              # game logic incorrect
     AUTH = "auth"                # session / auth failures
     MISSING_FIELD = "missing"    # required field absent from response
+    UI = "ui"                    # browser/rendering/JS error
 
 
 @dataclass

--- a/tools/inquisitor/browser_layer.py
+++ b/tools/inquisitor/browser_layer.py
@@ -29,7 +29,7 @@ from tools.inquisitor.game_tools import ToolResult
 ROOT = Path(__file__).resolve().parent.parent.parent
 FRONTEND_DIR = ROOT / "frontend"
 API_URL = "http://localhost:5000"
-FRONTEND_URL = "http://localhost:3000"
+FRONTEND_URL = "http://localhost:3000/games/HeartOfVirtue/"
 SERVER_STARTUP_TIMEOUT = 120  # seconds — Vite cold-starts slowly on first run
 SCREENSHOT_DIR = ROOT / "tools" / "inquisitor_screenshots"
 
@@ -234,7 +234,8 @@ class BrowserLayer:
                     os.path.expanduser(
                         "~/.cache/ms-playwright/chromium-*/chrome-linux/chrome"
                     )
-                ),
+                )
+                + _glob.glob("/opt/pw-browsers/chromium-*/chrome-linux/chrome"),
                 reverse=True,  # prefer highest build number
             )
             if not candidates:
@@ -245,10 +246,11 @@ class BrowserLayer:
         context = self._browser.new_context()
         self._page = context.new_page()
 
-        # Collect JS errors
+        # Collect JS errors and HTTP 4xx/5xx responses
         self._page.on("console", self._on_console)
         self._page.on("pageerror", self._on_page_error)
         self._page.on("requestfailed", self._on_request_failed)
+        self._page.on("response", self._on_response)
 
     def _login(self):
         """Register a fresh test account and extract the auth token."""
@@ -316,10 +318,13 @@ class BrowserLayer:
 
     def _on_console(self, msg):
         if msg.type in ("error", "warning"):
+            loc = msg.location or {}
+            loc_url = loc.get("url", "") if isinstance(loc, dict) else ""
             self._console_errors.append({
                 "type": msg.type,
-                "text": msg.text,
-                "location": str(msg.location),
+                # Include the location URL in text so _is_noise() can pattern-match it
+                "text": msg.text + (f" [{loc_url}]" if loc_url else ""),
+                "location": str(loc),
             })
 
     def _on_page_error(self, exc):
@@ -331,6 +336,15 @@ class BrowserLayer:
             "failure": request.failure,
             "method": request.method,
         })
+
+    def _on_response(self, response):
+        """Capture HTTP 4xx/5xx responses as network failures for noise filtering."""
+        if response.status >= 400:
+            self._network_failures.append({
+                "url": response.url,
+                "failure": f"HTTP {response.status}",
+                "method": response.request.method,
+            })
 
     # ------------------------------------------------------------------
     # HTTP helpers (uses real server + auth token)
@@ -466,6 +480,8 @@ class BrowserLayer:
         # External font CDNs are unreachable in offline / sandboxed CI.
         "fonts.googleapis.com",
         "fonts.gstatic.com",
+        # favicon.ico is not present in the dev build — harmless in production.
+        "favicon.ico",
         # React Router v6 → v7 migration warnings — known, tracked upstream.
         "React Router Future Flag Warning",
         "React.startTransition",


### PR DESCRIPTION
- Add NpcChatLLMAdapter to ai/llm_client.py extending GenericLLMClient
  with three call types: generate_personality (generic nomad seeding),
  generate_npc_turn (NPC opening/response with quality signal), and
  generate_jean_options (3 Jean choices in a single structured call)
- Add ai/npc/human/world_facts.json: canonical lore block (allowed
  proper nouns, geography, factions, tone) injected into all human NPC
  system prompts
- Add ai/npc/human/mara.json, devet.json, liss.json: per-character
  personality configs with voice_summary, knowledge_scope, prohibited
  phrases, chapter-specific conversation starters, loquacity_base, and
  system prompt snippets
- Add npc_chat_histories dict to MinimalPlayer for conversation
  history and loquacity state persistence

https://claude.ai/code/session_01MZJXXEGnyBH4yVceTMDCDs