### PR TITLE
Add support for using consumable items on party members

### DIFF
--- a/frontend/src/components/ItemDetailDialog.jsx
+++ b/frontend/src/components/ItemDetailDialog.jsx
@@ -21,6 +21,7 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
       })
       const data = response.data || response
       if (data.success) {
+        setActionMessage(`✓ ${item.name} used on ${ally.name}!`)
         setActionResult({
           message: (
             <div style={{ whiteSpace: 'pre-wrap', textAlign: 'left', fontSize: '14px', fontFamily: 'monospace' }}>

--- a/frontend/src/components/ItemDetailDialog.jsx
+++ b/frontend/src/components/ItemDetailDialog.jsx
@@ -6,6 +6,43 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
   const [actionMessage, setActionMessage] = useState('')
   const [showDropConfirm, setShowDropConfirm] = useState(false)
   const [actionResult, setActionResult] = useState(null)
+  const [showAllyPicker, setShowAllyPicker] = useState(false)
+
+  const partyMembers = player?.party_members || []
+  const hasPartyMembers = partyMembers.length > 0
+
+  const handleUseOnAlly = async (ally) => {
+    setShowAllyPicker(false)
+    setIsLoading(true)
+    try {
+      const response = await apiClient.post('/inventory/use', {
+        item_id: item.id,
+        target_id: ally.id,
+      })
+      const data = response.data || response
+      if (data.success) {
+        setActionResult({
+          message: (
+            <div style={{ whiteSpace: 'pre-wrap', textAlign: 'left', fontSize: '14px', fontFamily: 'monospace' }}>
+              <strong>{player?.name || 'Player'}</strong> used <span style={{ color: '#ffff00' }}>{item.name}</span> on <strong>{ally.name}</strong>.{data.message ? `\n\n${data.message}` : ''}
+            </div>
+          )
+        })
+        if (onItemRemoved) onItemRemoved(item.id)
+        if (onRefetch) onRefetch()
+      } else {
+        setActionMessage('✗ ' + (data.error || 'Cannot use this item'))
+      }
+    } catch (err) {
+      if (err.response?.data?.error) {
+        setActionMessage(err.response.data.error)
+      } else {
+        setActionMessage('✗ Error: ' + err.message)
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
   const handleEquip = async () => {
     if (!item.can_equip) return
@@ -402,36 +439,71 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
         )}
 
         {item.can_use && !item.is_merchandise && (
-          <button
-            onClick={handleUse}
-            disabled={isLoading}
-            style={{
-              flex: 1,
-              padding: '10px',
-              backgroundColor: '#663300',
-              color: '#ffff00',
-              border: '1px solid #ffaa00',
-              borderRadius: '3px',
-              cursor: 'pointer',
-              fontSize: '15px',
-              fontFamily: 'monospace',
-              fontWeight: 'bold',
-              transition: 'all 0.2s',
-              opacity: isLoading ? 0.6 : 1,
-            }}
-            onMouseEnter={(e) => {
-              if (!isLoading) {
-                e.target.style.backgroundColor = '#994400'
-                e.target.style.boxShadow = '0 0 8px rgba(255, 170, 0, 0.6)'
-              }
-            }}
-            onMouseLeave={(e) => {
-              e.target.style.backgroundColor = '#663300'
-              e.target.style.boxShadow = 'none'
-            }}
-          >
-            💊 Use
-          </button>
+          <>
+            <button
+              onClick={handleUse}
+              disabled={isLoading}
+              style={{
+                flex: 1,
+                padding: '10px',
+                backgroundColor: '#663300',
+                color: '#ffff00',
+                border: '1px solid #ffaa00',
+                borderRadius: '3px',
+                cursor: 'pointer',
+                fontSize: '15px',
+                fontFamily: 'monospace',
+                fontWeight: 'bold',
+                transition: 'all 0.2s',
+                opacity: isLoading ? 0.6 : 1,
+              }}
+              onMouseEnter={(e) => {
+                if (!isLoading) {
+                  e.target.style.backgroundColor = '#994400'
+                  e.target.style.boxShadow = '0 0 8px rgba(255, 170, 0, 0.6)'
+                }
+              }}
+              onMouseLeave={(e) => {
+                e.target.style.backgroundColor = '#663300'
+                e.target.style.boxShadow = 'none'
+              }}
+            >
+              💊 Use
+            </button>
+            {hasPartyMembers && (
+              <button
+                onClick={() => setShowAllyPicker(true)}
+                disabled={isLoading}
+                title="Use this item on a party member"
+                style={{
+                  flex: 1,
+                  padding: '10px',
+                  backgroundColor: '#004466',
+                  color: '#00ccff',
+                  border: '1px solid #0099cc',
+                  borderRadius: '3px',
+                  cursor: 'pointer',
+                  fontSize: '15px',
+                  fontFamily: 'monospace',
+                  fontWeight: 'bold',
+                  transition: 'all 0.2s',
+                  opacity: isLoading ? 0.6 : 1,
+                }}
+                onMouseEnter={(e) => {
+                  if (!isLoading) {
+                    e.target.style.backgroundColor = '#006699'
+                    e.target.style.boxShadow = '0 0 8px rgba(0, 204, 255, 0.6)'
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  e.target.style.backgroundColor = '#004466'
+                  e.target.style.boxShadow = 'none'
+                }}
+              >
+                👥 Use on...
+              </button>
+            )}
+          </>
         )}
 
         {item.can_drop && !combatMode && (
@@ -662,6 +734,76 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
                 {isLoading ? '...' : '🗑️ Drop'}
               </button>
             </div>
+          </div>
+        </div>
+      )}
+      {showAllyPicker && (
+        <div style={{
+          position: 'fixed',
+          top: 0, left: 0, right: 0, bottom: 0,
+          backgroundColor: 'rgba(0,0,0,0.8)',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          zIndex: 1700,
+        }}>
+          <div style={{
+            backgroundColor: 'rgba(0, 20, 40, 0.98)',
+            border: '2px solid #0099cc',
+            borderRadius: '8px',
+            padding: '24px',
+            maxWidth: '400px',
+            width: '90%',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '16px',
+            boxShadow: '0 0 20px rgba(0, 153, 204, 0.3)',
+          }}>
+            <div style={{ fontSize: '16px', fontWeight: 'bold', color: '#00ccff', fontFamily: 'monospace', borderBottom: '1px solid #0099cc', paddingBottom: '10px' }}>
+              👥 USE ON — {item.name}
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              {partyMembers.map((member) => {
+                const hpPct = Math.min(100, ((member.hp || 0) / (member.max_hp || 100)) * 100)
+                const outOfRange = member.in_range === false
+                return (
+                  <button
+                    key={member.id}
+                    onClick={() => !outOfRange && handleUseOnAlly(member)}
+                    disabled={outOfRange}
+                    title={outOfRange ? 'Out of range — use Advance to close distance first' : `Use ${item.name} on ${member.name}`}
+                    style={{
+                      padding: '12px',
+                      backgroundColor: outOfRange ? 'rgba(40,40,40,0.6)' : 'rgba(0,30,50,0.8)',
+                      border: `1px solid ${outOfRange ? '#444' : '#0099cc'}`,
+                      borderRadius: '6px',
+                      cursor: outOfRange ? 'not-allowed' : 'pointer',
+                      textAlign: 'left',
+                      opacity: outOfRange ? 0.5 : 1,
+                      transition: 'all 0.15s',
+                    }}
+                  >
+                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '6px' }}>
+                      <span style={{ color: outOfRange ? '#888' : '#00ccff', fontFamily: 'monospace', fontWeight: 'bold', fontSize: '14px' }}>{member.name}</span>
+                      {outOfRange && <span style={{ color: '#ff6666', fontSize: '11px', fontFamily: 'monospace' }}>OUT OF RANGE</span>}
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                      <span style={{ fontSize: '10px', color: '#ff6666', fontFamily: 'monospace', minWidth: '28px' }}>HP</span>
+                      <div style={{ flex: 1, height: '4px', backgroundColor: 'rgba(255,0,0,0.2)', borderRadius: '2px' }}>
+                        <div style={{ width: `${hpPct}%`, height: '100%', backgroundColor: hpPct > 50 ? '#44ff88' : hpPct > 25 ? '#ffaa00' : '#ff4444', borderRadius: '2px' }} />
+                      </div>
+                      <span style={{ fontSize: '10px', color: '#aaa', fontFamily: 'monospace' }}>{member.hp}/{member.max_hp}</span>
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+            <button
+              onClick={() => setShowAllyPicker(false)}
+              style={{ padding: '8px 24px', backgroundColor: 'transparent', color: '#888', border: '1px solid #444', borderRadius: '4px', cursor: 'pointer', fontFamily: 'monospace', fontSize: '13px', alignSelf: 'center' }}
+            >
+              Cancel
+            </button>
           </div>
         </div>
       )}

--- a/frontend/src/components/PartyPanel.jsx
+++ b/frontend/src/components/PartyPanel.jsx
@@ -1,13 +1,52 @@
+import { useState } from 'react'
 import BaseDialog from './BaseDialog'
-import { colors, spacing } from '../styles/theme'
+import { colors } from '../styles/theme'
+import apiClient from '../api/client'
 
 /**
- * PartyPanel - View current party members and their vital stats
+ * PartyPanel - View current party members and their vital stats.
+ * Allows using consumable items on individual party members out of combat.
  */
-export default function PartyPanel({ player, onClose }) {
+export default function PartyPanel({ player, onClose, onRefetch }) {
   if (!player) return null
 
   const partyMembers = player.party_members || []
+  const [useItemTarget, setUseItemTarget] = useState(null) // member being targeted
+  const [actionResult, setActionResult] = useState(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Gather consumables from player inventory (serialized shape: {id, name, can_use, ...})
+  const consumables = (player.inventory || []).filter(
+    (it) => it.can_use && !it.is_merchandise
+  )
+
+  const handleUseItem = async (item, member) => {
+    setIsLoading(true)
+    try {
+      const response = await apiClient.post('/inventory/use', {
+        item_id: item.id,
+        target_id: member.id,
+      })
+      const data = response.data || response
+      if (data.success) {
+        setActionResult({
+          memberName: member.name,
+          itemName: item.name,
+          message: data.message || '',
+        })
+        setUseItemTarget(null)
+        if (onRefetch) onRefetch()
+      } else {
+        setActionResult({ error: data.error || 'Failed to use item' })
+        setUseItemTarget(null)
+      }
+    } catch (err) {
+      setActionResult({ error: err.response?.data?.error || err.message })
+      setUseItemTarget(null)
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
   return (
     <BaseDialog
@@ -101,9 +140,44 @@ export default function PartyPanel({ player, onClose }) {
                     padding: '8px',
                     backgroundColor: 'rgba(0,0,0,0.2)',
                     borderRadius: '4px',
+                    marginBottom: '8px',
                   }}>
                     "{member.description}"
                   </div>
+                )}
+
+                {/* USE ITEM button */}
+                {consumables.length > 0 && (
+                  <button
+                    onClick={() => setUseItemTarget(member)}
+                    disabled={isLoading}
+                    style={{
+                      width: '100%',
+                      padding: '7px',
+                      backgroundColor: '#004466',
+                      color: '#00ccff',
+                      border: '1px solid #0099cc',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      fontSize: '12px',
+                      fontFamily: 'monospace',
+                      fontWeight: 'bold',
+                      transition: 'all 0.2s',
+                      opacity: isLoading ? 0.6 : 1,
+                    }}
+                    onMouseEnter={(e) => {
+                      if (!isLoading) {
+                        e.target.style.backgroundColor = '#006699'
+                        e.target.style.boxShadow = '0 0 8px rgba(0,204,255,0.5)'
+                      }
+                    }}
+                    onMouseLeave={(e) => {
+                      e.target.style.backgroundColor = '#004466'
+                      e.target.style.boxShadow = 'none'
+                    }}
+                  >
+                    💊 USE ITEM
+                  </button>
                 )}
               </div>
             ))}
@@ -138,7 +212,120 @@ export default function PartyPanel({ player, onClose }) {
           </button>
         </div>
       </div>
+
+      {/* Consumable picker overlay */}
+      {useItemTarget && (
+        <div style={{
+          position: 'fixed',
+          top: 0, left: 0, right: 0, bottom: 0,
+          backgroundColor: 'rgba(0,0,0,0.8)',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          zIndex: 2500,
+        }}>
+          <div style={{
+            backgroundColor: 'rgba(0, 20, 40, 0.98)',
+            border: '2px solid #0099cc',
+            borderRadius: '8px',
+            padding: '24px',
+            maxWidth: '380px',
+            width: '90%',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '12px',
+            boxShadow: '0 0 20px rgba(0,153,204,0.3)',
+          }}>
+            <div style={{ fontSize: '15px', fontWeight: 'bold', color: '#00ccff', fontFamily: 'monospace', borderBottom: '1px solid #0099cc', paddingBottom: '10px' }}>
+              💊 USE ON — {useItemTarget.name}
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', maxHeight: '50vh', overflowY: 'auto' }}>
+              {consumables.map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => handleUseItem(item, useItemTarget)}
+                  disabled={isLoading}
+                  style={{
+                    padding: '10px 14px',
+                    backgroundColor: 'rgba(10,30,50,0.9)',
+                    border: '1px solid #0099cc',
+                    borderRadius: '5px',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    color: '#ffcc00',
+                    fontFamily: 'monospace',
+                    fontSize: '13px',
+                    fontWeight: 'bold',
+                    transition: 'all 0.15s',
+                    opacity: isLoading ? 0.6 : 1,
+                  }}
+                  onMouseEnter={(e) => {
+                    if (!isLoading) {
+                      e.target.style.backgroundColor = 'rgba(0,60,100,0.9)'
+                      e.target.style.borderColor = '#00ccff'
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    e.target.style.backgroundColor = 'rgba(10,30,50,0.9)'
+                    e.target.style.borderColor = '#0099cc'
+                  }}
+                >
+                  {item.name}
+                  {item.quantity > 1 && <span style={{ color: '#aaa', fontSize: '11px', marginLeft: '8px' }}>×{item.quantity}</span>}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={() => setUseItemTarget(null)}
+              style={{ padding: '7px 20px', backgroundColor: 'transparent', color: '#888', border: '1px solid #444', borderRadius: '4px', cursor: 'pointer', fontFamily: 'monospace', fontSize: '12px', alignSelf: 'center' }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Action result overlay */}
+      {actionResult && (
+        <div style={{
+          position: 'fixed',
+          top: 0, left: 0, right: 0, bottom: 0,
+          backgroundColor: 'rgba(0,0,0,0.8)',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          zIndex: 2500,
+        }}>
+          <div style={{
+            backgroundColor: 'rgba(10,20,10,0.98)',
+            border: `2px solid ${actionResult.error ? '#ff4444' : '#00ff88'}`,
+            borderRadius: '8px',
+            padding: '24px',
+            maxWidth: '380px',
+            width: '90%',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '16px',
+            boxShadow: `0 0 20px ${actionResult.error ? 'rgba(255,68,68,0.3)' : 'rgba(0,255,136,0.3)'}`,
+          }}>
+            <div style={{ color: actionResult.error ? '#ff8888' : '#00ff88', fontFamily: 'monospace', fontSize: '14px', textAlign: 'center', lineHeight: '1.5' }}>
+              {actionResult.error
+                ? `✗ ${actionResult.error}`
+                : <>
+                    <strong>{player?.name || 'Player'}</strong> used <span style={{ color: '#ffff00' }}>{actionResult.itemName}</span> on <strong>{actionResult.memberName}</strong>.
+                    {actionResult.message && <div style={{ marginTop: '8px', whiteSpace: 'pre-wrap', textAlign: 'left' }}>{actionResult.message}</div>}
+                  </>
+              }
+            </div>
+            <button
+              onClick={() => setActionResult(null)}
+              style={{ padding: '8px 28px', backgroundColor: '#004400', color: '#00ff00', border: '1px solid #00ff00', borderRadius: '3px', cursor: 'pointer', fontSize: '13px', fontFamily: 'monospace', fontWeight: 'bold', alignSelf: 'center', textTransform: 'uppercase' }}
+            >
+              Ok
+            </button>
+          </div>
+        </div>
+      )}
     </BaseDialog>
   )
 }
-

--- a/frontend/src/components/PartyPanel.jsx
+++ b/frontend/src/components/PartyPanel.jsx
@@ -294,7 +294,7 @@ export default function PartyPanel({ player, onClose, onRefetch }) {
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
-          zIndex: 2500,
+          zIndex: 2501,
         }}>
           <div style={{
             backgroundColor: 'rgba(10,20,10,0.98)',

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -30,6 +30,17 @@ _ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\_-]|\[[0-?]*[ -/]*[@-~])")
 
 logger = logging.getLogger(__name__)
 
+_ALLY_HEAL_THRESHOLD = 0.5  # NPC uses item on ally below this HP fraction
+_ITEM_USE_RANGE = 5  # ft — max range for in-combat item targeting
+
+
+def _strip_combatant_prefix(target_id: str) -> str:
+    """Strip 'enemy_' or 'ally_' prefix and return the raw Python id string."""
+    for prefix in ("enemy_", "ally_"):
+        if target_id.startswith(prefix):
+            return target_id[len(prefix):]
+    return target_id
+
 
 class CombatOutputCapture:
     """Captures print statements and stores them in a combat log."""
@@ -540,7 +551,7 @@ class ApiCombatAdapter:
 
             if target_id:
                 # Try to find the specified target
-                target_obj_id = target_id.replace("enemy_", "")
+                target_obj_id = _strip_combatant_prefix(target_id)
                 all_combatants = (
                     self.player.combat_list + self.player.combat_list_allies
                 )
@@ -560,7 +571,7 @@ class ApiCombatAdapter:
                     if not isinstance(single_target_id, str):
                         return {"error": "Invalid target"}
 
-                    target_obj_id = single_target_id.replace("enemy_", "")
+                    target_obj_id = _strip_combatant_prefix(single_target_id)
                     all_combatants = (
                         self.player.combat_list + self.player.combat_list_allies
                     )
@@ -647,7 +658,7 @@ class ApiCombatAdapter:
                 if not isinstance(single_target_id, str):
                     return {"error": "Invalid target"}
 
-                target_obj_id = single_target_id.replace("enemy_", "")
+                target_obj_id = _strip_combatant_prefix(single_target_id)
                 target = None
                 all_combatants = (
                     self.player.combat_list + self.player.combat_list_allies
@@ -721,8 +732,7 @@ class ApiCombatAdapter:
         # Find target in available options
         target = None
         # Look up target by ID from player's combat list (enemies) or allies
-        # We need to parse the target_id (e.g. "enemy_123456")
-        target_obj_id = target_id.replace("enemy_", "")
+        target_obj_id = _strip_combatant_prefix(target_id)
 
         all_combatants = self.player.combat_list + self.player.combat_list_allies
         for combatant in all_combatants:
@@ -1330,6 +1340,10 @@ class ApiCombatAdapter:
             npc.combat_delay -= 1
         else:
             if npc.current_move is None:
+                # Ally-healing check: use a consumable on a nearby friendly below threshold
+                if self._npc_try_heal_ally(npc):
+                    return
+
                 # Select target
                 if not npc.friend:
                     npc.target = random.choice(self.player.combat_list_allies)
@@ -1389,6 +1403,83 @@ class ApiCombatAdapter:
 
         for move in moves_to_advance:
             move.advance(npc)
+
+    def _npc_try_heal_ally(self, npc) -> bool:
+        """Check whether this NPC should spend its turn healing a nearby ally.
+
+        Applies to any NPC that has consumable items in its inventory.  Returns
+        True and executes the heal (consuming the item) if a valid target was
+        found; returns False so normal move-selection proceeds otherwise.
+        """
+        import items as items_module
+
+        inventory = getattr(npc, "inventory", [])
+        consumables = [
+            it for it in inventory
+            if isinstance(it, items_module.Consumable) and hasattr(it, "use")
+        ]
+        if not consumables:
+            return False
+
+        # Build list of friendlies (allies share the same faction)
+        if npc.friend:
+            # Friendly NPC: allies are player + other friends; enemies are combat_list
+            friendlies = list(getattr(self.player, "combat_list_allies", []))
+        else:
+            # Enemy NPC: allies are other enemies
+            friendlies = list(getattr(self.player, "combat_list", []))
+
+        # Find a living friendly below the heal threshold that is within range
+        heal_target = None
+        for friendly in friendlies:
+            if friendly is npc or not friendly.is_alive():
+                continue
+            maxhp = getattr(friendly, "maxhp", 1) or 1
+            hp_frac = getattr(friendly, "hp", maxhp) / maxhp
+            if hp_frac >= _ALLY_HEAL_THRESHOLD:
+                continue
+            dist = npc.combat_proximity.get(friendly, 9999)
+            if dist > _ITEM_USE_RANGE:
+                continue
+            # Prefer the most-injured friendly
+            if heal_target is None:
+                heal_target = friendly
+            elif (getattr(friendly, "hp", 0) / maxhp) < (
+                getattr(heal_target, "hp", 0) / (getattr(heal_target, "maxhp", 1) or 1)
+            ):
+                heal_target = friendly
+
+        if heal_target is None:
+            return False
+
+        item = consumables[0]
+        item_name = getattr(item, "name", "item")
+        with self._capture_output():
+            item.use(heal_target)
+
+        # Remove consumed item from NPC inventory
+        if item in inventory:
+            inventory.remove(item)
+
+        target_label = "player" if heal_target == self.player else f"ally_{id(heal_target)}"
+        self._add_log_entry(
+            self.player.combat_beat,
+            f"{npc.name} uses {item_name} on {heal_target.name}!",
+            "combat",
+        )
+        self._add_log_entry(
+            self.player.combat_beat,
+            f"{npc.name} uses {item_name}",
+            "animation",
+            beat_index=self.current_beat_state_index,
+            animation_data={
+                "type": "pulse",
+                "source_id": f"{'ally' if npc.friend else 'enemy'}_{id(npc)}",
+                "target_id": target_label,
+                "move_name": f"Use {item_name}",
+            },
+        )
+        return True
 
     def _update_heat(self):
         """Update the heat multiplier."""
@@ -1773,6 +1864,7 @@ class ApiCombatAdapter:
                     "id": f"enemy_{id(enemy)}",
                     "name": enemy.name,
                     "distance": distance,
+                    "is_ally": False,
                     "health": {
                         "current": getattr(enemy, "hp", getattr(enemy, "health", 0)),
                         "max": getattr(
@@ -1786,6 +1878,26 @@ class ApiCombatAdapter:
                     target_data["hit_chance"] = move.calculate_hit_chance(enemy)
 
                 targets.append(target_data)
+
+        # Include allies when the move explicitly accepts them (e.g. Advance for healing setup)
+        if getattr(move, "accepts_ally_target", False):
+            for ally in self.player.combat_list_allies:
+                if ally == self.player or not ally.is_alive():
+                    continue
+                distance = self.player.combat_proximity.get(ally, 0)
+                if range_min <= distance <= range_max:
+                    targets.append(
+                        {
+                            "id": f"ally_{id(ally)}",
+                            "name": ally.name,
+                            "distance": distance,
+                            "is_ally": True,
+                            "health": {
+                                "current": getattr(ally, "hp", 0),
+                                "max": getattr(ally, "maxhp", 100),
+                            },
+                        }
+                    )
 
         # Sort by distance
         targets.sort(key=lambda t: t["distance"])

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -20,6 +20,7 @@ from src.api.serializers.combat import (
     CombatStateSerializer,
     CombatantSerializer,
 )
+from src.api.constants import ITEM_USE_RANGE, ALLY_HEAL_THRESHOLD
 from ai.combat_strategist import CombatStrategist
 
 if TYPE_CHECKING:
@@ -30,15 +31,12 @@ _ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\_-]|\[[0-?]*[ -/]*[@-~])")
 
 logger = logging.getLogger(__name__)
 
-_ALLY_HEAL_THRESHOLD = 0.5  # NPC uses item on ally below this HP fraction
-_ITEM_USE_RANGE = 5  # ft — max range for in-combat item targeting
-
 
 def _strip_combatant_prefix(target_id: str) -> str:
     """Strip 'enemy_' or 'ally_' prefix and return the raw Python id string."""
     for prefix in ("enemy_", "ally_"):
         if target_id.startswith(prefix):
-            return target_id[len(prefix):]
+            return target_id[len(prefix) :]
     return target_id
 
 
@@ -1415,7 +1413,8 @@ class ApiCombatAdapter:
 
         inventory = getattr(npc, "inventory", [])
         consumables = [
-            it for it in inventory
+            it
+            for it in inventory
             if isinstance(it, items_module.Consumable) and hasattr(it, "use")
         ]
         if not consumables:
@@ -1436,10 +1435,10 @@ class ApiCombatAdapter:
                 continue
             maxhp = getattr(friendly, "maxhp", 1) or 1
             hp_frac = getattr(friendly, "hp", maxhp) / maxhp
-            if hp_frac >= _ALLY_HEAL_THRESHOLD:
+            if hp_frac >= ALLY_HEAL_THRESHOLD:
                 continue
             dist = npc.combat_proximity.get(friendly, 9999)
-            if dist > _ITEM_USE_RANGE:
+            if dist > ITEM_USE_RANGE:
                 continue
             # Prefer the most-injured friendly
             if heal_target is None:
@@ -1454,14 +1453,22 @@ class ApiCombatAdapter:
 
         item = consumables[0]
         item_name = getattr(item, "name", "item")
-        with self._capture_output():
-            item.use(heal_target)
+        try:
+            with self._capture_output():
+                item.use(heal_target)
+        except Exception:
+            logger.exception(
+                "%s failed to use %s on %s", npc.name, item_name, heal_target.name
+            )
+            return False
 
-        # Remove consumed item from NPC inventory
+        # Only remove the item after a successful use
         if item in inventory:
             inventory.remove(item)
 
-        target_label = "player" if heal_target == self.player else f"ally_{id(heal_target)}"
+        target_label = (
+            "player" if heal_target == self.player else f"ally_{id(heal_target)}"
+        )
         self._add_log_entry(
             self.player.combat_beat,
             f"{npc.name} uses {item_name} on {heal_target.name}!",

--- a/src/api/constants.py
+++ b/src/api/constants.py
@@ -1,0 +1,7 @@
+"""Shared constants for the API layer."""
+
+# Maximum distance (ft) for in-combat item targeting (player→ally or player→enemy)
+ITEM_USE_RANGE = 5
+
+# HP fraction below which an NPC will spend its turn healing a nearby friendly
+ALLY_HEAL_THRESHOLD = 0.5

--- a/src/api/routes/inventory.py
+++ b/src/api/routes/inventory.py
@@ -8,6 +8,8 @@ Provides endpoints for:
 """
 
 from flask import Blueprint, current_app, jsonify, request
+
+_ITEM_USE_RANGE = 5
 import contextlib
 import io
 import re
@@ -89,6 +91,23 @@ def get_item_and_index(player, item_id=None, item_index=None):
         return None, None
 
     return None, None
+
+
+def _resolve_ally_target(player, target_id: str):
+    """Resolve a target_id string to an NPC ally object.
+
+    Accepts IDs in the form "ally_<python-id>" as produced by the party_members
+    serializer and the combat serializer.  Returns None if not found.
+    """
+    for prefix in ("ally_", "enemy_"):
+        if target_id.startswith(prefix):
+            target_id = target_id[len(prefix):]
+            break
+    raw_id = target_id
+    for ally in getattr(player, "combat_list_allies", [])[1:]:
+        if str(id(ally)) == raw_id:
+            return ally
+    return None
 
 
 @inventory_bp.route("/inventory", methods=["GET"])
@@ -402,6 +421,9 @@ def use_item():
     JSON body:
         item_id: Unique ID of the item (preferred)
         item_index: Item index in inventory (fallback)
+        target_id: Optional ally ID (e.g. "ally_<python-id>"). When provided
+                   the item's effect is applied to that ally instead of self.
+                   In combat the target must be within 5 ft.
 
     Returns:
         JSON with result of item use
@@ -416,6 +438,7 @@ def use_item():
         # Get item ID or index from request
         item_id = data.get("item_id")
         item_index = data.get("item_index")
+        target_id = data.get("target_id")
 
         if not item_id and item_index is None:
             return (
@@ -455,6 +478,30 @@ def use_item():
                 400,
             )
 
+        # Resolve optional ally target
+        item_target = player
+        if target_id:
+            resolved = _resolve_ally_target(player, target_id)
+            if resolved is None:
+                return (
+                    jsonify({"success": False, "error": "Target not found"}),
+                    400,
+                )
+            # In combat, enforce 5 ft range
+            if getattr(player, "in_combat", False):
+                dist = player.combat_proximity.get(resolved, 9999)
+                if dist > _ITEM_USE_RANGE:
+                    return (
+                        jsonify(
+                            {
+                                "success": False,
+                                "error": f"{resolved.name} is too far away ({int(dist)} ft). Use Advance to close the distance first.",
+                            }
+                        ),
+                        400,
+                    )
+            item_target = resolved
+
         # Capture output from item use
         f = io.StringIO()
 
@@ -472,7 +519,7 @@ def use_item():
             "time.sleep", return_value=None
         ):
             # Call the item's use method
-            item.use(player)
+            item.use(item_target)
 
         output = f.getvalue()
         # Clean up output (remove ANSI codes)
@@ -513,6 +560,7 @@ def use_item():
             "success": True,
             "message": clean_output,
             "inventory": inventory_data,
+            "target_name": getattr(item_target, "name", None) if item_target is not player else None,
         }
 
         # If in combat, also return updated combat state

--- a/src/api/routes/inventory.py
+++ b/src/api/routes/inventory.py
@@ -7,13 +7,14 @@ Provides endpoints for:
 - Currency/stat queries
 """
 
-from flask import Blueprint, current_app, jsonify, request
-
-_ITEM_USE_RANGE = 5
 import contextlib
 import io
 import re
 from unittest.mock import patch
+
+from flask import Blueprint, current_app, jsonify, request
+
+from src.api.constants import ITEM_USE_RANGE
 
 from src.api.services.validators import (
     validate_equipment_slot,
@@ -101,9 +102,10 @@ def _resolve_ally_target(player, target_id: str):
     """
     for prefix in ("ally_", "enemy_"):
         if target_id.startswith(prefix):
-            target_id = target_id[len(prefix):]
+            target_id = target_id[len(prefix) :]
             break
     raw_id = target_id
+    # Skip index 0 (the player) — allies start at index 1
     for ally in getattr(player, "combat_list_allies", [])[1:]:
         if str(id(ally)) == raw_id:
             return ally
@@ -490,7 +492,7 @@ def use_item():
             # In combat, enforce 5 ft range
             if getattr(player, "in_combat", False):
                 dist = player.combat_proximity.get(resolved, 9999)
-                if dist > _ITEM_USE_RANGE:
+                if dist > ITEM_USE_RANGE:
                     return (
                         jsonify(
                             {
@@ -560,7 +562,11 @@ def use_item():
             "success": True,
             "message": clean_output,
             "inventory": inventory_data,
-            "target_name": getattr(item_target, "name", None) if item_target is not player else None,
+            "target_name": (
+                getattr(item_target, "name", None)
+                if item_target is not player
+                else None
+            ),
         }
 
         # If in combat, also return updated combat state

--- a/src/api/serializers/combat.py
+++ b/src/api/serializers/combat.py
@@ -10,6 +10,8 @@ This module provides serialization for:
 
 from typing import Dict, List, Any, Optional, TYPE_CHECKING
 
+_ITEM_USE_RANGE = 5
+
 if TYPE_CHECKING:
     from player import Player
     from npc import NPC
@@ -198,9 +200,15 @@ class CombatantSerializer:
             Dict with combatant state
         """
         is_player = combatant.__class__.__name__ == "Player"
+        is_ally = not is_player and getattr(combatant, "friend", False)
+        # Derive in_range from distance to the reference (player). Allies within 5 ft
+        # are targetable with healing items; enemies within range are attackable.
+        distance_to_ref = CombatantSerializer._get_distance(combatant, reference)
+        in_range = distance_to_ref <= _ITEM_USE_RANGE if reference is not None else True
 
         return {
-            "id": "player" if is_player else f"enemy_{id(combatant)}",
+            "id": "player" if is_player else (f"ally_{id(combatant)}" if is_ally else f"enemy_{id(combatant)}"),
+            "in_range": in_range,
             "name": getattr(combatant, "name", "Unknown"),
             "battle_symbol": getattr(combatant, "battle_symbol", None),
             "type": "player" if is_player else "npc",
@@ -228,7 +236,7 @@ class CombatantSerializer:
             "status_effects": CombatantSerializer._serialize_status_effects(combatant),
             "passives": CombatantSerializer._serialize_passives(combatant),
             "equipment": CombatantSerializer._serialize_combat_equipment(combatant),
-            "distance": CombatantSerializer._get_distance(combatant, reference),
+            "distance": distance_to_ref,
             "position": CombatantSerializer._serialize_position(combatant),
             "current_move": CombatantSerializer._serialize_active_move(combatant),
             "move_in_process": CombatantSerializer._serialize_active_move(

--- a/src/api/serializers/combat.py
+++ b/src/api/serializers/combat.py
@@ -10,7 +10,7 @@ This module provides serialization for:
 
 from typing import Dict, List, Any, Optional, TYPE_CHECKING
 
-_ITEM_USE_RANGE = 5
+from src.api.constants import ITEM_USE_RANGE
 
 if TYPE_CHECKING:
     from player import Player
@@ -204,10 +204,14 @@ class CombatantSerializer:
         # Derive in_range from distance to the reference (player). Allies within 5 ft
         # are targetable with healing items; enemies within range are attackable.
         distance_to_ref = CombatantSerializer._get_distance(combatant, reference)
-        in_range = distance_to_ref <= _ITEM_USE_RANGE if reference is not None else True
+        in_range = distance_to_ref <= ITEM_USE_RANGE if reference is not None else True
 
         return {
-            "id": "player" if is_player else (f"ally_{id(combatant)}" if is_ally else f"enemy_{id(combatant)}"),
+            "id": (
+                "player"
+                if is_player
+                else (f"ally_{id(combatant)}" if is_ally else f"enemy_{id(combatant)}")
+            ),
             "in_range": in_range,
             "name": getattr(combatant, "name", "Unknown"),
             "battle_symbol": getattr(combatant, "battle_symbol", None),

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -6,6 +6,7 @@ import re
 from typing import TYPE_CHECKING, Dict, Any, Optional, List
 from unittest.mock import patch
 
+from src.api.constants import ITEM_USE_RANGE
 from src.interface import get_gold
 
 if TYPE_CHECKING:
@@ -2350,9 +2351,9 @@ class GameService:
                     "max_hp": getattr(a, "maxhp", 0),
                     "level": getattr(a, "level", 1),
                     "description": getattr(a, "description", "").strip(),
-                    # in_range: True outside combat (no restriction) or within 5 ft in combat
                     "in_range": (
-                        getattr(player, "combat_proximity", {}).get(a, 0) <= 5
+                        getattr(player, "combat_proximity", {}).get(a, 0)
+                        <= ITEM_USE_RANGE
                         if getattr(player, "in_combat", False)
                         else True
                     ),

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2344,11 +2344,18 @@ class GameService:
             "state": "normal",  # TODO: Get actual status effects
             "party_members": [
                 {
+                    "id": f"ally_{id(a)}",
                     "name": getattr(a, "name", "Unknown"),
                     "hp": getattr(a, "hp", 0),
                     "max_hp": getattr(a, "maxhp", 0),
                     "level": getattr(a, "level", 1),
                     "description": getattr(a, "description", "").strip(),
+                    # in_range: True outside combat (no restriction) or within 5 ft in combat
+                    "in_range": (
+                        getattr(player, "combat_proximity", {}).get(a, 0) <= 5
+                        if getattr(player, "in_combat", False)
+                        else True
+                    ),
                 }
                 for a in getattr(player, "combat_list_allies", [])[1:]
             ],

--- a/src/items.py
+++ b/src/items.py
@@ -3598,7 +3598,9 @@ class ConclaveSignalStone(Key):
         )
         self.value = 0
         self.weight = 0.1
-        self.discovery_message = "a flat stone disc bearing a Conclave authorization sigil!"
+        self.discovery_message = (
+            "a flat stone disc bearing a Conclave authorization sigil!"
+        )
         self.announce = "A flat stone authorization disc rests here."
         self.interactions = ["examine", "drop"]
 

--- a/src/moves/_movement.py
+++ b/src/moves/_movement.py
@@ -120,7 +120,7 @@ class Parry(Move):
 
 class Advance(Move):
     def __init__(self, user):
-        description = "Get closer to a target enemy."
+        description = "Get closer to a target (enemy or ally)."
         prep = 0
         execute = 4
         recoil = 0
@@ -143,13 +143,19 @@ class Advance(Move):
             category="Maneuver",
         )
         self.fatigue_per_beat = 1
+        # Allows allies to be valid targets (e.g. to close distance for healing)
+        self.accepts_ally_target = True
         self.evaluate()
 
     def refresh_announcements(self, user):
         self.stage_announce = [f"{user.name} begins advancing...", "", "", ""]
 
     def viable(self):
-        """Advance is only viable if there are enemies beyond striking distance OR current target is at a good distance"""
+        """Advance is viable when the target is beyond adjacent range.
+
+        Accepts both enemy and ally targets so the player can close distance
+        to an ally before using a healing item on them.
+        """
         if not hasattr(self.user, "combat_proximity"):
             return False
 
@@ -159,8 +165,9 @@ class Advance(Move):
                 return True
             return False
 
-        for enemy, distance in self.user.combat_proximity.items():
-            if enemy.is_alive and distance > 1:
+        # Check for any combatant (enemy or ally) farther than adjacent
+        for combatant, distance in self.user.combat_proximity.items():
+            if combatant.is_alive and distance > 1:
                 return True
         return False
 

--- a/src/moves/_movement.py
+++ b/src/moves/_movement.py
@@ -153,8 +153,8 @@ class Advance(Move):
     def viable(self):
         """Advance is viable when the target is beyond adjacent range.
 
-        Accepts both enemy and ally targets so the player can close distance
-        to an ally before using a healing item on them.
+        Targeting an ally closes distance for healing (no damage is dealt to
+        friendlies); targeting an enemy closes distance to attack.
         """
         if not hasattr(self.user, "combat_proximity"):
             return False

--- a/src/player/_inventory.py
+++ b/src/player/_inventory.py
@@ -338,8 +338,14 @@ class PlayerInventoryMixin:
             # Out of range -> re-loop
             continue
 
-    def use_item(self, phrase=""):
-        """Use a consumable or special item, either by phrase match or interactive menu."""
+    def use_item(self, phrase="", target=None):
+        """Use a consumable or special item, either by phrase match or interactive menu.
+
+        Args:
+            phrase: Optional phrase to match item name (skips menu).
+            target: Optional combatant to receive the item's effect. Defaults to self.
+        """
+        _target = target if target is not None else self
         if phrase == "":
             num_consumables = 0
             num_special = 0
@@ -439,7 +445,7 @@ class PlayerInventoryMixin:
                                 break
                             if "use" in item.interactions and hasattr(item, "use"):
                                 print("{} used {}!".format(self.name, item.name))
-                                item.use(self)
+                                item.use(_target)
                             elif "prefer" in item.interactions and hasattr(
                                 item, "prefer"
                             ):
@@ -491,7 +497,7 @@ class PlayerInventoryMixin:
                             "YES",
                         ]
                         if confirm in acceptable_confirm_phrases:
-                            item.use(self)
+                            item.use(_target)
                             break
 
     def stack_inv_items(self):

--- a/tests/combat/test_ally_healing.py
+++ b/tests/combat/test_ally_healing.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for ally-healing targeting feature.
+
+Covers:
+- _resolve_ally_target: valid/invalid IDs, prefix stripping
+- _npc_try_heal_ally: finds most-injured ally, respects range, consumes item, error safety
+"""
+
+import contextlib
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.api.routes.inventory import _resolve_ally_target
+from src.api.constants import ITEM_USE_RANGE, ALLY_HEAL_THRESHOLD
+
+# ---------------------------------------------------------------------------
+# _resolve_ally_target
+# ---------------------------------------------------------------------------
+
+
+def _make_player_with_allies(*allies):
+    player = MagicMock()
+    player.combat_list_allies = [player] + list(allies)  # index 0 = player
+    return player
+
+
+def test_resolve_ally_target_valid():
+    ally = MagicMock()
+    player = _make_player_with_allies(ally)
+    assert _resolve_ally_target(player, f"ally_{id(ally)}") is ally
+
+
+def test_resolve_ally_target_enemy_prefix_stripped():
+    ally = MagicMock()
+    player = _make_player_with_allies(ally)
+    assert _resolve_ally_target(player, f"enemy_{id(ally)}") is ally
+
+
+def test_resolve_ally_target_unknown_id_returns_none():
+    ally = MagicMock()
+    player = _make_player_with_allies(ally)
+    assert _resolve_ally_target(player, "ally_99999999") is None
+
+
+def test_resolve_ally_target_no_allies_returns_none():
+    player = MagicMock()
+    player.combat_list_allies = [player]
+    assert _resolve_ally_target(player, "ally_1") is None
+
+
+def test_resolve_ally_target_skips_player_at_index_zero():
+    """The player at index 0 must never be returned."""
+    player = MagicMock()
+    player.combat_list_allies = [player]
+    assert _resolve_ally_target(player, f"ally_{id(player)}") is None
+
+
+# ---------------------------------------------------------------------------
+# _npc_try_heal_ally helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter():
+    from src.api.combat_adapter import ApiCombatAdapter
+
+    adapter = ApiCombatAdapter.__new__(ApiCombatAdapter)
+    player = MagicMock()
+    player.name = "Jean"
+    player.hp = 100
+    player.maxhp = 100
+    player.is_alive.return_value = True
+    player.combat_beat = 1
+    adapter.player = player
+    adapter.current_beat_state_index = 0
+    adapter._add_log_entry = MagicMock()
+
+    @contextlib.contextmanager
+    def _noop_capture():
+        yield
+
+    adapter._capture_output = _noop_capture
+    return adapter
+
+
+def _make_npc(friend=True):
+    npc = MagicMock()
+    npc.name = "Gorran"
+    npc.friend = friend
+    npc.hp = 100
+    npc.maxhp = 100
+    npc.is_alive.return_value = True
+    npc.combat_proximity = {}
+    return npc
+
+
+def _make_ally(hp=20, maxhp=100):
+    ally = MagicMock()
+    ally.name = "AllyNPC"
+    ally.hp = hp
+    ally.maxhp = maxhp
+    ally.is_alive.return_value = True
+    return ally
+
+
+def _run_heal(adapter, npc):
+    with patch("items.Consumable", MagicMock) as mock_cls:
+        mock_cls.__instancecheck__ = lambda cls, obj: True
+        return adapter._npc_try_heal_ally(npc)
+
+
+# ---------------------------------------------------------------------------
+# _npc_try_heal_ally tests
+# ---------------------------------------------------------------------------
+
+
+def test_npc_try_heal_ally_heals_injured_friendly():
+    adapter = _make_adapter()
+    npc = _make_npc(friend=True)
+    ally = _make_ally(hp=20, maxhp=100)
+    npc.combat_proximity = {ally: 3}
+
+    item = MagicMock(name="Health Potion")
+    npc.inventory = [item]
+    adapter.player.combat_list_allies = [adapter.player, ally]
+
+    result = _run_heal(adapter, npc)
+
+    item.use.assert_called_once_with(ally)
+    assert result is True
+    assert item not in npc.inventory
+
+
+def test_npc_try_heal_ally_skips_out_of_range():
+    adapter = _make_adapter()
+    npc = _make_npc(friend=True)
+    ally = _make_ally(hp=10, maxhp=100)
+    npc.combat_proximity = {ally: ITEM_USE_RANGE + 1}
+
+    item = MagicMock(name="Health Potion")
+    npc.inventory = [item]
+    adapter.player.combat_list_allies = [adapter.player, ally]
+
+    result = _run_heal(adapter, npc)
+
+    item.use.assert_not_called()
+    assert result is False
+
+
+def test_npc_try_heal_ally_skips_healthy_ally():
+    adapter = _make_adapter()
+    npc = _make_npc(friend=True)
+    ally = _make_ally(hp=80, maxhp=100)  # 80% HP — above threshold
+    npc.combat_proximity = {ally: 2}
+
+    item = MagicMock(name="Health Potion")
+    npc.inventory = [item]
+    adapter.player.combat_list_allies = [adapter.player, ally]
+
+    result = _run_heal(adapter, npc)
+
+    item.use.assert_not_called()
+    assert result is False
+
+
+def test_npc_try_heal_ally_exception_does_not_consume_item():
+    """If item.use() raises, item must not be removed and False is returned."""
+    adapter = _make_adapter()
+    npc = _make_npc(friend=True)
+    ally = _make_ally(hp=10, maxhp=100)
+    npc.combat_proximity = {ally: 2}
+
+    item = MagicMock(name="Health Potion")
+    item.use.side_effect = RuntimeError("item exploded")
+    npc.inventory = [item]
+    adapter.player.combat_list_allies = [adapter.player, ally]
+
+    result = _run_heal(adapter, npc)
+
+    assert result is False
+    assert item in npc.inventory
+
+
+def test_npc_try_heal_ally_no_consumables():
+    adapter = _make_adapter()
+    npc = _make_npc(friend=True)
+    npc.inventory = []
+    adapter.player.combat_list_allies = [adapter.player]
+
+    result = _run_heal(adapter, npc)
+
+    assert result is False


### PR DESCRIPTION
## Summary
This PR adds the ability to use consumable items on party members both in and out of combat. Players can now target healing items and other consumables on allies through new UI pickers in both the ItemDetailDialog and PartyPanel components, and NPCs can intelligently use healing items on injured allies during combat.

## Key Changes

### Frontend
- **ItemDetailDialog**: Added "Use on..." button that appears when party members are available, opening an ally picker modal showing party members with HP bars and range indicators
- **PartyPanel**: Added "USE ITEM" button on each party member card that opens a consumable picker, allowing out-of-combat item usage on specific allies
- Both components now display action results with formatted messages showing who used what item on whom

### Backend - Combat System
- **combat_adapter.py**: 
  - Added `_npc_try_heal_ally()` method that enables NPCs to intelligently use consumable items on nearby injured allies below a 50% HP threshold
  - NPCs check for consumable items in their inventory and apply them to the most injured friendly within 5 ft range
  - Added `accepts_ally_target` flag to moves (e.g., Advance) to allow targeting allies for distance-closing before healing
  - Updated target serialization to include `is_ally` flag and `in_range` status based on 5 ft proximity

### Backend - Inventory & Routes
- **inventory.py**: 
  - Modified `/inventory/use` endpoint to accept optional `target_id` parameter for ally targeting
  - Added `_resolve_ally_target()` helper to parse ally IDs and validate targets
  - Enforces 5 ft range restriction in combat when targeting allies
  - Returns `target_name` in response when item is used on an ally
- **_inventory.py**: Updated `use_item()` method to accept optional `target` parameter

### Backend - Serialization
- **combat.py**: Updated `serialize_combatant()` to include `in_range` field indicating whether a combatant is within 5 ft (item use range)
- **game_service.py**: Enhanced party member serialization to include `id` field (ally_<python-id>) for targeting

### Mechanics
- Item use range limited to 5 ft in combat; out-of-combat usage has no range restriction
- NPC healing AI uses items on allies below 50% HP, preferring the most injured target
- Advance move now accepts ally targets to allow players to close distance before healing

https://claude.ai/code/session_01CZg9prc2VSBuX42pWe4nEb