### PR TITLE
feat(frontend): add stack count indicator to inventory item cards

### DIFF
--- a/frontend/src/components/InventoryDialog.jsx
+++ b/frontend/src/components/InventoryDialog.jsx
@@ -370,6 +370,23 @@ function ItemCard({ item, onClick, isShop }) {
         </div>
       )}
 
+      {item.quantity > 1 && (
+        <div style={{
+          position: 'absolute',
+          top: '-6px',
+          right: isEquipped ? '50px' : '-6px',
+          backgroundColor: colors.gold,
+          color: '#000',
+          fontSize: '9px',
+          padding: '2px 6px',
+          borderRadius: '10px',
+          fontWeight: 'bold',
+          boxShadow: '0 2px 4px rgba(0,0,0,0.5)'
+        }}>
+          x{item.quantity}
+        </div>
+      )}
+
       <div style={{
         fontSize: '13px',
         fontWeight: 'bold',

--- a/frontend/src/components/InventoryDialog.test.jsx
+++ b/frontend/src/components/InventoryDialog.test.jsx
@@ -178,4 +178,26 @@ describe('InventoryDialog', () => {
 
     expect(screen.getByText('EQUIPPED')).toBeDefined();
   });
+
+  it('shows stack count for items with quantity > 1', () => {
+    const playerWithStacks = {
+      ...mockPlayer,
+      inventory: [
+        ...mockPlayer.inventory,
+        { id: 9, name: 'Test Potion', maintype: 'Consumable', subtype: 'Potion', value: 15, weight: 0.5, quantity: 3 }
+      ]
+    };
+    const { container } = render(<InventoryDialog player={playerWithStacks} onClose={mockOnClose} onRefetch={mockOnRefetch} />);
+
+    // Navigate to Consumables tab
+    const consumablesTab = screen.getByTitle('Consumables');
+    fireEvent.click(consumablesTab);
+
+    // Check that Test Potion with quantity 3 is displayed with the quantity badge
+    expect(screen.getByText(/Test Potion/)).toBeDefined();
+    // The x3 badge should be in the DOM
+    const badges = container.querySelectorAll('div');
+    const quantityBadges = Array.from(badges).filter(div => div.textContent?.includes('x3'));
+    expect(quantityBadges.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
Adds a quantity badge displaying 'x{quantity}' on item cards when quantity > 1.
The badge is positioned at the top-right of the card in gold color, adjacent to
the equipped badge when present. Improves UX by showing stack counts without
requiring users to click into items.

https://claude.ai/code/session_01NbLyhQB4hwtMzoq3MSKqo6