### PR TITLE
Support consumable items usable on allies in combat

### DIFF
--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1462,7 +1462,9 @@ class ApiCombatAdapter:
             )
             return False
 
-        # Only remove the item after a successful use
+        # Stacked consumables self-remove via the user= parameter when count
+        # hits zero. This guard handles any item type that does NOT remove
+        # itself inside use() (e.g. a future reusable NPC consumable).
         if item in inventory:
             inventory.remove(item)
 

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1455,7 +1455,7 @@ class ApiCombatAdapter:
         item_name = getattr(item, "name", "item")
         try:
             with self._capture_output():
-                item.use(heal_target)
+                item.use(heal_target, user=npc)
         except Exception:
             logger.exception(
                 "%s failed to use %s on %s", npc.name, item_name, heal_target.name

--- a/src/api/routes/inventory.py
+++ b/src/api/routes/inventory.py
@@ -100,10 +100,8 @@ def _resolve_ally_target(player, target_id: str):
     Accepts IDs in the form "ally_<python-id>" as produced by the party_members
     serializer and the combat serializer.  Returns None if not found.
     """
-    for prefix in ("ally_", "enemy_"):
-        if target_id.startswith(prefix):
-            target_id = target_id[len(prefix) :]
-            break
+    if target_id.startswith("ally_"):
+        target_id = target_id[len("ally_"):]
     raw_id = target_id
     # Skip index 0 (the player) — allies start at index 1
     for ally in getattr(player, "combat_list_allies", [])[1:]:

--- a/src/api/routes/inventory.py
+++ b/src/api/routes/inventory.py
@@ -521,7 +521,7 @@ def use_item():
             "time.sleep", return_value=None
         ):
             # Call the item's use method
-            item.use(item_target)
+            item.use(item_target, user=player)
 
         output = f.getvalue()
         # Clean up output (remove ANSI codes)

--- a/src/api/routes/inventory.py
+++ b/src/api/routes/inventory.py
@@ -101,7 +101,7 @@ def _resolve_ally_target(player, target_id: str):
     serializer and the combat serializer.  Returns None if not found.
     """
     if target_id.startswith("ally_"):
-        target_id = target_id[len("ally_"):]
+        target_id = target_id[len("ally_") :]
     raw_id = target_id
     # Skip index 0 (the player) — allies start at index 1
     for ally in getattr(player, "combat_list_allies", [])[1:]:

--- a/src/items.py
+++ b/src/items.py
@@ -2412,8 +2412,8 @@ class Restorative(Consumable):
                 "reading, 'Restorative.'"
             )
 
-    def drink(self, player: "Player") -> None:
-        self.use(player)
+    def drink(self, player: "Player", user=None) -> None:
+        self.use(player, user=user)
 
     def use(self, player: "Player", user=None) -> None:
         _user = user if user is not None else player
@@ -2428,24 +2428,22 @@ class Restorative(Consumable):
             return
         if player.hp < player.maxhp:
             print(
-                "Jean quaffs down the Restorative. The liquid burns slightly in his throat for a moment, before the \n"
+                "{} quaffs down the Restorative. The liquid burns slightly in his throat for a moment, before the \n"
                 "sensation is replaced with a period of numbness. He feels his limbs getting a bit lighter, his \n"
-                "muscles relaxing, and the myriad of scratches and cuts closing up.\n"
+                "muscles relaxing, and the myriad of scratches and cuts closing up.\n".format(player.name)
             )
             amount: int = int((self.power * random.uniform(0.8, 1.2)))
             missing_hp: int = player.maxhp - player.hp
             if amount > missing_hp:
                 amount = missing_hp
             player.hp += amount
-            cprint("Jean recovered {} HP!".format(amount), "green")
+            cprint("{} recovered {} HP!".format(player.name, amount), "green")
             self.count -= 1
             self.stack_grammar()
             if self.count <= 0:
                 _user.inventory.remove(self)
         else:
