### PR TITLE
fix(universe): prevent seek_class from walking parent package on dotted names

### DIFF
--- a/src/functions.py
+++ b/src/functions.py
@@ -1060,14 +1060,8 @@ def seek_class(classname, package="all", allow_other_modules=True):
 
     def add_modules_for(base_pkg):
         try:
-            # __import__ for dotted names (e.g. "src.tilesets") returns the top-level package,
-            # so root_pkg.__path__ covers the entire parent directory — intentional when
-            # allow_other_modules=True.  When strict mode is requested, importlib.import_module
-            # returns the exact subpackage so only its own directory is walked.
-            if allow_other_modules:
-                root_pkg = __import__(base_pkg)
-            else:
-                root_pkg = importlib.import_module(base_pkg)
+            # importlib returns the exact subpackage; __import__ returns only the top-level package
+            root_pkg = __import__(base_pkg) if allow_other_modules else importlib.import_module(base_pkg)
             # Walk the package tree recursively to include nested modules (effects, ch01, etc.)
             for modinfo in pkgutil.walk_packages(root_pkg.__path__, prefix=root_pkg.__name__ + "."):  # type: ignore
                 module_paths.add(modinfo.name)

--- a/src/functions.py
+++ b/src/functions.py
@@ -1044,11 +1044,15 @@ def randomize_amount(param):
         return int(param)
 
 
-def seek_class(classname, package="all"):
+def seek_class(classname, package="all", allow_other_modules=True):
     """
     Searches through the requested package(s) and returns the matching class object
     :param str classname: the classname of the desired object as a string
     :param str package: optionally provide the desired package to search, leave default to search all packages
+    :param bool allow_other_modules: when False, restricts the search strictly to the named package.
+        The default (True) uses __import__ which resolves dotted names to the top-level package,
+        so "src.tilesets" walks all of src/; set to False when callers must avoid class-name collisions
+        with unrelated modules in the same root package.
     :return object or None:
     """
     packages = ["story", "tilesets"]
@@ -1056,7 +1060,14 @@ def seek_class(classname, package="all"):
 
     def add_modules_for(base_pkg):
         try:
-            root_pkg = __import__(base_pkg)
+            # __import__ for dotted names (e.g. "src.tilesets") returns the top-level package,
+            # so root_pkg.__path__ covers the entire parent directory — intentional when
+            # allow_other_modules=True.  When strict mode is requested, importlib.import_module
+            # returns the exact subpackage so only its own directory is walked.
+            if allow_other_modules:
+                root_pkg = __import__(base_pkg)
+            else:
+                root_pkg = importlib.import_module(base_pkg)
             # Walk the package tree recursively to include nested modules (effects, ch01, etc.)
             for modinfo in pkgutil.walk_packages(root_pkg.__path__, prefix=root_pkg.__name__ + "."):  # type: ignore
                 module_paths.add(modinfo.name)

