### PR TITLE
Clear session data when starting a new game

### DIFF
--- a/src/api/services/session_manager.py
+++ b/src/api/services/session_manager.py
@@ -721,8 +721,9 @@ class SessionManager:
         # Replace existing player
         self.players[player_id] = player
 
-        # Explicitly clear any combat state if game_service exists (though we don't have ref here easily)
-        # Actually replacing the player object should be enough as combat is usually linked to player
+        # Clear stale per-game session data (e.g. initial_tile_events_done, pending_events,
+        # tile_modifications) so the new game starts with a clean slate.
+        session.data.clear()
 
         return True
 


### PR DESCRIPTION
## Summary
This change ensures that per-game session data is properly cleared when starting a new game, preventing stale state from persisting across game sessions.

## Key Changes
- Replaced ineffective comment about clearing combat state with actual implementation that clears session data
- Added `session.data.clear()` call in `start_new_game()` method to reset per-game session state
- Updated comment to explicitly document which data is being cleared (initial_tile_events_done, pending_events, tile_modifications)

## Implementation Details
The new game initialization now explicitly clears the session data dictionary, ensuring a clean slate for:
- Initial tile events tracking
- Pending events queue
- Tile modifications state

This prevents bugs where stale data from a previous game could affect the new game's behavior.

https://claude.ai/code/session_01M13c3Gr1qZPRXu2SonFvBy