-            raise ValueError(
-                "Jean is already at full health. He places the Restorative back into his bag."
-            )
+            print("{} is already at full health.".format(player.name))
 
 
 class Draught(Consumable):
@@ -2489,8 +2487,8 @@ class Draught(Consumable):
                 "Its label reads, simply, 'Draught.'"
             )
 
-    def drink(self, player: "Player") -> None:
-        self.use(player)
+    def drink(self, player: "Player", user=None) -> None:
+        self.use(player, user=user)
 
     def use(self, player: "Player", user=None) -> None:
         _user = user if user is not None else player
@@ -2504,9 +2502,9 @@ class Draught(Consumable):
             return
         if player.fatigue < player.maxfatigue:
             print(
-                "Jean gulps down the {}. It's surprisingly sweet and warm. The burden of fatigue seems \n"
+                "{} gulps down the {}. It's surprisingly sweet and warm. The burden of fatigue seems \n"
                 "to have lifted off of his shoulders for the time being.".format(
-                    self.name
+                    player.name, self.name
                 )
             )
             amount: int = int(math.ceil(self.power * random.uniform(0.8, 1.2)))
@@ -2514,7 +2512,7 @@ class Draught(Consumable):
             if amount > missing_fatigue:
                 amount = missing_fatigue
             player.fatigue += amount
-            cprint("Jean recovered {} fatigue!".format(amount), "green")
+            cprint("{} recovered {} fatigue!".format(player.name, amount), "green")
             self.count -= 1
             self.stack_grammar()
             if self.count <= 0:
@@ -2523,15 +2521,11 @@ class Draught(Consumable):
             # Check if item is in inventory or on the ground
             if self in _user.inventory:
                 print(
-                    "Jean is already fully rested. He places the {} back into his bag.".format(
-                        self.name
-                    )
+                    "{} is already fully rested.".format(player.name)
                 )
             else:
                 print(
-                    "Jean is already fully rested. He sets the {} back down.".format(
-                        self.name
-                    )
+                    "{} is already fully rested.".format(player.name)
                 )
 
 
@@ -2579,8 +2573,8 @@ class Antidote(Consumable):
                 "fluid inside and a label reading, 'Antidote.'"
             )
 
-    def drink(self, player: "Player") -> None:
-        self.use(player)
+    def drink(self, player: "Player", user=None) -> None:
+        self.use(player, user=user)
 
     def use(self, player: "Player", user=None) -> None:
         _user = user if user is not None else player
@@ -2600,9 +2594,9 @@ class Antidote(Consumable):
 
         if poisons:
             print(
-                "Jean sips gingerly at the Antidote. The liquid feels very cool as it slides thickly down \n"
+                "{} sips gingerly at the Antidote. The liquid feels very cool as it slides thickly down \n"
                 "his throat. He shudders uncontrollably for a moment as the medicine flows into his \n"
-                "bloodstream, doing its work on whatever toxic agent made its home there.\n"
+                "bloodstream, doing its work on whatever toxic agent made its home there.\n".format(player.name)
             )
             amount: int = int((self.power * random.uniform(0.8, 1.2)))
             missing_hp: int = player.maxhp - player.hp
@@ -2610,7 +2604,7 @@ class Antidote(Consumable):
                 if amount > missing_hp:
                     amount = missing_hp
                 player.hp += amount
-                cprint("Jean recovered {} HP!".format(amount), "green")
+                cprint("{} recovered {} HP!".format(player.name, amount), "green")
             for poison in poisons:
                 poison.on_removal(poison.target)
                 player.states.remove(poison)
@@ -2623,10 +2617,10 @@ class Antidote(Consumable):
             # Check if item is in inventory or on the ground
             if self in _user.inventory:
                 print(
-                    "Jean is not beset by poison. He places the Antidote back into his bag."
+                    "{} is not beset by poison.".format(player.name)
                 )
             else:
