### PR TITLE
fix(inventory): correct equipped-item secondary effects on drop/unequip; remove dead stubs

### DIFF
--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -84,14 +84,11 @@ export const combat = {
 // Inventory endpoints
 export const inventory = {
   useItem: (itemId) => apiClient.post('/inventory/use', { item_id: itemId }),
-  dropItem: (itemId) => apiClient.post('/inventory/drop', { item_id: itemId }),
-  pickupItem: (itemId) => apiClient.post('/inventory/take', { item_id: itemId }),
 }
 
 // Equipment endpoints
 export const equipment = {
   equipItem: (itemId, slot) => apiClient.post('/inventory/equip', { item_id: itemId, slot }),
-  unequipItem: (slot) => apiClient.post('/inventory/unequip', { slot }),
 }
 
 // Save/Load endpoints

--- a/frontend/src/api/endpoints.test.js
+++ b/frontend/src/api/endpoints.test.js
@@ -180,26 +180,12 @@ describe('endpoints', () => {
       expect(apiClient.post).toHaveBeenCalledWith('/inventory/use', { item_id: 'item123' });
     });
 
-    it('calls dropItem endpoint', () => {
-      endpoints.inventory.dropItem('item123');
-      expect(apiClient.post).toHaveBeenCalledWith('/inventory/drop', { item_id: 'item123' });
-    });
-
-    it('calls pickupItem endpoint', () => {
-      endpoints.inventory.pickupItem('item123');
-      expect(apiClient.post).toHaveBeenCalledWith('/inventory/take', { item_id: 'item123' });
-    });
   });
 
   describe('equipment', () => {
     it('calls equipItem endpoint', () => {
       endpoints.equipment.equipItem('sword1', 'main_hand');
       expect(apiClient.post).toHaveBeenCalledWith('/inventory/equip', { item_id: 'sword1', slot: 'main_hand' });
-    });
-
-    it('calls unequipItem endpoint', () => {
-      endpoints.equipment.unequipItem('main_hand');
-      expect(apiClient.post).toHaveBeenCalledWith('/inventory/unequip', { slot: 'main_hand' });
     });
   });
 

--- a/src/api/routes/inventory.py
+++ b/src/api/routes/inventory.py
@@ -158,56 +158,6 @@ def examine_item():
         return jsonify({"success": False, "error": str(e)}), 500
 
 
-@inventory_bp.route("/inventory/take", methods=["POST"])
-def take_item():
-    """Take item from current tile into inventory.
-
-    JSON body:
-        index: Item index on tile
-
-    Returns:
-        JSON with updated inventory
-    """
-    session, player, error, status = get_session_and_player()
-    if error:
-        return error, status
-
-    try:
-        data = request.get_json() or {}
-        is_valid, error_msg = validate_required_fields(data, ["index"])
-        if not is_valid:
-            return jsonify({"success": False, "error": error_msg}), 400
-
-        item_index = data["index"]
-
-        # Get current tile
-        x, y = int(player.location_x), int(player.location_y)
-        tile_data = current_app.game_service.get_tile(player, x, y)
-        if not tile_data or "error" in tile_data:
-            return jsonify({"success": False, "error": "Tile not found"}), 404
-
-        # For now, just validate the index and return success
-        # Full implementation requires game engine state manipulation
-        is_valid, error_msg = validate_item_index(
-            item_index, len(tile_data.get("items", []))
-        )
-        if not is_valid:
-            return jsonify({"success": False, "error": error_msg}), 400
-
-        inventory_data = InventorySerializer.serialize(player)
-        return (
-            jsonify(
-                {
-                    "success": True,
-                    "message": "Item taken",
-                    "inventory": inventory_data,
-                }
-            ),
-            200,
-        )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
-
 
 @inventory_bp.route("/inventory/drop", methods=["POST"])
 def drop_item():
@@ -261,6 +211,16 @@ def drop_item():
                 jsonify({"success": False, "error": "Current tile not found"}),
                 400,
             )
