### PR TITLE
fix(combat): ally KO system — friends survive battle and follow Jean

### DIFF
--- a/src/combat.py
+++ b/src/combat.py
@@ -565,25 +565,39 @@ def combat(player, event_config: Optional[CombatEventConfig] = None):
         ):  # advances moves one beat along the path toward cooldown zero.
             move.advance(player)
 
-        for i, ally in enumerate(player.combat_list_allies):
-            if not ally == player:  # make sure you don't select Jean!
-                if not ally.is_alive():
-                    ally.die()
-                if (
-                    not ally.is_alive()
-                ):  # check again in case some pre-death sequence saved the NPC
+        for ally in list(player.combat_list_allies):
+            if ally == player:
+                continue
+            if not ally.is_alive():
+                if getattr(ally, "friend", False):
+                    # Named companions are knocked out rather than killed — set to
+                    # 1 HP and removed from this fight but kept in the room so they
+                    # can be healed and rejoin the next battle.
+                    ally.hp = 1
                     print(
                         colored(ally.name, "yellow", attrs="bold")
-                        + " has fallen in battle!"
+                        + " has been knocked out!"
                     )
-                    # not sure yet if I want to change this
-                    player.current_room.npcs_here.remove(ally)
                     player.combat_list_allies.remove(ally)
                 else:
-                    process_npc(ally)
-                    gorran_beat_cooldown = maybe_combat_flavor(
-                        player, beat, gorran_beat_cooldown
-                    )
+                    ally.die()
+                    if not ally.is_alive():
+                        print(
+                            colored(ally.name, "yellow", attrs="bold")
+                            + " has fallen in battle!"
+                        )
+                        player.current_room.npcs_here.remove(ally)
+                        player.combat_list_allies.remove(ally)
+                    else:
+                        process_npc(ally)
+                        gorran_beat_cooldown = maybe_combat_flavor(
+                            player, beat, gorran_beat_cooldown
+                        )
+            else:
+                process_npc(ally)
+                gorran_beat_cooldown = maybe_combat_flavor(
+                    player, beat, gorran_beat_cooldown
+                )
 
         for enemy in player.combat_list:
             check_for_dead_enemy(

--- a/src/combat.py
+++ b/src/combat.py
@@ -120,6 +120,8 @@ def combat(player, event_config: Optional[CombatEventConfig] = None):
     # Set player reference on all combatants for config access
     for npc in player.combat_list + player.combat_list_allies:
         npc.player_ref = player
+        if getattr(npc, "knocked_out", False):
+            npc.knocked_out = False  # allies recover between battles
 
     def process_npc(npc):  # when an NPC's turn comes up, perform these actions
         npc.cycle_states()
@@ -568,17 +570,19 @@ def combat(player, event_config: Optional[CombatEventConfig] = None):
         for ally in list(player.combat_list_allies):
             if ally == player:
                 continue
+            if getattr(ally, "knocked_out", False):
+                continue  # sits out this fight; still follows Jean between battles
             if not ally.is_alive():
                 if getattr(ally, "friend", False):
-                    # Named companions are knocked out rather than killed — set to
-                    # 1 HP and removed from this fight but kept in the room so they
-                    # can be healed and rejoin the next battle.
+                    # Named companions are knocked out rather than killed — 1 HP,
+                    # flagged out of this fight, but kept in the party list so
+                    # recall_friends() still brings them along between battles.
                     ally.hp = 1
+                    ally.knocked_out = True
                     print(
                         colored(ally.name, "yellow", attrs="bold")
                         + " has been knocked out!"
                     )
-                    player.combat_list_allies.remove(ally)
                 else:
                     ally.die()
                     if not ally.is_alive():

--- a/src/combat.py
+++ b/src/combat.py
@@ -593,10 +593,7 @@ def combat(player, event_config: Optional[CombatEventConfig] = None):
                         player.current_room.npcs_here.remove(ally)
                         player.combat_list_allies.remove(ally)
                     else:
-                        process_npc(ally)
-                        gorran_beat_cooldown = maybe_combat_flavor(
-                            player, beat, gorran_beat_cooldown
-                        )
+                        process_npc(ally)  # revived by before_death(); act this beat
             else:
                 process_npc(ally)
                 gorran_beat_cooldown = maybe_combat_flavor(

--- a/src/game.py
+++ b/src/game.py
@@ -203,6 +203,14 @@ _\\|//__( | )______)_/
             player.recall_friends()  # bring any party members along
             for actor in player.combat_list_allies:
                 actor.cycle_states()
+            if player.universe.game_tick % 5 == 0:
+                for actor in player.combat_list_allies:
+                    if actor is player:
+                        continue
+                    if actor.hp < actor.maxhp // 2:
+                        flavor = getattr(actor, "wounded_flavor", lambda: None)()
+                        if flavor:
+                            print(colored(flavor, "yellow"))
             player.current_room.evaluate_events()
             player.current_room.modify_player(player)
             if mark_health != player.hp:

--- a/src/game.py
+++ b/src/game.py
@@ -208,7 +208,7 @@ _\\|//__( | )______)_/
                     if actor is player:
                         continue
                     if actor.hp < actor.maxhp // 2:
-                        flavor = getattr(actor, "wounded_flavor", lambda: None)()
+                        flavor = actor.wounded_flavor()
                         if flavor:
                             print(colored(flavor, "yellow"))
             player.current_room.evaluate_events()

--- a/src/npc/_base.py
+++ b/src/npc/_base.py
@@ -181,10 +181,15 @@ class Friend(NPC):
             target=target,
             friend=friend,
         )
+        self.knocked_out = False  # True while sitting out a fight after being KO'd
 
     def wounded_flavor(self):
-        """Return a one-line string of flavor text indicating this ally is hurt,
-        or None to suppress output. Override per companion for voice-appropriate lines."""
+        """Return a one-line flavor string shown periodically when this ally is
+        below half HP, or None to suppress output.
+
+        Override this in every named companion class with character-appropriate
+        lines — the base implementation is intentionally silent so generic
+        Friend instances don't produce out-of-character output."""
         return None
 
     def talk(self, player):

--- a/src/npc/_base.py
+++ b/src/npc/_base.py
@@ -182,5 +182,10 @@ class Friend(NPC):
             friend=friend,
         )
 
