### PR TITLE
Round damage values in inventory and combat serializers

### DIFF
--- a/frontend/src/components/InventoryDialog.jsx
+++ b/frontend/src/components/InventoryDialog.jsx
@@ -400,7 +400,7 @@ function ItemCard({ item, onClick, isShop }) {
 
       <div style={{ fontSize: '10px', color: colors.text.muted, display: 'flex', justifyContent: 'space-between' }}>
         <span>{item.subtype || item.maintype}</span>
-        {item.damage && <span style={{ color: colors.danger }}>{getItemIcon(item)}{item.damage}</span>}
+        {item.damage && <span style={{ color: colors.danger }}>{getItemIcon(item)}{Math.round(item.damage)}</span>}
         {item.protection && <span style={{ color: colors.text.highlight }}>🛡️{item.protection}</span>}
       </div>
 

--- a/src/api/serializers/combat.py
+++ b/src/api/serializers/combat.py
@@ -351,7 +351,7 @@ class CombatantSerializer:
     def _serialize_combat_stats(combatant: Any) -> Dict[str, Any]:
         """Serialize combat-relevant stats."""
         return {
-            "damage": int(getattr(combatant, "damage", 0)),
+            "damage": round(getattr(combatant, "damage", 0)),
             "armor": int(getattr(combatant, "armor", 0)),
             "speed": int(getattr(combatant, "speed", 5)),
             "accuracy": int(getattr(combatant, "accuracy", 80)),

--- a/src/api/serializers/inventory.py
+++ b/src/api/serializers/inventory.py
@@ -87,7 +87,7 @@ class InventoryItemSerializer:
 
         # Add weapon-specific stats
         if item_type == "Weapon" or maintype == "Weapon":
-            item_data["damage"] = getattr(item, "damage", 0)
+            item_data["damage"] = round(getattr(item, "damage", 0))
             item_data["str_mod"] = getattr(item, "str_mod", 0)
             item_data["fin_mod"] = getattr(item, "fin_mod", 0)
 
@@ -179,7 +179,7 @@ class EquipmentSlotSerializer:
             "item_name": getattr(item, "name", "Unknown"),
             "item_type": item.__class__.__name__,
             "armor": getattr(item, "armor", 0),
-            "damage": getattr(item, "damage", 0),
+            "damage": round(getattr(item, "damage", 0)),
             "weight": getattr(item, "weight", 0.0),
             "value": getattr(item, "value", 0),
             "stat_bonuses": getattr(item, "stat_bonuses", {}),
@@ -309,7 +309,7 @@ class ItemDetailSerializer:
             "can_drop": True,  # Most items can be dropped
             "stats": {
                 "armor": getattr(item, "armor", 0),
-                "damage": getattr(item, "damage", 0),
+                "damage": round(getattr(item, "damage", 0)),
                 "magic_attack": getattr(item, "magic_attack", 0),
                 "magic_defense": getattr(item, "magic_defense", 0),
                 "accuracy": getattr(item, "accuracy", 0),


### PR DESCRIPTION
## Summary
This PR ensures consistent rounding of damage values across the inventory and combat serialization layers, preventing floating-point damage values from being displayed to users.

## Key Changes
- **Backend serializers**: Updated three inventory serialization functions to round damage values using `round()` instead of passing raw float values
  - `inventory.py` line 90: Round damage in weapon-specific stats serialization
  - `inventory.py` line 182: Round damage in slot serialization
  - `inventory.py` line 312: Round damage in item stats serialization
  - `combat.py` line 354: Changed `int()` to `round()` for consistency with inventory serializers

- **Frontend**: Updated `InventoryDialog.jsx` to round damage display using `Math.round()` for consistency with backend values

## Implementation Details
- Uses Python's `round()` function (banker's rounding) on the backend for consistency
- Uses JavaScript's `Math.round()` on the frontend for equivalent behavior
- Maintains backward compatibility by keeping default value of 0 for missing damage attributes
- Ensures damage values are always displayed as integers to users while preserving precision in calculations

https://claude.ai/code/session_0157AL9kVNCN4zpznbtQLRsn