### PR TITLE
Fix NPC combat logic to rest when attack is in range but unaffordable

### DIFF
--- a/src/npc/_combat.py
+++ b/src/npc/_combat.py
@@ -71,8 +71,19 @@ class NPCCombatMixin:
             for m in available_moves
         )
         if not can_attack and self.fatigue < self.maxfatigue:
-            # Only force-rest when advancing is not an option.  If a viable Advance move
-            # exists the NPC should close distance rather than stand still and recover.
+            # If an offensive move is already in range (just unaffordable due to low
+            # fatigue), rest to recover rather than uselessly advancing.  Advance floors
+            # at distance 3 in both movement systems, so an NPC at distance 2–3 with a
+            # range-0-5 attack would otherwise loop: Advance (no-op) → Advance → …
+            in_attack_range = any(
+                getattr(m, "category", "") == "Offensive" and m.viable()
+                for m in self.known_moves
+            )
+            if in_attack_range:
+                self.current_move = moves.NpcRest(self)
+                return
+            # Only force-rest when advancing is also not an option.  If a viable Advance
+            # move exists and the target is genuinely out of range, close distance instead.
             can_advance = any(
                 getattr(m, "name", "") == "Advance" for m in available_moves
             )


### PR DESCRIPTION
## Summary
Improved NPC combat decision-making to prevent infinite loops when an offensive move is within range but the NPC lacks sufficient fatigue to execute it.

## Key Changes
- Added logic to detect when an offensive move is already in range but unaffordable due to low fatigue
- NPCs now rest to recover fatigue in this scenario instead of uselessly advancing
- Prevents the "Advance (no-op) → Advance → …" loop that occurred when NPCs were at distance 2–3 with range-0-5 attacks, since Advance floors at distance 3 in both movement systems
- Clarified the comment to explain that rest is only force-triggered when advancing is also not a viable option

## Implementation Details
- Checks if any known move is categorized as "Offensive" and is viable (in range) before deciding to rest
- If an attack is in range, the NPC immediately returns with a Rest move rather than continuing to evaluate other options
- Preserves the original behavior of preferring to advance when the target is genuinely out of range and no offensive moves are available

https://claude.ai/code/session_01HX4CHpBR74xLLJZGL1MyDQ