--- a/src/resources/maps/eastern-descent.json
+++ b/src/resources/maps/eastern-descent.json
@@ -339,7 +339,7 @@
     },
     "(2, 2)": {
         "id": "tile_2_2",
-        "title": "Hollow",
+        "title": "HollowClearing",
         "description": "The boulders open briefly into a rough oval clearing — not large, but large enough to see the sky directly overhead. The ground here is darker than the surrounding scree: earth and old leaf litter carried by the wind over years. Deep scratches mark the boulders on all sides at roughly hip height.",
         "exits": [
             "north",

--- a/src/universe.py
+++ b/src/universe.py
@@ -207,7 +207,7 @@ class Universe:  # "globals" for the game state can be stored here, as well as a
             title = tile_data.get("title") or tile_data.get("id") or f"tile_{x}_{y}"
             description = tile_data.get("description", "")
             try:
-                tile_cls = functions.seek_class(title, "tilesets")
+                tile_cls = functions.seek_class(title, "tilesets", allow_other_modules=False)
             except Exception:
                 try:
                     tiles_mod = importlib.import_module("tiles")
@@ -366,7 +366,7 @@ class Universe:  # "globals" for the game state can be stored here, as well as a
                 if block_contents:
                     block_list = block_contents.split("|")
                     tile_name = block_list[0]
-                    this_map[(x, y)] = functions.seek_class(tile_name, "tilesets")(
+                    this_map[(x, y)] = functions.seek_class(tile_name, "tilesets", allow_other_modules=False)(
                         self, this_map, x, y
                     )
                     if len(block_list) > 1:

--- a/tests/test_player_core.py
+++ b/tests/test_player_core.py
@@ -53,6 +53,8 @@ class TestPlayerCore:
         target.hp = 100
         target.is_alive.return_value = True
         target.alert_message = "is angry!"
+        target.current_health = 100
+        target.maxhealth = 100
 
         player.current_room.npcs_here = [target]
         player.strength = 10
@@ -70,7 +72,7 @@ class TestPlayerCore:
             with patch('random.randint', return_value=50): # hit_chance = (98-10)+10 = 98. 50 < 98 is a hit.
                 with patch('random.uniform', return_value=1.0):
                     with patch('functions.check_for_combat', return_value=[]):
-                        with patch('combat.combat') as mock_combat_module:
+                        with patch('player._combat.combat.combat') as mock_combat_module:
                             player.attack()
                             assert target.hp < 100
                             assert target.in_combat is True
@@ -732,7 +734,7 @@ class TestPlayerCore:
         assert npc.hidden is False
 
     @patch('builtins.input', return_value='0')
-    @patch('combat.combat')
+    @patch('player._combat.combat.combat')
     @patch('functions.check_for_combat', return_value=[])
     @patch('random.randint', return_value=50)
     @patch('random.uniform', return_value=1.0)
@@ -745,6 +747,8 @@ class TestPlayerCore:
         npc.hp = 20
         npc.is_alive.return_value = True
         npc.alert_message = "attacks!"
+        npc.current_health = 20
+        npc.maxhealth = 20
 
         player.current_room = MagicMock()
         player.current_room.npcs_here = [npc]
@@ -779,6 +783,8 @@ class TestPlayerCore:
         npc.alert_message = "attacks!"
         npc.announce = "A green creature"
         npc.idle_message = ""
+        npc.current_health = 20
+        npc.maxhealth = 20
 
         player.current_room = MagicMock()
         player.current_room.npcs_here = [npc]
@@ -791,7 +797,7 @@ class TestPlayerCore:
         player.finesse = 10
         player.combat_exp = {"Basic": 0}
 
-        with patch('combat.combat') as mock_combat_mod:
+        with patch('player._combat.combat.combat') as mock_combat_mod:
             player.attack(phrase="green")
             assert npc.hp == 5
             mock_combat_mod.assert_called_once_with(player)

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -183,7 +183,7 @@ def test_load_single_json_map(monkeypatch, tmp_path):
             self.items_here = []
             self.npcs_here = []
             self.objects_here = []
-    monkeypatch.setattr(functions, 'seek_class', lambda title, mod: DummyTile)
+    monkeypatch.setattr(functions, 'seek_class', lambda title, mod, **kw: DummyTile)
     # Create dummy map JSON
     map_json = tmp_path / 'testmap.json'
     map_json.write_text('{"(1,2)": {"title": "DummyTile", "description": "desc", "block_exit": ["N"], "symbol": "#", "events": [], "items": [], "npcs": [], "objects": []}}')
@@ -208,7 +208,7 @@ def test_load_tiles(monkeypatch, tmp_path):
         def __init__(self, universe, this_map, x, y):
             self.x = x
             self.y = y
-    monkeypatch.setattr(functions, 'seek_class', lambda name, mod: DummyTile)
+    monkeypatch.setattr(functions, 'seek_class', lambda name, mod, **kw: DummyTile)
     # Create dummy txt file
     txt_path = tmp_path / 'testmap.txt'
     txt_path.write_text('DummyTile\t\n\n')


### PR DESCRIPTION
__import__("src.tilesets") returns the top-level `src` package, not
`src.tilesets`, so root_pkg.__path__ covered the entire src/ directory.
This caused seek_class("Hollow", "tilesets") to find Hollow(Enchantment)
from src/enchant_tables.py (sorted before src/tilesets.*), which then
crashed on map load with "takes 2 positional arguments but 5 were given".

Add allow_other_modules=True parameter to seek_class.  When False,
importlib.import_module is used instead of __import__, returning the
exact subpackage so only its own directory is walked.  Both universe.py
tile-loading callers now pass allow_other_modules=False.

Also rename the "Hollow" tile in eastern-descent.json to "HollowClearing"
as belt-and-suspenders protection against future name collisions.

Closes #137

https://claude.ai/code/session_01MV1ZJcpwp9iiELgcN8v4bT