+    def wounded_flavor(self):
+        """Return a one-line string of flavor text indicating this ally is hurt,
+        or None to suppress output. Override per companion for voice-appropriate lines."""
+        return None
+
     def talk(self, player):
         print(self.name + " has nothing to say.")

--- a/src/npc/_friends.py
+++ b/src/npc/_friends.py
@@ -180,14 +180,6 @@ friendly enough to Jean.
     def name(self, value):
         self._name = value
 
-    def before_death(self):
-        print(
-            colored(self.name, "yellow", attrs=["bold"]) + " quaffs one of his potions!"
-        )
-        self.fatigue /= 2
-        self.hp = self.maxhp
-        return False
-
     def talk(self, player):
         if self.current_room.universe.story["gorran_first"] == "0":
             self.current_room.events_here.append(

--- a/src/npc/_friends.py
+++ b/src/npc/_friends.py
@@ -180,6 +180,21 @@ friendly enough to Jean.
     def name(self, value):
         self._name = value
 
+    def wounded_flavor(self):
+        msgs = [
+            self.name + " moves with an uneven gait, stone scraping faintly.",
+            "A low subsonic pressure radiates from "
+            + self.name
+            + ". He pushes forward without comment.",
+            self.name + " pauses for a moment. His jaw shifts. He continues.",
+            "The cracks along "
+            + self.name
+            + "'s shoulder have widened. He gives no sign of noticing.",
+            self.name
+            + " produces a small stone chip from somewhere and rolls it in his palm. Keeps moving.",
+        ]
+        return random.choice(msgs)
+
     def talk(self, player):
         if self.current_room.universe.story["gorran_first"] == "0":
             self.current_room.events_here.append(
@@ -594,6 +609,17 @@ class Mara(HumanNPCLLMMixin, Friend):
         self.dagger_range = (0, 3)  # Dagger effective range
         self._chat_config_path = str(_HUMAN_NPC_DIR / "mara.json")
         self._init_chat_attrs()
+
+    def wounded_flavor(self):
+        msgs = [
+            "Mara moves with precision, though she favors her right side.",
+            "Mara tears a strip from her pack cloth and binds something beneath her sleeve."
+            " She says nothing.",
+            "Mara exhales slowly. Her pace doesn't change.",
+            "Mara's eyes move to Jean once, assess, and return forward. She doesn't comment.",
+            "Mara adjusts her grip on her bag — a small, deliberate motion. She keeps moving.",
+        ]
+        return random.choice(msgs)
 
     def talk(self, player):
         """Mara's dialogue is sparse, practical, observant."""


### PR DESCRIPTION
## Summary

- **Allies no longer die permanently in combat.** Named friends (Gorran, Mara, any `friend=True` NPC) that reach 0 HP are knocked out at 1 HP instead of being erased from the world. They sit out the current fight via a `knocked_out` flag, then re-enter the next encounter with the flag cleared.
- **KO'd friends stay in the party.** They remain in `combat_list_allies` so `recall_friends()` keeps bringing them along between battles. Heal them out of combat to restore them before the next fight.
- **Periodic wounded flavor text.** Every 5 world ticks, allies below 50% max HP emit a character-appropriate line. Gorran and Mara each have five lines matching their established voices. New companions override `wounded_flavor()` on their class; the base returns `None` (silent).

## Changed files

| File | Change |
|---|---|
| `src/combat.py` | KO mechanic + `knocked_out` flag; reset at combat start; fix latent mutation-during-iteration bug in ally loop |
| `src/npc/_base.py` | `knocked_out = False` in `Friend.__init__`; `wounded_flavor()` hook with author guidance in docstring |
| `src/npc/_friends.py` | `wounded_flavor()` overrides for Gorran and Mara; removed superseded `before_death()` potion-revive from Gorran |
| `src/game.py` | World-beat wounded flavor trigger (every 5 ticks, allies < 50% HP) |

## Test plan

- [ ] Enter combat with Gorran or Mara in party; let ally reach 0 HP — confirm "knocked out" message, ally stays in room
- [ ] After combat, move to adjacent tile — confirm ally follows Jean (`recall_friends` still works)
- [ ] Start a new combat — confirm ally re-enters the fight at 1 HP (with `knocked_out` cleared)
- [ ] Heal ally above 50% maxhp between fights — confirm wounded flavor text stops firing
- [ ] Move around world for 5+ ticks with an ally below half HP — confirm periodic flavor text fires in yellow
- [ ] Run `python tools/bug_hunt.py --scenario ally` to verify no regression in ally AI scenario

https://claude.ai/code/session_01LUDKKPt3uTqM7FfUDNEixf