### PR TITLE
Add Nexus Fidei branding links to login and main menu pages

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -264,6 +264,22 @@ export default function LoginPage() {
           >
             Terms of Service &amp; Privacy Policy
           </button>
+          <a
+            href="https://nexusfidei.dev"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              color: colors.text.dim,
+              fontFamily: 'monospace',
+              fontSize: '11px',
+              textDecoration: 'underline',
+              transition: 'color 0.2s',
+            }}
+            onMouseEnter={(e) => e.target.style.color = colors.text.muted}
+            onMouseLeave={(e) => e.target.style.color = colors.text.dim}
+          >
+            Nexus Fidei
+          </a>
         </div>
       </div>
 

--- a/frontend/src/pages/MainMenuPage.jsx
+++ b/frontend/src/pages/MainMenuPage.jsx
@@ -235,6 +235,25 @@ export default function MainMenuPage() {
                     <GameButton onClick={() => setShowCredits(true)} size="large" style={{ width: '100%' }}>Credits</GameButton>
                     <GameButton onClick={handleLogout} variant="danger" size="large" style={{ width: '100%' }}>Logout</GameButton>
                 </nav>
+
+                <div style={{ marginTop: spacing.xl, textAlign: 'center' }}>
+                    <a
+                        href="https://nexusfidei.dev"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                            color: colors.text.dim,
+                            fontFamily: fonts.main,
+                            fontSize: '11px',
+                            textDecoration: 'underline',
+                            transition: 'color 0.2s',
+                        }}
+                        onMouseEnter={(e) => e.target.style.color = colors.text.muted}
+                        onMouseLeave={(e) => e.target.style.color = colors.text.dim}
+                    >
+                        Nexus Fidei
+                    </a>
+                </div>
             </GamePanel>
 
             {/* Settings Modal */}


### PR DESCRIPTION
## Summary
Added footer links to the Nexus Fidei website on both the LoginPage and MainMenuPage components to improve brand visibility and provide easy access to the project's main website.

## Key Changes
- **LoginPage**: Added a styled footer link to `https://nexusfidei.dev` below the Terms of Service button
- **MainMenuPage**: Added a styled footer link to `https://nexusfidei.dev` below the navigation menu

## Implementation Details
- Both links use consistent styling with:
  - Small font size (11px) for subtle branding
  - Dim text color that transitions to muted on hover
  - Underlined text decoration
  - `target="_blank"` and `rel="noopener noreferrer"` for secure external navigation
- LoginPage uses `fontFamily: 'monospace'` while MainMenuPage uses `fonts.main` for consistency with existing design tokens
- Hover effects implemented via inline `onMouseEnter` and `onMouseLeave` handlers for smooth color transitions

https://claude.ai/code/session_01BCfbG8HBNNCXYvprNMXVob