### PR TITLE
Refactor combat end dialog timing to use explicit delays

### DIFF
--- a/frontend/src/hooks/useCombatCoordinator.js
+++ b/frontend/src/hooks/useCombatCoordinator.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
 /**
  * Custom hook for managing combat coordination state and handlers.
@@ -44,8 +44,14 @@ export function useCombatCoordinator({
     // Target hover state
     const [hoveredTargetId, setHoveredTargetId] = useState(null)
 
+    // Timer ref for post-combat dialog delay
+    const endStateTimerRef = useRef(null)
+
     /**
-     * Handle victory/defeat dialog display when combat ends
+     * Handle victory/defeat dialog display when combat ends.
+     * Waits for the combat log to finish spooling, then delays 5 seconds
+     * so the final attack animation and result are fully visible before
+     * the dialog interrupts.
      */
     useEffect(() => {
         const maybeEnd = combat?.end_state
@@ -55,18 +61,31 @@ export function useCombatCoordinator({
         if (!inCombat && maybeEnd && (maybeEnd.status === 'victory' || maybeEnd.status === 'defeat')) {
             setEndState(maybeEnd)
             if (!isCombatLogProcessing && !hasPendingLogs && maybeEnd.id && maybeEnd.id !== lastEndStateId) {
-                if (maybeEnd.status === 'victory') {
-                    setShowVictoryDialog(true)
-                    // Play fanfare as a one-shot sting (non-looping)
-                    if (playSting) playSting('fanfare')
-                } else {
-                    setShowDefeatDialog(true)
-                }
+                // Mark handled immediately so re-renders don't schedule a second timer
                 setLastEndStateId(maybeEnd.id)
                 sessionStorage.setItem('hov_last_end_state_id', maybeEnd.id)
+
+                const isVictory = maybeEnd.status === 'victory'
+                endStateTimerRef.current = setTimeout(() => {
+                    endStateTimerRef.current = null
+                    if (isVictory) {
+                        setShowVictoryDialog(true)
+                        // Play fanfare as a one-shot sting (non-looping)
+                        if (playSting) playSting('fanfare')
+                    } else {
+                        setShowDefeatDialog(true)
+                    }
+                }, 5000)
             }
         }
     }, [inCombat, combat?.end_state, isCombatLogProcessing, lastEndStateId, displayedLogCount, combat?.log, playSting])
+
+    // Cancel any pending end-state timer when the hook unmounts
+    useEffect(() => {
+        return () => {
+            if (endStateTimerRef.current) clearTimeout(endStateTimerRef.current)
+        }
+    }, [])
 
     /**
      * Reset combat dialog state when combat ends

--- a/frontend/src/hooks/useCombatCoordinator.test.js
+++ b/frontend/src/hooks/useCombatCoordinator.test.js
@@ -1,5 +1,5 @@
-import { renderHook, act, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useCombatCoordinator } from './useCombatCoordinator'
 
 describe('useCombatCoordinator', () => {
@@ -50,7 +50,15 @@ describe('useCombatCoordinator', () => {
     })
 
     describe('victory/defeat dialog handling', () => {
-        it('should show victory dialog when combat ends with victory', async () => {
+        beforeEach(() => {
+            vi.useFakeTimers()
+        })
+
+        afterEach(() => {
+            vi.useRealTimers()
+        })
+
+        it('should show victory dialog when combat ends with victory', () => {
             const combat = {
                 end_state: {
                     id: 'victory-1',
@@ -64,13 +72,13 @@ describe('useCombatCoordinator', () => {
                 useCombatCoordinator({ ...defaultParams, combat, inCombat: false })
             )
 
-            await waitFor(() => {
-                expect(result.current.showVictoryDialog).toBe(true)
-                expect(result.current.endState).toEqual(combat.end_state)
-            })
+            act(() => vi.advanceTimersByTime(5000))
+
+            expect(result.current.showVictoryDialog).toBe(true)
+            expect(result.current.endState).toEqual(combat.end_state)
         })
 
-        it('should show defeat dialog when combat ends with defeat', async () => {
+        it('should show defeat dialog when combat ends with defeat', () => {
             const combat = {
                 end_state: {
                     id: 'defeat-1',
@@ -84,10 +92,10 @@ describe('useCombatCoordinator', () => {
                 useCombatCoordinator({ ...defaultParams, combat, inCombat: false })
             )
 
-            await waitFor(() => {
-                expect(result.current.showDefeatDialog).toBe(true)
-                expect(result.current.endState).toEqual(combat.end_state)
-            })
+            act(() => vi.advanceTimersByTime(5000))
+
+            expect(result.current.showDefeatDialog).toBe(true)
+            expect(result.current.endState).toEqual(combat.end_state)
         })
 
         it('should not show dialog if combat log is still processing', () => {
@@ -143,7 +151,7 @@ describe('useCombatCoordinator', () => {
             expect(result.current.showVictoryDialog).toBe(false)
         })
 
-        it('should not show same end state twice', async () => {
+        it('should not show same end state twice', () => {
             const combat = {
                 end_state: {
                     id: 'victory-1',
@@ -158,17 +166,18 @@ describe('useCombatCoordinator', () => {
                 { initialProps: { combat } }
             )
 
-            await waitFor(() => {
-                expect(result.current.showVictoryDialog).toBe(true)
-            })
+            // Advance time to trigger the delayed dialog
+            act(() => vi.advanceTimersByTime(5000))
+            expect(result.current.showVictoryDialog).toBe(true)
 
             // Close the dialog
             act(() => {
                 result.current.setShowVictoryDialog(false)
             })
 
-            // Re-render with same end state
+            // Re-render with same end state — lastEndStateId already matches so no timer fires
             rerender({ combat })
+            act(() => vi.advanceTimersByTime(5000))
 
             // Should not show again
             expect(result.current.showVictoryDialog).toBe(false)

--- a/frontend/src/pages/GamePage.test.jsx
+++ b/frontend/src/pages/GamePage.test.jsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import GamePage from './GamePage';
 import { usePlayer, useWorld, useCombat, useExploration, useExits, useAutosave } from '../hooks/useApi';
 import { useAudio } from '../context/AudioContext';
@@ -222,26 +222,32 @@ describe('GamePage', () => {
     });
 
 
-    it('shows victory dialog after combat win', async () => {
-        useCombat.mockReturnValue({
-            combat: {
-                combat_active: false,
-                end_state: { id: 'win-1', status: 'victory', message: 'You won!' }
-            },
-            inCombat: false,
-            loading: false,
-            fetchCombatStatus: vi.fn(),
-            performAction: vi.fn()
-        });
+    it('shows victory dialog after combat win', () => {
+        vi.useFakeTimers();
+        try {
+            useCombat.mockReturnValue({
+                combat: {
+                    combat_active: false,
+                    end_state: { id: 'win-1', status: 'victory', message: 'You won!' }
+                },
+                inCombat: false,
+                loading: false,
+                fetchCombatStatus: vi.fn(),
+                performAction: vi.fn()
+            });
 
-        renderGamePage();
+            renderGamePage();
 
-        await waitFor(() => {
+            act(() => vi.advanceTimersByTime(5000));
+
             expect(screen.getByText(/You won!/i)).toBeDefined();
-        });
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('shows BetaEndDialog after closing victory dialog with beta_end=true', async () => {
+        vi.useFakeTimers();
         const mockFetchCombatStatus = vi.fn().mockResolvedValue(undefined);
 
         useCombat.mockReturnValue({
@@ -270,17 +276,20 @@ describe('GamePage', () => {
 
         renderGamePage();
 
-        // Victory dialog should appear
-        await waitFor(() => {
-            expect(screen.getByText(/Victory!/i)).toBeDefined();
-        });
+        // Advance time to trigger the delayed victory dialog
+        act(() => vi.advanceTimersByTime(5000));
+
+        expect(screen.getByText(/Victory!/i)).toBeDefined();
 
         // Close button is enabled (no points to spend)
         const closeBtn = screen.getByText('CLOSE');
         expect(closeBtn.disabled).toBe(false);
         fireEvent.click(closeBtn);
 
-        // BetaEndDialog should appear
+        // Switch back to real timers so waitFor can retry for the BetaEndDialog
+        vi.useRealTimers();
+
+        // BetaEndDialog should appear after closing the victory dialog
         await waitFor(() => {
             expect(screen.getByText('END OF BETA')).toBeDefined();
         });

--- a/frontend/src/pages/GamePage.test.jsx
+++ b/frontend/src/pages/GamePage.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import GamePage from './GamePage';
 import { usePlayer, useWorld, useCombat, useExploration, useExits, useAutosave } from '../hooks/useApi';
 import { useAudio } from '../context/AudioContext';
@@ -248,51 +248,55 @@ describe('GamePage', () => {
 
     it('shows BetaEndDialog after closing victory dialog with beta_end=true', async () => {
         vi.useFakeTimers();
-        const mockFetchCombatStatus = vi.fn().mockResolvedValue(undefined);
+        try {
+            const mockFetchCombatStatus = vi.fn().mockResolvedValue(undefined);
 
-        useCombat.mockReturnValue({
-            combat: {
-                combat_active: false,
-                end_state: {
-                    id: 'lurker-win-1',
-                    status: 'victory',
-                    message: 'Victory!',
-                    beta_end: true,
-                    exp_gained: {},
-                    items_dropped: [],
-                    level_ups: [],
-                    attribute_points_available: 0,
-                    attributes: {
-                        strength_base: 10, finesse_base: 10, speed_base: 10,
-                        endurance_base: 10, charisma_base: 10, intelligence_base: 10,
-                    },
-                }
-            },
-            inCombat: false,
-            loading: false,
-            fetchCombatStatus: mockFetchCombatStatus,
-            performAction: vi.fn()
-        });
+            useCombat.mockReturnValue({
+                combat: {
+                    combat_active: false,
+                    end_state: {
+                        id: 'lurker-win-1',
+                        status: 'victory',
+                        message: 'Victory!',
+                        beta_end: true,
+                        exp_gained: {},
+                        items_dropped: [],
+                        level_ups: [],
+                        attribute_points_available: 0,
+                        attributes: {
+                            strength_base: 10, finesse_base: 10, speed_base: 10,
+                            endurance_base: 10, charisma_base: 10, intelligence_base: 10,
+                        },
+                    }
+                },
+                inCombat: false,
+                loading: false,
+                fetchCombatStatus: mockFetchCombatStatus,
+                performAction: vi.fn()
+            });
 
-        renderGamePage();
+            renderGamePage();
 
-        // Advance time to trigger the delayed victory dialog
-        act(() => vi.advanceTimersByTime(5000));
+            // Advance time to trigger the delayed victory dialog
+            act(() => vi.advanceTimersByTime(5000));
 
-        expect(screen.getByText(/Victory!/i)).toBeDefined();
+            expect(screen.getByText(/Victory!/i)).toBeDefined();
 
-        // Close button is enabled (no points to spend)
-        const closeBtn = screen.getByText('CLOSE');
-        expect(closeBtn.disabled).toBe(false);
-        fireEvent.click(closeBtn);
+            // Close button is enabled (no points to spend)
+            const closeBtn = screen.getByText('CLOSE');
+            expect(closeBtn.disabled).toBe(false);
+            fireEvent.click(closeBtn);
 
-        // Switch back to real timers so waitFor can retry for the BetaEndDialog
-        vi.useRealTimers();
+            // Switch back to real timers so waitFor can retry for the BetaEndDialog
+            vi.useRealTimers();
 
-        // BetaEndDialog should appear after closing the victory dialog
-        await waitFor(() => {
-            expect(screen.getByText('END OF BETA')).toBeDefined();
-        });
+            // BetaEndDialog should appear after closing the victory dialog
+            await waitFor(() => {
+                expect(screen.getByText('END OF BETA')).toBeDefined();
+            });
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });
 


### PR DESCRIPTION
## Summary
Refactored the combat end dialog display logic to use explicit 5-second delays via `setTimeout` instead of relying on async/await patterns with `waitFor`. This makes the timing behavior more predictable and testable, especially when using fake timers in tests.

## Key Changes

- **useCombatCoordinator.js**: 
  - Added `useRef` to track the end-state timer and prevent multiple timers from being scheduled
  - Moved dialog display logic into a `setTimeout` callback with a 5-second delay
  - Set `lastEndStateId` immediately to prevent race conditions on re-renders
  - Added cleanup effect to cancel pending timers on unmount
  - Updated JSDoc to clarify the delay is for animation visibility

- **useCombatCoordinator.test.js**:
  - Added `beforeEach`/`afterEach` hooks to manage fake timers for the victory/defeat dialog tests
  - Replaced `waitFor` calls with `act(() => vi.advanceTimersByTime(5000))` for deterministic timing
  - Removed `async` from test functions that no longer need it
  - Updated test comments to clarify timer behavior

- **GamePage.test.jsx**:
  - Added `act` import from testing library
  - Wrapped fake timer setup in try/finally blocks for proper cleanup
  - Replaced `waitFor` with `act(() => vi.advanceTimersByTime(5000))` for victory dialog tests
  - Strategically switched back to real timers before `waitFor` calls where async behavior is needed

## Implementation Details

The 5-second delay ensures the final combat animation and result are fully visible before the victory/defeat dialog interrupts the user's view. By using explicit `setTimeout` with a ref, we can:
- Prevent multiple timers from being scheduled on re-renders
- Properly clean up pending timers on unmount
- Make tests deterministic by advancing fake timers by exactly 5000ms
- Avoid flaky async/await patterns in tests

https://claude.ai/code/session_01DHrfLeNRD1DwKsfpUCrHyu