### PR TITLE
fix(combat): enforce shorter attack cooldown

### DIFF
--- a/src/moves/_utility.py
+++ b/src/moves/_utility.py
@@ -475,7 +475,7 @@ class Attack(Move):  # basic attack function, always uses equipped weapon, playe
 
         execute = 1
 
-        cooldown = (2 + self.user.eq_weapon.weight) - int(self.user.speed / 10)
+        cooldown = 5 - int(self.user.speed / 10)
         if cooldown < 0:
             cooldown = 0
 


### PR DESCRIPTION
Removes weapon weight logic from \Attack.evaluate()\ so it matches \__init__\ intent, ensuring it displays correctly.