+
+        # If equipped, unequip cleanly before dropping
+        if getattr(item_to_drop, "isequipped", False):
+            item_to_drop.isequipped = False
+            if hasattr(item_to_drop, "on_unequip"):
+                item_to_drop.on_unequip(player)
+            if getattr(item_to_drop, "maintype", None) == "Weapon":
+                player.eq_weapon = getattr(player, "fists", None)
+            from src import functions
+            functions.refresh_stat_bonuses(player)
 
         # Remove item from inventory and add to tile
         inventory_list = getattr(player, "inventory_list", None) or getattr(
@@ -369,6 +329,10 @@ def equip_item():
             item.isequipped = False
             if hasattr(item, "on_unequip"):
                 item.on_unequip(player)
+            if getattr(item, "maintype", None) == "Weapon":
+                player.eq_weapon = getattr(player, "fists", None)
+            from src import functions
+            functions.refresh_stat_bonuses(player)
             message = f"{item.name} unequipped"
         else:
             # Check if merchandise - can't equip until purchased
@@ -595,71 +559,6 @@ def use_item():
     except Exception as e:
         return jsonify({"success": False, "error": str(e)}), 500
 
-
-@inventory_bp.route("/inventory/unequip", methods=["POST"])
-def unequip_item():
-    """Unequip an item from a slot.
-
-    JSON body:
-        slot: Equipment slot name (head, chest, etc.)
-
-    Returns:
-        JSON with updated equipment
-    """
-    session, player, error, status = get_session_and_player()
-    if error:
-        return error, status
-
-    try:
-        data = request.get_json() or {}
-        is_valid, error_msg = validate_required_fields(data, ["slot"])
-        if not is_valid:
-            return jsonify({"success": False, "error": error_msg}), 400
-
-        slot_name = data["slot"]
-
-        # Validate slot
-        is_valid, error_msg = validate_equipment_slot(slot_name)
-        if not is_valid:
-            return jsonify({"success": False, "error": error_msg}), 400
-
-        # Check if slot has item (handle both equipped and equipment)
-        equipment_dict = getattr(player, "equipped", None) or getattr(
-            player, "equipment", {}
-        )
-        if not equipment_dict or slot_name not in equipment_dict:
-            return (
-                jsonify({"success": False, "error": f"Invalid slot: {slot_name}"}),
-                400,
-            )
-
-        item = equipment_dict.get(slot_name)
-        if not item:
-            return (
-                jsonify(
-                    {
-                        "success": False,
-                        "error": f"No item equipped in {slot_name}",
-                    }
-                ),
-                400,
-            )
-
-        # For now, just validate and return success
-        # Full implementation requires game engine state manipulation
-        equipment_data = EquipmentSerializer.serialize(player)
-        return (
-            jsonify(
-                {
-                    "success": True,
-                    "message": "Unequipped item",
-                    "equipment": equipment_data,
-                }
-            ),
-            200,
-        )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
 
 
 @inventory_bp.route("/inventory/compare", methods=["GET"])

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -1409,47 +1409,6 @@ class GameService:
         """
         return InventorySerializer.serialize(player)
 
-    def take_item(self, player: "player_module.Player", item_id: str) -> Dict[str, Any]:
-        """Take an item from the ground.
-
-        Args:
-            player: The Player instance
-            item_id: ID of item to take
-
-        Returns:
-            Result of action
-        """
-        # TODO: Implement item pickup logic
-        return {"success": True, "item_id": item_id, "message": "Item taken"}
-
-    def drop_item(self, player: "player_module.Player", item_id: str) -> Dict[str, Any]:
-        """Drop an item from inventory.
-
-        Args:
-            player: The Player instance
-            item_id: ID of item to drop
-
-        Returns:
-            Result of action
-        """
-        # TODO: Implement item drop logic
-        return {"success": True, "item_id": item_id, "message": "Item dropped"}
-
-    def examine_item(
-        self, player: "player_module.Player", item_id: str
-    ) -> Dict[str, Any]:
-        """Examine an item in inventory.
-
-        Args:
-            player: The Player instance
-            item_id: ID of item to examine
-
-        Returns:
-            Dictionary with item details
-        """
-        # TODO: Implement item examination logic
-        return {"item_id": item_id, "message": "Unknown item"}
-
     # ========================
     # Equipment Methods
     # ========================


### PR DESCRIPTION
Two bugs fixed in active code paths:
- drop_item(): dropping an equipped item now calls on_unequip(), resets
  player.eq_weapon for weapons, and calls refresh_stat_bonuses() before
  moving the item to the tile — matching Item.drop() in the engine.
- equip_item() unequip branch: now calls refresh_stat_bonuses() and
  resets player.eq_weapon, which the equip branch already did but the
  unequip branch was missing entirely.

Dead code removed:
- game_service.take_item/drop_item/examine_item (no route called them)
- POST /inventory/take route (returned success without moving the item;
  real take path is POST /world/interact)
- POST /inventory/unequip route (returned success without changing state;
  unequip is handled by the equip toggle in POST /inventory/equip)
- endpoints.js pickupItem/dropItem/unequipItem helpers and their tests

https://claude.ai/code/session_01QRWXao1z5pE7zDDjbyLYdE