-                print("Jean is not beset by poison. He sets the Antidote back down.")
+                print("{} is not beset by poison.".format(player.name))
 
 
 # ---------------------------------------------------------------------------
@@ -3329,20 +3323,20 @@ class DriedCrystalSap(Consumable):
         _user = user if user is not None else player
         heal = min(self.power, player.maxhp - player.hp)
         if heal <= 0:
-            print("Jean is already in good health. He pockets the sap.")
+            print("{} is already in good health.".format(player.name))
             return
-        print("Jean bites into the waxy lump. The ozone smell sharpens for a moment.")
+        print("{} bites into the waxy lump. The ozone smell sharpens for a moment.".format(player.name))
         _time.sleep(1)
         player.hp += heal
-        cprint(f"HP restored by {heal}.", "green")
+        cprint("{} recovered {} HP!".format(player.name, heal), "green")
         self.count -= 1
         self.stack_grammar()
         if self.count <= 0:
             if self in _user.inventory:
                 _user.inventory.remove(self)
 
-    def drink(self, player: "Player") -> None:  # type: ignore[override]
-        self.use(player)
+    def drink(self, player: "Player", user=None) -> None:  # type: ignore[override]
+        self.use(player, user=user)
 
 
 class FabricariumRejectionShard(Special):
@@ -3721,28 +3715,28 @@ class IronRation(Consumable):
             return
         if player.hp < player.maxhp:
             print(
-                "Jean tears into the rations. The hardtack is stale, the meat tough, "
+                "{} tears into the rations. The hardtack is stale, the meat tough, "
                 "but he chews through them methodically. The familiar taste settles "
-                "something in him.\n"
+                "something in him.\n".format(player.name)
             )
             amount: int = int((self.power * random.uniform(0.9, 1.1)))
             missing_hp: int = player.maxhp - player.hp
             if amount > missing_hp:
                 amount = missing_hp
             player.hp += amount
-            cprint("Jean recovered {} HP!".format(amount), "green")
+            cprint("{} recovered {} HP!".format(player.name, amount), "green")
             self.count -= 1
             self.stack_grammar()
             if self.count <= 0:
                 _user.inventory.remove(self)
         else:
-            print("Jean is already in good health. He stows the rations for later.")
+            print("{} is already in good health.".format(player.name))
 
-    def eat(self, player: "Player") -> None:
-        self.use(player)
+    def eat(self, player: "Player", user=None) -> None:
+        self.use(player, user=user)
 
-    def consume(self, player: "Player") -> None:
-        self.use(player)
+    def consume(self, player: "Player", user=None) -> None:
+        self.use(player, user=user)
 
 
 class Bitterroot(Consumable):
@@ -3799,32 +3793,32 @@ class Bitterroot(Consumable):
             return
         if player.hp < player.maxhp:
             print(
-                "Jean places the bitterroot on his tongue. The taste is immediate — "
+                "{} places the bitterroot on his tongue. The taste is immediate — "
                 "sharp, almost painful, cutting through every sense. For a moment he gags. "
                 "Then warmth spreads from his chest outward, and the ache in his muscles "
-                "begins to fade.\n"
+                "begins to fade.\n".format(player.name)
             )
             amount: int = int((self.power * random.uniform(0.85, 1.15)))
             missing_hp: int = player.maxhp - player.hp
             if amount > missing_hp:
                 amount = missing_hp
             player.hp += amount
-            cprint("Jean recovered {} HP!".format(amount), "green")
+            cprint("{} recovered {} HP!".format(player.name, amount), "green")
             self.count -= 1
             self.stack_grammar()
             if self.count <= 0:
                 _user.inventory.remove(self)
         else:
-            print("Jean is already in good health. He pockets the root for later.")
+            print("{} is already in good health.".format(player.name))
 
-    def eat(self, player: "Player") -> None:
-        self.use(player)
+    def eat(self, player: "Player", user=None) -> None:
+        self.use(player, user=user)
 
