### PR TITLE
Add touch pan gesture and mobile UI improvements

### DIFF
--- a/frontend/src/components/BattlefieldGrid.jsx
+++ b/frontend/src/components/BattlefieldGrid.jsx
@@ -1173,7 +1173,7 @@ function BattlefieldGrid({
     <div
       ref={gridContainerRef}
       onClick={handleGridClick}
-      style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: colors.bg.main, overflow: 'hidden' }}
+      style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: colors.bg.main, overflow: 'hidden', touchAction: 'none' }}
     >
       {/*
         panLayerRef: touch-drag pan offset layer. Translates independently of the
@@ -1269,7 +1269,7 @@ function BattlefieldGrid({
         </div>
       )}
 
-      {/* Drag-to-pan hint — only shown on touch devices, fades after first interaction */}
+      {/* Drag-to-pan hint — visible on all devices, useful as a first-use affordance */}
       <div
         style={{
           position: 'absolute', bottom: '28px', right: '6px',

--- a/frontend/src/components/BattlefieldGrid.jsx
+++ b/frontend/src/components/BattlefieldGrid.jsx
@@ -713,6 +713,14 @@ function BattlefieldGrid({
   const cameraRafRef  = useRef(null);
   const [snapState, setSnapState] = useState(null); // triggers re-render on cell boundary cross
 
+  // Touch pan — a separate layer that moves independently of the RAF camera,
+  // so panning doesn't interfere with the smooth camera animation.
+  const panLayerRef = useRef(null);
+  const gridContainerRef = useRef(null);
+  const touchPanRef = useRef({ x: 0, y: 0 }); // current pan offset in pixels
+  const touchStartRef = useRef(null);           // { x, y } of last touch point
+  const panDecayRafRef = useRef(null);
+
   // Resolve effective map size: API value → bounding box of entity positions → 9
   const resolvedMapSize = useMemo(() => {
     if (mapSize && mapSize > 0) return mapSize;
@@ -727,6 +735,76 @@ function BattlefieldGrid({
   // Keep a ref so the RAF loop can read the latest value without being recreated
   const mapSizeRef = useRef(resolvedMapSize);
   useEffect(() => { mapSizeRef.current = resolvedMapSize; }, [resolvedMapSize]);
+
+  // Touch pan handlers — attached via useEffect so touchmove can be non-passive
+  const applyPanTransform = useCallback(() => {
+    if (panLayerRef.current) {
+      const { x, y } = touchPanRef.current;
+      panLayerRef.current.style.transform = `translate(${x.toFixed(1)}px, ${y.toFixed(1)}px)`;
+    }
+  }, []);
+
+  const decayPan = useCallback(() => {
+    const pan = touchPanRef.current;
+    if (Math.abs(pan.x) < 0.5 && Math.abs(pan.y) < 0.5) {
+      touchPanRef.current = { x: 0, y: 0 };
+      applyPanTransform();
+      panDecayRafRef.current = null;
+      return;
+    }
+    touchPanRef.current = { x: pan.x * 0.85, y: pan.y * 0.85 };
+    applyPanTransform();
+    panDecayRafRef.current = requestAnimationFrame(decayPan);
+  }, [applyPanTransform]);
+
+  useEffect(() => {
+    const el = gridContainerRef.current;
+    if (!el) return;
+
+    const onTouchStart = (e) => {
+      if (e.touches.length !== 1) return;
+      if (panDecayRafRef.current) {
+        cancelAnimationFrame(panDecayRafRef.current);
+        panDecayRafRef.current = null;
+      }
+      touchStartRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    };
+
+    const onTouchMove = (e) => {
+      if (!touchStartRef.current || e.touches.length !== 1) return;
+      e.preventDefault();
+      const dx = e.touches[0].clientX - touchStartRef.current.x;
+      const dy = e.touches[0].clientY - touchStartRef.current.y;
+      touchStartRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+
+      // Clamp to ~40% of container dims so the map never flies off-screen
+      const { width, height } = el.getBoundingClientRect();
+      const maxX = width * 0.4;
+      const maxY = height * 0.4;
+      touchPanRef.current = {
+        x: Math.max(-maxX, Math.min(maxX, touchPanRef.current.x + dx)),
+        y: Math.max(-maxY, Math.min(maxY, touchPanRef.current.y + dy)),
+      };
+      applyPanTransform();
+    };
+
+    const onTouchEnd = () => {
+      touchStartRef.current = null;
+      // Smoothly decay pan offset back to (0, 0)
+      if (panDecayRafRef.current) cancelAnimationFrame(panDecayRafRef.current);
+      panDecayRafRef.current = requestAnimationFrame(decayPan);
+    };
+
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    el.addEventListener('touchmove', onTouchMove, { passive: false });
+    el.addEventListener('touchend', onTouchEnd, { passive: true });
+    return () => {
+      el.removeEventListener('touchstart', onTouchStart);
+      el.removeEventListener('touchmove', onTouchMove);
+      el.removeEventListener('touchend', onTouchEnd);
+      if (panDecayRafRef.current) cancelAnimationFrame(panDecayRafRef.current);
+    };
+  }, [applyPanTransform, decayPan]);
 
   const handleGridClick = useCallback((e) => {
     if (e.target === e.currentTarget) setSelectedEntity(null);
@@ -1093,15 +1171,16 @@ function BattlefieldGrid({
 
   return (
     <div
+      ref={gridContainerRef}
       onClick={handleGridClick}
       style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: colors.bg.main, overflow: 'hidden' }}
     >
       {/*
-        contentDivRef receives a sub-cell CSS transform each RAF frame,
-        smoothly sliding the grid between integer snap positions without
-        triggering a React re-render. The outer container clips the overflow
-        so the edges of the map never become visible.
+        panLayerRef: touch-drag pan offset layer. Translates independently of the
+        RAF camera so finger panning doesn't interfere with smooth camera animation.
+        contentDivRef sits inside it and receives the per-frame sub-cell transform.
       */}
+      <div ref={panLayerRef} style={{ position: 'absolute', inset: 0 }}>
       <div ref={contentDivRef} style={{ position: 'absolute', inset: 0, willChange: 'transform' }}>
         {/* Background grid */}
         <div style={{
@@ -1168,9 +1247,10 @@ function BattlefieldGrid({
 
         <DeathAnimationLayer dyingEntities={dyingEntities} getEntityStyle={getEntityStyle} />
       </div>
+      </div>{/* end panLayerRef */}
 
-      {/* SelectedEntityPanel lives outside contentDivRef — it is screen-fixed
-          relative to the grid container and must not be translated with the map. */}
+      {/* SelectedEntityPanel and overlays live outside panLayerRef — screen-fixed
+          relative to the grid container and must not translate with the map. */}
       {selectedEntity && (
         <SelectedEntityPanel
           entity={selectedEntity}
@@ -1188,6 +1268,20 @@ function BattlefieldGrid({
           {` · q${animationQueue.length}`}
         </div>
       )}
+
+      {/* Drag-to-pan hint — only shown on touch devices, fades after first interaction */}
+      <div
+        style={{
+          position: 'absolute', bottom: '28px', right: '6px',
+          zIndex: 140, pointerEvents: 'none',
+          fontSize: '9px', fontFamily: 'monospace',
+          color: 'rgba(255,255,255,0.35)', userSelect: 'none',
+          display: 'flex', alignItems: 'center', gap: '3px',
+        }}
+        aria-label="Drag to pan the map"
+      >
+        <span>drag to pan</span>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/CombatLog.jsx
+++ b/frontend/src/components/CombatLog.jsx
@@ -99,7 +99,9 @@ export default function CombatLog({ log, className = '', allowResize = true, isM
               gap: '4px',
               fontFamily: fonts.main,
               scrollbarWidth: 'thin',
-              scrollbarColor: `${colors.border.main} transparent`
+              scrollbarColor: `${colors.border.main} transparent`,
+              WebkitOverflowScrolling: 'touch',
+              touchAction: 'pan-y',
             }}
           >
             {log?.length === 0 && (

--- a/frontend/src/components/LeftPanel.jsx
+++ b/frontend/src/components/LeftPanel.jsx
@@ -702,6 +702,7 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
             suggestions={combat?.suggested_moves || []}
             suggestionsLoading={combat?.battle_state?.suggestions_loading || combat?.suggestions_loading || false}
             lastOutcome={combat?.last_move_outcome || ""}
+            isMobile={isMobile}
             lastMoveViable={
               Array.isArray(combat?.available_options) &&
               combat.available_options.some(opt => opt.name === combat?.last_move_name && opt.available) &&

--- a/frontend/src/components/SuggestedMovesPanel.jsx
+++ b/frontend/src/components/SuggestedMovesPanel.jsx
@@ -21,7 +21,6 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
 
     // Mobile collapsed view — just a compact tap-to-expand header
     if (isMobile && !mobileExpanded) {
-        const suggCount = suggestionsLoading ? '…' : suggestions.length
         return (
             <div
                 onClick={() => setMobileExpanded(true)}
@@ -59,7 +58,7 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
                             backgroundColor: `${colors.primary}22`,
                             padding: '1px 5px', borderRadius: '8px',
                         }}>
-                            {suggCount} tips
+                            {suggestions.length} tips
                         </span>
                     )}
                     {suggestionsLoading && (

--- a/frontend/src/components/SuggestedMovesPanel.jsx
+++ b/frontend/src/components/SuggestedMovesPanel.jsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react'
 import { colors } from '../styles/theme'
 
-export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoading = false, lastOutcome = "", lastMoveViable = false, onSuggestClick, isPlayerTurn = false, onTargetHover }) {
+export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoading = false, lastOutcome = "", lastMoveViable = false, onSuggestClick, isPlayerTurn = false, onTargetHover, isMobile = false }) {
     const [isVisible, setIsVisible] = useState(false)
     const [hoveredSuggestionName, setHoveredSuggestionName] = useState(null)
     const [hoveredRepeatBtn, setHoveredRepeatBtn] = useState(false)
+    const [mobileExpanded, setMobileExpanded] = useState(false)
 
     useEffect(() => {
         if (isPlayerTurn) {
@@ -12,10 +13,63 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
             return () => clearTimeout(timer)
         } else {
             setIsVisible(false)
+            setMobileExpanded(false)
         }
     }, [isPlayerTurn])
 
     if (!isPlayerTurn) return null
+
+    // Mobile collapsed view — just a compact tap-to-expand header
+    if (isMobile && !mobileExpanded) {
+        const suggCount = suggestionsLoading ? '…' : suggestions.length
+        return (
+            <div
+                onClick={() => setMobileExpanded(true)}
+                style={{
+                    width: '100%',
+                    backgroundColor: 'rgba(10, 15, 10, 0.9)',
+                    border: `1px solid ${colors.primary}66`,
+                    borderRadius: '6px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    padding: '7px 10px',
+                    fontFamily: 'monospace',
+                    cursor: 'pointer',
+                    opacity: isVisible ? 1 : 0,
+                    transition: 'all 0.4s ease-out',
+                    flexShrink: 0,
+                    touchAction: 'manipulation',
+                }}
+            >
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    <div style={{
+                        width: '6px', height: '6px', borderRadius: '50%',
+                        backgroundColor: colors.primary,
+                        boxShadow: `0 0 6px ${colors.primary}`,
+                        animation: 'suggested-blink 1.5s infinite ease-in-out',
+                        flexShrink: 0,
+                    }} />
+                    <span style={{ color: colors.primary, fontWeight: 'bold', fontSize: '11px', letterSpacing: '1px' }}>
+                        TACTICAL ADVISOR
+                    </span>
+                    {!suggestionsLoading && suggestions.length > 0 && (
+                        <span style={{
+                            color: colors.primary, fontSize: '10px',
+                            backgroundColor: `${colors.primary}22`,
+                            padding: '1px 5px', borderRadius: '8px',
+                        }}>
+                            {suggCount} tips
+                        </span>
+                    )}
+                    {suggestionsLoading && (
+                        <span style={{ color: colors.text.muted, fontSize: '10px' }}>analyzing…</span>
+                    )}
+                </div>
+                <span style={{ color: colors.primary, fontSize: '12px', opacity: 0.7 }}>▼</span>
+            </div>
+        )
+    }
 
     return (
         <div style={{
@@ -35,14 +89,19 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
             flexShrink: 0
         }}>
             {/* Header */}
-            <div style={{
-                padding: '12px',
-                backgroundColor: `${colors.primary}22`,
-                borderBottom: `1px solid ${colors.primary}44`,
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px'
-            }}>
+            <div
+                onClick={isMobile ? () => setMobileExpanded(false) : undefined}
+                style={{
+                    padding: '12px',
+                    backgroundColor: `${colors.primary}22`,
+                    borderBottom: `1px solid ${colors.primary}44`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    cursor: isMobile ? 'pointer' : 'default',
+                    touchAction: isMobile ? 'manipulation' : undefined,
+                }}
+            >
                 <div style={{
                     width: '8px',
                     height: '8px',
@@ -51,9 +110,12 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
                     boxShadow: `0 0 8px ${colors.primary}`,
                     animation: 'suggested-blink 1.5s infinite ease-in-out'
                 }} />
-                <span style={{ color: colors.primary, fontWeight: 'bold', fontSize: '14px', letterSpacing: '1px' }}>
+                <span style={{ color: colors.primary, fontWeight: 'bold', fontSize: '14px', letterSpacing: '1px', flex: 1 }}>
                     TACTICAL ADVISOR
                 </span>
+                {isMobile && (
+                    <span style={{ color: colors.primary, fontSize: '12px', opacity: 0.7 }}>▲</span>
+                )}
             </div>
 
             {/* Outcome Section & Repeat Action */}


### PR DESCRIPTION
## Summary
This PR adds touch-based pan/drag gestures to the battlefield grid and improves mobile UI responsiveness across multiple components. The implementation uses a separate pan layer that operates independently of the camera animation system, ensuring smooth interactions without interference.

## Key Changes

**BattlefieldGrid.jsx:**
- Added touch pan layer (`panLayerRef`) that translates independently of the RAF camera animation
- Implemented touch event handlers (touchstart, touchmove, touchend) with momentum decay
- Pan offset is clamped to 40% of container dimensions to prevent the map from flying off-screen
- Added momentum decay animation that smoothly returns pan to (0,0) after touch ends
- Added "drag to pan" hint UI in bottom-right corner as a first-use affordance
- Set `touchAction: 'none'` on grid container to prevent browser default touch behaviors

**SuggestedMovesPanel.jsx:**
- Added `isMobile` prop to enable mobile-specific UI
- Implemented collapsed header view for mobile that shows a compact tap-to-expand button
- Mobile expanded view displays suggestion count and loading state in the header
- Added close button (▲/▼ chevron) in mobile header for collapsing the panel
- Applied `touchAction: 'manipulation'` to interactive elements for better mobile responsiveness

**CombatLog.jsx:**
- Added `WebkitOverflowScrolling: 'touch'` for momentum scrolling on iOS
- Added `touchAction: 'pan-y'` to allow vertical scrolling while preventing horizontal interference

**LeftPanel.jsx:**
- Passed `isMobile` prop to SuggestedMovesPanel component

## Implementation Details

The touch pan system uses three refs to track state:
- `touchPanRef`: Current pan offset in pixels
- `touchStartRef`: Last touch point coordinates
- `panDecayRafRef`: RAF ID for momentum decay animation

The pan layer sits between the grid container and content div, allowing independent translation without affecting the smooth camera animation. Touch move events are non-passive to enable `preventDefault()` for better control. The momentum decay uses a 0.85 multiplier per frame for natural deceleration.

https://claude.ai/code/session_01AVgxxmrdTxghNzJpFg81gA