### PR TITLE
Balance adjustments: increase enemy difficulty and leveling requirements

### DIFF
--- a/src/items.py
+++ b/src/items.py
@@ -3598,7 +3598,9 @@ class ConclaveSignalStone(Key):
         )
         self.value = 0
         self.weight = 0.1
-        self.discovery_message = "a flat stone disc bearing a Conclave authorization sigil!"
+        self.discovery_message = (
+            "a flat stone disc bearing a Conclave authorization sigil!"
+        )
         self.announce = "A flat stone authorization disc rests here."
         self.interactions = ["examine", "drop"]
 

--- a/src/npc/_enemies.py
+++ b/src/npc/_enemies.py
@@ -21,11 +21,11 @@ class Slime(NPC):
         super().__init__(
             name="Slime " + genericng.generate(4, 5),
             description=description,
-            maxhp=10,
-            damage=20,
+            maxhp=20,
+            damage=26,
             awareness=12,
             aggro=True,
-            exp_award=1,
+            exp_award=2,
             idle_message=" is glopping about.",
             alert_message="burbles angrily at Jean!",
         )
@@ -65,12 +65,12 @@ class RockRumbler(NPC):
         super().__init__(
             name="Rock Rumbler " + genericng.generate(2, 4),
             description=description,
-            maxhp=30,
-            damage=22,
+            maxhp=55,
+            damage=30,
             protection=30,
             awareness=25,
             aggro=True,
-            exp_award=100,
+            exp_award=120,
         )
         self.resistance_base["earth"] = 0.5
         self.resistance_base["fire"] = 0.5
@@ -93,13 +93,13 @@ class Lurker(NPC):
         super().__init__(
             name="Lurker " + genericng.generate(2, 4),
             description=description,
-            maxhp=250,
-            damage=25,
+            maxhp=450,
+            damage=35,
             protection=0,
             awareness=60,
             endurance=20,
             aggro=True,
-            exp_award=800,
+            exp_award=950,
         )
         self.loot = loot.lev1
         self.resistance_base["dark"] = 0.5
@@ -153,13 +153,13 @@ class CaveBat(NPC):
         super().__init__(
             name="Cave Bat " + genericng.generate(2, 4),
             description=description,
-            maxhp=8,
-            damage=18,
+            maxhp=15,
+            damage=23,
             protection=0,
             awareness=14,
             speed=40,
             aggro=True,
-            exp_award=4,
+            exp_award=6,
             idle_message=" is hanging from the ceiling.",
             alert_message="screeches and dives!",
         )

--- a/src/player/__init__.py
+++ b/src/player/__init__.py
@@ -138,7 +138,7 @@ class Player(
         ):  # initialize an exp pool for each skill subtype
             self.skill_exp[subtype] = 0
         self.level = 1
-        self.exp_to_level = 100
+        self.exp_to_level = 150
         self.location_x, self.location_y = (0, 0)
         self.prev_location_x, self.prev_location_y = (
             0,

--- a/src/player/_leveling.py
+++ b/src/player/_leveling.py
@@ -69,7 +69,7 @@ class PlayerLevelingMixin:
         # Level up bookkeeping (match terminal behavior)
         self.level += 1
         self.exp -= self.exp_to_level
-        self.exp_to_level = self.level * (150 - self.intelligence)
+        self.exp_to_level = self.level * (165 - self.intelligence)
 
         # Apply random bonus increases to base stats
         bonuses = {}
@@ -133,7 +133,7 @@ class PlayerLevelingMixin:
         self.level += 1
         print(colored("He is now level {}".format(self.level)))
         self.exp -= self.exp_to_level
-        self.exp_to_level = self.level * (150 - self.intelligence)
+        self.exp_to_level = self.level * (165 - self.intelligence)
         cprint(
             "{} exp needed for the next level.".format(self.exp_to_level - self.exp),
             "yellow",

--- a/tests/test_cave_bat.py
+++ b/tests/test_cave_bat.py
@@ -53,13 +53,13 @@ def test_cave_bat_basic_attributes():
     bat = CaveBat()
     # Name and basic stats
     assert bat.name.startswith("Cave Bat")
-    assert bat.maxhp == 8
+    assert bat.maxhp == 15
     assert bat.hp == bat.maxhp
-    assert bat.damage == 18
+    assert bat.damage == 23
     assert bat.awareness == 14
     assert bat.speed == 40
     assert bat.aggro is True
-    assert bat.exp_award == 4
+    assert bat.exp_award == 6
     # Flavor resistances
     assert pytest.approx(bat.resistance_base.get("light", 1.0), rel=1e-3) == 0.8
     assert pytest.approx(bat.resistance_base.get("earth", 1.0), rel=1e-3) == 1.1

--- a/tests/test_player_core.py
+++ b/tests/test_player_core.py
@@ -542,7 +542,7 @@ class TestPlayerCore:
         assert player.strength_base == 13
         # 10 (base) + 1 (random bonus) + 3 (allocated) = 14
         assert player.finesse_base == 14
-        assert player.exp_to_level == 2 * (150 - 10) # 280
+        assert player.exp_to_level == 2 * (165 - 10)  # 310
 
     @patch('player.input', return_value='y')
     def test_equip_item_with_phrase(self, mock_input, player):


### PR DESCRIPTION
## Summary
This PR adjusts game balance by increasing enemy stats and experience rewards across multiple enemy types, while also increasing the experience required for player leveling.

## Key Changes

**Enemy Balance Updates** (`src/npc/_enemies.py`):
- **Slime**: Increased maxhp (10→20), damage (20→26), and exp_award (1→2)
- **Rock Rumbler**: Increased maxhp (30→55), damage (22→30), and exp_award (100→120)
- **Lurker**: Increased maxhp (250→450), damage (25→35), and exp_award (800→950)
- **Cave Bat**: Increased maxhp (8→15), damage (18→23), and exp_award (4→6)

**Player Leveling Adjustments** (`src/player/_leveling.py`):
- Increased experience requirement multiplier from 150 to 165 in both `_level_up_api()` and `level_up()` methods
- This makes each level require more experience to achieve

**Initial Experience Threshold** (`src/player/__init__.py`):
- Increased initial `exp_to_level` from 100 to 150 for new characters

## Implementation Details
The changes maintain consistent scaling across all enemy types while proportionally increasing both their threat level and reward value. The leveling curve adjustment (150→165 multiplier) combined with the higher initial threshold (100→150) creates a more gradual progression system that better matches the increased enemy difficulty.

https://claude.ai/code/session_012xuneTq6fn6FC6NXvXC6Je