-    def chew(self, player: "Player") -> None:
-        self.use(player)
+    def chew(self, player: "Player", user=None) -> None:
+        self.use(player, user=user)
 
-    def consume(self, player: "Player") -> None:
-        self.use(player)
+    def consume(self, player: "Player", user=None) -> None:
+        self.use(player, user=user)
 
 
 class MerchantJournalFragment(Book):

--- a/src/items.py
+++ b/src/items.py
@@ -2415,7 +2415,8 @@ class Restorative(Consumable):
     def drink(self, player: "Player") -> None:
         self.use(player)
 
-    def use(self, player: "Player") -> None:
+    def use(self, player: "Player", user=None) -> None:
+        _user = user if user is not None else player
         # Prevent using merchandise items until purchased
         if getattr(self, "merchandise", False):
             cprint(
@@ -2440,7 +2441,7 @@ class Restorative(Consumable):
             self.count -= 1
             self.stack_grammar()
             if self.count <= 0:
-                player.inventory.remove(self)
+                _user.inventory.remove(self)
         else:
             raise ValueError(
                 "Jean is already at full health. He places the Restorative back into his bag."
@@ -2491,7 +2492,8 @@ class Draught(Consumable):
     def drink(self, player: "Player") -> None:
         self.use(player)
 
-    def use(self, player: "Player") -> None:
+    def use(self, player: "Player", user=None) -> None:
+        _user = user if user is not None else player
         if getattr(self, "merchandise", False):
             cprint(
                 "{} must purchase {} before using or equipping it.".format(
@@ -2516,10 +2518,10 @@ class Draught(Consumable):
             self.count -= 1
             self.stack_grammar()
             if self.count <= 0:
-                player.inventory.remove(self)
+                _user.inventory.remove(self)
         else:
             # Check if item is in inventory or on the ground
-            if self in player.inventory:
+            if self in _user.inventory:
                 print(
                     "Jean is already fully rested. He places the {} back into his bag.".format(
                         self.name
@@ -2580,7 +2582,8 @@ class Antidote(Consumable):
     def drink(self, player: "Player") -> None:
         self.use(player)
 
-    def use(self, player: "Player") -> None:
+    def use(self, player: "Player", user=None) -> None:
+        _user = user if user is not None else player
         if getattr(self, "merchandise", False):
             cprint(
                 "{} must purchase {} before using or equipping it.".format(
@@ -2614,11 +2617,11 @@ class Antidote(Consumable):
             self.count -= 1
             self.stack_grammar()
             if self.count <= 0:
-                player.inventory.remove(self)
+                _user.inventory.remove(self)
             return
         else:
             # Check if item is in inventory or on the ground
-            if self in player.inventory:
+            if self in _user.inventory:
                 print(
                     "Jean is not beset by poison. He places the Antidote back into his bag."
                 )
@@ -3320,9 +3323,10 @@ class DriedCrystalSap(Consumable):
                 "Chewing one seems to dull minor wounds."
             )
 
-    def use(self, player: "Player") -> None:  # type: ignore[override]
+    def use(self, player: "Player", user=None) -> None:  # type: ignore[override]
         import time as _time
 
+        _user = user if user is not None else player
         heal = min(self.power, player.maxhp - player.hp)
         if heal <= 0:
             print("Jean is already in good health. He pockets the sap.")
@@ -3334,8 +3338,8 @@ class DriedCrystalSap(Consumable):
         self.count -= 1
         self.stack_grammar()
         if self.count <= 0:
-            if self in player.inventory:
-                player.inventory.remove(self)
+            if self in _user.inventory:
+                _user.inventory.remove(self)
 
     def drink(self, player: "Player") -> None:  # type: ignore[override]
         self.use(player)
@@ -3705,7 +3709,8 @@ class IronRation(Consumable):
             )
             self.announce = "Jean notices a bundle of travel rations wrapped in cloth."
 
-    def use(self, player: "Player") -> None:
+    def use(self, player: "Player", user=None) -> None:
+        _user = user if user is not None else player
         if getattr(self, "merchandise", False):
             cprint(
                 "{} must purchase {} before using or equipping it.".format(
@@ -3729,7 +3734,7 @@ class IronRation(Consumable):
             self.count -= 1
             self.stack_grammar()
             if self.count <= 0:
-                player.inventory.remove(self)
+                _user.inventory.remove(self)
         else:
             print("Jean is already in good health. He stows the rations for later.")
 
@@ -3784,7 +3789,8 @@ class Bitterroot(Consumable):
                 "A dried root lies here, sharp-smelling even from a distance."
             )
 
-    def use(self, player: "Player") -> None:
+    def use(self, player: "Player", user=None) -> None:
+        _user = user if user is not None else player
         if getattr(self, "merchandise", False):
             cprint(
                 "{} must purchase {} before using it.".format(player.name, self.name),
@@ -3807,7 +3813,7 @@ class Bitterroot(Consumable):
             self.count -= 1
             self.stack_grammar()
             if self.count <= 0:
-                player.inventory.remove(self)
+                _user.inventory.remove(self)
         else:
             print("Jean is already in good health. He pockets the root for later.")
 

--- a/src/items.py
+++ b/src/items.py
@@ -2428,9 +2428,9 @@ class Restorative(Consumable):
             return
         if player.hp < player.maxhp:
             print(
-                "{} quaffs down the Restorative. The liquid burns slightly in his throat for a moment, before the \n"
+                f"{player.name} quaffs down the Restorative. The liquid burns slightly in his throat for a moment, before the \n"
                 "sensation is replaced with a period of numbness. He feels his limbs getting a bit lighter, his \n"
-                "muscles relaxing, and the myriad of scratches and cuts closing up.\n".format(player.name)
+                "muscles relaxing, and the myriad of scratches and cuts closing up.\n"
             )
             amount: int = int((self.power * random.uniform(0.8, 1.2)))
             missing_hp: int = player.maxhp - player.hp
@@ -2518,15 +2518,7 @@ class Draught(Consumable):
             if self.count <= 0:
                 _user.inventory.remove(self)
         else:
-            # Check if item is in inventory or on the ground
-            if self in _user.inventory:
-                print(
-                    "{} is already fully rested.".format(player.name)
-                )
-            else:
-                print(
-                    "{} is already fully rested.".format(player.name)
-                )
+            print("{} is already fully rested.".format(player.name))
 
 
 class Antidote(Consumable):
@@ -2594,9 +2586,9 @@ class Antidote(Consumable):
 
         if poisons:
             print(
-                "{} sips gingerly at the Antidote. The liquid feels very cool as it slides thickly down \n"
+                f"{player.name} sips gingerly at the Antidote. The liquid feels very cool as it slides thickly down \n"
                 "his throat. He shudders uncontrollably for a moment as the medicine flows into his \n"
-                "bloodstream, doing its work on whatever toxic agent made its home there.\n".format(player.name)
+                "bloodstream, doing its work on whatever toxic agent made its home there.\n"
             )
             amount: int = int((self.power * random.uniform(0.8, 1.2)))
             missing_hp: int = player.maxhp - player.hp
@@ -2614,13 +2606,7 @@ class Antidote(Consumable):
                 _user.inventory.remove(self)
             return
         else:
-            # Check if item is in inventory or on the ground
-            if self in _user.inventory:
-                print(
-                    "{} is not beset by poison.".format(player.name)
-                )
-            else:
-                print("{} is not beset by poison.".format(player.name))
+            print("{} is not beset by poison.".format(player.name))
 
 
 # ---------------------------------------------------------------------------
@@ -3325,7 +3311,10 @@ class DriedCrystalSap(Consumable):
         if heal <= 0:
             print("{} is already in good health.".format(player.name))
             return
-        print("{} bites into the waxy lump. The ozone smell sharpens for a moment.".format(player.name))
+        print(
+            f"{player.name} bites into the waxy lump. "
+            "The ozone smell sharpens for a moment."
+        )
         _time.sleep(1)
         player.hp += heal
         cprint("{} recovered {} HP!".format(player.name, heal), "green")

--- a/src/moves/_utility.py
+++ b/src/moves/_utility.py
@@ -647,7 +647,9 @@ class UseItem(Move):
             while True:
                 cprint("Use item on whom?", "cyan")
                 for i, t in enumerate(possible_targets):
-                    print(colored(str(i), "magenta") + ": " + colored(t.name, "magenta"))
+                    print(
+                        colored(str(i), "magenta") + ": " + colored(t.name, "magenta")
+                    )
                 cprint("x: Cancel", "magenta")
                 choice = input(colored("Target: ", "cyan"))
                 if choice.lower() == "x":

--- a/src/moves/_utility.py
+++ b/src/moves/_utility.py
@@ -638,7 +638,8 @@ class UseItem(Move):
 
     def execute(self, player):
         possible_targets = [player] + [
-            a for a in player.combat_list_allies[1:]
+            a
+            for a in player.combat_list_allies[1:]
             if a.is_alive() and not getattr(a, "knocked_out", False)
         ]
         target = player

--- a/src/moves/_utility.py
+++ b/src/moves/_utility.py
@@ -640,5 +640,26 @@ class UseItem(Move):
         return viability
 
     def execute(self, player):
-        player.use_item()  # opens the category view for the standard "use item" action
+        possible_targets = [player] + [
+            a for a in player.combat_list_allies[1:] if a.is_alive()
+        ]
+        target = player
+        if len(possible_targets) > 1:
+            while True:
+                cprint("Use item on whom?", "cyan")
+                for i, t in enumerate(possible_targets):
+                    print(colored(str(i), "magenta") + ": " + colored(t.name, "magenta"))
+                cprint("x: Cancel", "magenta")
+                choice = input(colored("Target: ", "cyan"))
+                if choice.lower() == "x":
+                    return
+                if not functions.is_input_integer(choice):
+                    cprint("Invalid selection!", "red")
+                    continue
+                idx = int(choice)
+                if 0 <= idx < len(possible_targets):
+                    target = possible_targets[idx]
+                    break
+                cprint("Invalid selection!", "red")
+        player.use_item(target=target)
         player.combat_exp["Basic"] += 1

--- a/src/moves/_utility.py
+++ b/src/moves/_utility.py
@@ -629,19 +629,17 @@ class UseItem(Move):
         )
 
     def viable(self):
-        viability = True
         if not self.user.inventory:
-            viability = False
-        else:
-            for item in self.user.inventory:
-                if item.type == "Consumable" or "Special":
-                    viability = True
-                    break
-        return viability
+            return False
+        for item in self.user.inventory:
+            if item.type in ("Consumable", "Special"):
+                return True
+        return False
 
     def execute(self, player):
         possible_targets = [player] + [
-            a for a in player.combat_list_allies[1:] if a.is_alive()
+            a for a in player.combat_list_allies[1:]
+            if a.is_alive() and not getattr(a, "knocked_out", False)
         ]
         target = player
         if len(possible_targets) > 1:

--- a/src/player/_inventory.py
+++ b/src/player/_inventory.py
@@ -445,7 +445,7 @@ class PlayerInventoryMixin:
                                 break
                             if "use" in item.interactions and hasattr(item, "use"):
                                 print("{} used {}!".format(self.name, item.name))
-                                item.use(_target)
+                                item.use(_target, user=self)
                             elif "prefer" in item.interactions and hasattr(
                                 item, "prefer"
                             ):
@@ -497,7 +497,7 @@ class PlayerInventoryMixin:
                             "YES",
                         ]
                         if confirm in acceptable_confirm_phrases:
-                            item.use(_target)
+                            item.use(_target, user=self)
                             break
 
     def stack_inv_items(self):

--- a/tests/combat/test_ally_healing.py
+++ b/tests/combat/test_ally_healing.py
@@ -30,10 +30,11 @@ def test_resolve_ally_target_valid():
     assert _resolve_ally_target(player, f"ally_{id(ally)}") is ally
 
 
-def test_resolve_ally_target_enemy_prefix_stripped():
+def test_resolve_ally_target_enemy_prefix_not_stripped():
+    """enemy_ prefix must NOT be resolved as an ally — that was a bug (M2 fix)."""
     ally = MagicMock()
     player = _make_player_with_allies(ally)
-    assert _resolve_ally_target(player, f"enemy_{id(ally)}") is ally
+    assert _resolve_ally_target(player, f"enemy_{id(ally)}") is None
 
 
 def test_resolve_ally_target_unknown_id_returns_none():

--- a/tests/combat/test_ally_healing.py
+++ b/tests/combat/test_ally_healing.py
@@ -125,7 +125,7 @@ def test_npc_try_heal_ally_heals_injured_friendly():
 
     result = _run_heal(adapter, npc)
 
-    item.use.assert_called_once_with(ally)
+    item.use.assert_called_once_with(ally, user=npc)
     assert result is True
     assert item not in npc.inventory
 

--- a/tests/test_player_core.py
+++ b/tests/test_player_core.py
@@ -1194,7 +1194,7 @@ class TestPlayerCore:
 
         with patch('builtins.input', return_value="y"):
             player.use_item("Potion")
-            mock_item.use.assert_called_once_with(player)
+            mock_item.use.assert_called_once_with(player, user=player)
 
     def test_use_item_interactive(self, player):
         mock_item = MagicMock(spec=items.Restorative)
@@ -1214,7 +1214,7 @@ class TestPlayerCore:
              patch('builtins.print'), \
              patch('functions.is_input_integer', side_effect=lambda x: x.isdigit()):
             player.use_item()
-            mock_item.use.assert_called_once_with(player)
+            mock_item.use.assert_called_once_with(player, user=player)
 
     def test_add_items_to_inventory_2(self, player):
         player.weight_tolerance = 100


### PR DESCRIPTION
## Summary
This PR enables consumable items (potions, rations, etc.) to be used on allies during combat, not just on the player character. It introduces a `user` parameter to item `use()` methods to track who is using the item separately from who receives its effects.

## Key Changes

- **Added `user` parameter to consumable `use()` methods**: All consumable item classes (Restorative, Draught, Antidote, Sap, TravelRations, Bitterroot) now accept an optional `user` parameter to distinguish the item user from the target. When `user` is provided, item removal uses the user's inventory instead of the target's.

- **Updated item use calls throughout codebase**: Modified all calls to `item.use()` to pass `user=player` or `user=npc` to properly track inventory ownership:
  - `src/player/_inventory.py`: Player using items on themselves or allies
  - `src/api/routes/inventory.py`: API endpoint for item usage
  - `src/api/combat_adapter.py`: NPC using items on allies

- **Enhanced UseItem combat action**: The `UseItem` action in `src/moves/_utility.py` now:
  - Presents a target selection menu when multiple valid targets exist (player + alive allies)
  - Passes the selected target to `player.use_item(target=target)`
  - Properly validates targets (alive and not knocked out)

- **Improved consumable flavor text**: Updated hardcoded character names ("Jean") to use `player.name` for dynamic character support across all consumable items.

- **Fixed logic bugs**:
  - Corrected `UseItem.viable()` condition check from `item.type == "Consumable" or "Special"` to `item.type in ("Consumable", "Special")`
  - Simplified `_resolve_ally_target()` to only check "ally_" prefix instead of both "ally_" and "enemy_"

## Implementation Details

The `user` parameter defaults to `None`, and when `None`, it falls back to the `player` parameter for backward compatibility. This allows consumables to be used on different targets while maintaining proper inventory management—the item is removed from the user's inventory, not the target's.

https://claude.ai/code/session_01QCw8FzGfDmseRBYtMrQL7b