### PR TITLE
Add NomadCamp arrival sequence and post-cleansing pool descriptions

### DIFF
--- a/src/npc/_friends.py
+++ b/src/npc/_friends.py
@@ -523,7 +523,7 @@ class GronditeConclaveElder(Friend):
             )
             time.sleep(1.5)
             print(
-                "He studies him. Then he reaches into the folds of his stone-mantle and "
+                "He studies Jean. Then he reaches into the folds of his stone-mantle and "
                 "produces something: a small disc, cracked cleanly in half, one piece "
                 "missing. He holds it out toward Jean."
             )
@@ -535,27 +535,63 @@ class GronditeConclaveElder(Friend):
             time.sleep(1)
             print(
                 "Jean doesn't know what he is asking. But the broken disc is clearly "
-                "meant to show him."
+                "meant to show him — and the Elder's eyes, fixed on Jean's face, are "
+                "reading something there. Jean's hands. His posture. The weight in him "
+                "that he hasn't put down."
+            )
+            time.sleep(1.5)
+            print(
+                "Whatever he finds, it is not the answer he was hoping for. He doesn't "
+                "react to that — his expression doesn't change — but the disc lowers "
+                "slightly. He makes one short sound: not a dismissal. More like a comma."
+            )
+            time.sleep(1.5)
+            print(
+                "He holds Jean's gaze a moment longer than comfort requires. Then, "
+                "carefully, he folds the broken disc back into his mantle. He turns "
+                "to face the plinth. His back is not a rejection; it is simply where "
+                "he was before Jean arrived."
             )
             time.sleep(1)
             print(
-                "\n[A side quest would begin here — the Elder is looking for a missing "
-                "clan token. This quest is not yet available.]"
-            )
-            time.sleep(0.5)
-            print(
-                "\nThe Elder lowers the broken disc. He makes one short sound — patient, "
-                "not disappointed — and turns back to the plinth."
+                "Jean has the distinct sense that the question is still open. That the "
+                "Elder expects him to come back."
             )
             universe_story = getattr(getattr(player, "universe", None), "story", None)
             if universe_story is not None:
                 universe_story[self._INTRO_RUN_KEY] = "1"
+                universe_story["conclave_elder_disc_acknowledged"] = "1"
         else:
             lines = [
-                "The Elder turns and regards Jean for a moment. Then he produces the broken "
-                "disc again and holds it in the space between them.",
-                "The Elder makes the same rising sound as before. The question hasn't changed.",
-                "The Elder looks at Jean. Looks at the plinth. Looks at Jean again.",
+                (
+                    "The Elder turns when Jean enters. He produces the broken disc without "
+                    "preamble and holds it in the space between them. The question hasn't "
+                    "changed."
+                ),
+                (
+                    "The Elder regards Jean for a moment — unhurried, attentive. Then he "
+                    "reaches into his mantle and shows Jean the disc again. He makes the "
+                    "same rising sound as before."
+                ),
+                (
+                    "The Elder doesn't speak. He simply holds up the broken disc. His eyes "
+                    "find Jean's face with the patience of someone who has been waiting far "
+                    "longer than this visit."
+                ),
+                (
+                    "He produces the disc. He looks at Jean. He looks at the plinth. He "
+                    "looks at Jean again. The disc remains extended, one half of something "
+                    "that should be whole."
+                ),
+                (
+                    "The Elder turns as Jean approaches. He makes a low sound — not the "
+                    "question again, not exactly, but a variant of it. The disc is already "
+                    "in his hand."
+                ),
+                (
+                    "He holds up the broken disc. Jean still doesn't know where the missing "
+                    "piece is. The Elder still believes Jean is the one to find it."
+                ),
             ]
             print(random.choice(lines))
 

--- a/src/resources/maps/eastern-descent.json
+++ b/src/resources/maps/eastern-descent.json
@@ -844,7 +844,22 @@
             "east"
         ],
         "block_exit": [],
-        "events": [],
+        "events": [
+            {
+                "__class__": "NomadCampArrivalEvent",
+                "__module__": "story.ch03",
+                "props": {
+                    "name": "NomadCampArrival",
+                    "player": null,
+                    "tile": null,
+                    "repeat": false,
+                    "thread": null,
+                    "has_run": false,
+                    "params": null,
+                    "referenceobj": null
+                }
+            }
+        ],
         "items": [],
         "npcs": [
             {

--- a/src/story/ch02.py
+++ b/src/story/ch02.py
@@ -674,9 +674,83 @@ class AfterDefeatingKingSlime(Event):
         )
         time.sleep(1)
 
-        # TODO: All of the map tiles referencing active corruption or "rumbling" (in reference to the now-defeated King Slime) need to get revised descriptions to match the present state of affairs.
+        self._cleanse_pool_tiles(self.player, current_map)
 
         self.tile.remove_event(self.name)
+
+    def _cleanse_pool_tiles(self, player, current_map):
+        """Update corrupted channel tile descriptions to reflect the post-cleansing state.
+
+        Physical damage (acid pitting, dissolved floors, staining) persists as geological
+        evidence. Active slime, living corruption, and all rumbling references are gone.
+        """
+        cleansed = {
+            (2, 2): (
+                "The colour has returned. Where the channels ran green, they run clear now — "
+                "milky-blue, lit from below, moving with quiet purpose. The walls carry the "
+                "memory of what was here: a dark tide line, scored stone, old acid pitting. "
+                "The air is cold and mineral-clean. The crevice on the west wall is visible "
+                "now, no longer obscured — a thin gap breathing the same clean air as the "
+                "rest of the passage."
+            ),
+            (3, 2): (
+                "The walkway holds. The channel below is clear — mineral water moving slowly "
+                "east, washing over stone that shows where the slime ate in: pitting, softened "
+                "edges, the marks of something that fed here for a long time. To the east, the "
+                "sealed chamber is silent now. Whatever was feeding there is gone."
+            ),
+            (4, 2): (
+                "The pocket has drained. Walls that were sheeted in thick slime are bare — "
+                "acid-scored and stained, but bare. A stone shelf juts from the east wall, "
+                "its surface worn smooth. Whatever this room was before the infestation, it "
+                "is only an empty chamber now: still, cold, smelling of mineral water and "
+                "old stone."
+            ),
+            (2, 3): (
+                "The walkway is intact. Below it, the pool is clear — deep blue, faintly "
+                "luminous, the same light as the atrium above. The acid pitting on the walls "
+                "hasn't changed; the dissolution is old work, stone already spent. Above: "
+                "silence. Whatever was nesting in the ceiling has gone. The rumbling from "
+                "the south is gone too. It is quiet here in a way it wasn't before."
+            ),
+            (3, 3): (
+                "The wider cavern is still. The dissolution is visible — the walls stripped "
+                "back to raw mineral where the slime ate through centuries of accumulated "
+                "stone — but the slime itself is gone. The chamber is deep and cold and very "
+                "quiet. The far wall is bare."
+            ),
+            (4, 3): (
+                "The low chamber is unchanged by the cleansing — the ceiling is still "
+                "collapsed, the rubble still fills half the floor. The old slime residue has "
+                "dried to a thin dark crust on the stone: harmless, inert, the ghost of a "
+                "longer infestation. The collapsed section exposes raw mineral beneath, "
+                "unchanged. It is quiet here. It was quiet here before too."
+            ),
+            (2, 4): (
+                "The passage is as narrow as ever — the walls close to arm's width for a "
+                "long stretch — but the slime that coated them is gone, leaving bare stone "
+                "that shows where it was: long staining, dissolution marks where it ran "
+                "thickest. The south end opens into a larger space. No rumbling. No sound "
+                "at all except Jean's footsteps and the faint movement of water."
+            ),
+            (3, 4): (
+                "The floor is still dissolved — the passage still crosses stone islands "
+                "above where the slime ate through — but the water between them is clear "
+                "now: cold, still, faintly luminous. The high-water mark is still visible: "
+                "a clean band of stone above the old slime line, dissolution below. It is "
+                "just water now."
+            ),
+            (2, 5): (
+                "The passage is open and still. The walls are bare stone — stained where "
+                "the slime reached, but bare. The rumbling is gone. Jean's footsteps land "
+                "without answer. The passage south opens into a large space: blue-white "
+                "light, clean water, the quiet aftermath of something enormous being undone."
+            ),
+        }
+        for coords, description in cleansed.items():
+            if coords in current_map.tiles:
+                tile = current_map.tiles[coords]
+                tile.spawn_object("TileDescription", player, tile, description=description)
 
 
 class Ch02FragmentReminder(Event):

--- a/src/story/ch03.py
+++ b/src/story/ch03.py
@@ -2,8 +2,8 @@
 Chapter 03 events
 """
 
-from src.events import Event
-from src.functions import print_slow
+from src.events import Event, dialogue
+from src.functions import print_slow, await_input
 from neotermcolor import colored
 import time
 
@@ -88,3 +88,176 @@ class EasternRoadTurnbackEvent(Event):
                 self.player.current_tile = universe.tiles.get(
                     (4, 2), self.player.current_tile
                 )
+
+
+class NomadCampArrivalEvent(Event):
+    """
+    Fires once on Jean's first entry to the NomadCamp tile (2,5) on the Eastern Descent.
+    Introduces Mara, Devet, and Liss. Sets story gate 'nomad_camp_reached'.
+    Gorran is present throughout but non-verbal.
+    Source: docs/lore/story/ch02-ch03-transition.md, Beat 4.
+    """
+
+    def __init__(
+        self,
+        player,
+        tile,
+        params=None,
+        repeat=False,
+        name="NomadCampArrival",
+    ):
+        super().__init__(
+            name=name, player=player, tile=tile, repeat=repeat, params=params
+        )
+
+    def check_conditions(self):
+        story = getattr(getattr(self.player, "universe", None), "story", {})
+        if story.get("nomad_camp_reached") == "1":
+            if self in self.tile.events_here:
+                self.tile.events_here.remove(self)
+            return
+        self.pass_conditions_to_process()
+
+    def process(self):
+        if self.player.skip_dialog:
+            self._set_gate()
+            return
+
+        print("\n")
+        time.sleep(0.5)
+        print_slow(
+            "Jean smells the camp before he sees it — woodsmoke, dried meat, the particular "
+            "warmth of a fire that has been maintained rather than lit. The sound of the river "
+            "is constant behind it.",
+            delay=0.03,
+        )
+        time.sleep(1)
+        print_slow(
+            "A woman is watching them from the camp's edge. She clocked them while they were "
+            "still fifty paces out — Jean is sure of it — but by the time he reaches the fire "
+            "ring she is already back to what she was doing, crouched over a pack, sorting "
+            "something with methodical attention.",
+            delay=0.03,
+        )
+        time.sleep(1)
+        print_slow(
+            "The camp is neat. Lean-tos of oiled canvas over light poles, angled correctly "
+            "against the prevailing wind. A fire built in an established ring, its stones "
+            "black with years of use. These are people who know how to be somewhere without "
+            "being of it.",
+            delay=0.03,
+        )
+        time.sleep(1.5)
+        await_input()
+
+        print_slow(
+            "The woman doesn't look up. Her eyes find Jean for one flat second — taking in "
+            "his gear, his bearing, the large stone figure standing slightly behind him — "
+            "and return to the pack.",
+            delay=0.03,
+        )
+        time.sleep(1)
+        dialogue("Mara", "Crossing west?", "cyan")
+        time.sleep(0.5)
+        print_slow("Not a greeting. A question with a purpose.", delay=0.04)
+        time.sleep(1)
+        print_slow(
+            "When Jean says yes, she names a number. Flat, fair, not open to discussion. "
+            "She doesn't look up when she says it. She's already back to the pack before "
+            "the last word has settled.",
+            delay=0.03,
+        )
+        time.sleep(1.5)
+        await_input()
+
+        print_slow(
+            "An older man is tending the fire — unhurried, each movement economical in the "
+            "way of someone who has done this ten thousand times. He gives Jean one look "
+            "when Jean approaches: the look of someone who has seen desperate people cross "
+            "this river before, heading west, and knows most of them aren't running toward "
+            "something.",
+            delay=0.03,
+        )
+        time.sleep(1.5)
+        print_slow(
+            "He doesn't offer this observation aloud. He picks up a bowl and fills it from "
+            "the pot and holds it out. It is not a question.",
+            delay=0.04,
+        )
+        time.sleep(1)
+        print_slow(
+            "Gorran stands where Jean left him, still, watching the fire without watching "
+            "it. His presence has settled into the camp's edge the way large stones settle: "
+            "without effort, without apology.",
+            delay=0.03,
+        )
+        time.sleep(1.5)
+        await_input()
+
+        print_slow(
+            "A girl — young, dark-haired, openly curious — is at the camp's far edge. She "
+            "is not approaching Gorran. She is simply standing at a distance that is "
+            "technically not approaching, watching him with the focused intensity of someone "
+            "doing serious research.",
+            delay=0.03,
+        )
+        time.sleep(1)
+        print_slow(
+            "She asks Mara something in a low voice. Something about Golemites. Whether "
+            "they sleep. Whether they eat. Whether the sound they make is a language or "
+            "just a sound.",
+            delay=0.03,
+        )
+        time.sleep(1)
+        print_slow(
+            "Gorran can almost certainly hear her. He gives no indication of this. He "
+            "allows her attention with the patient forbearance of a very old, very large "
+            "thing being studied by a small one.",
+            delay=0.03,
+        )
+        time.sleep(1.5)
+        await_input()
+
+        # Equipment-conditional character-pinning exchange
+        has_mace = any(
+            item.__class__.__name__ == "Mace" for item in self.player.inventory
+        )
+        print_slow(
+            "A while later — Jean is sitting with the bowl, Gorran nearby, the fire "
+            "between them and the river — Mara speaks without looking up from what she "
+            "is sorting.",
+            delay=0.03,
+        )
+        time.sleep(1)
+        if has_mace:
+            print_slow(
+                "Her eyes track to Jean's mace for just a moment. Then back to her work.",
+                delay=0.04,
+            )
+            time.sleep(0.5)
+            dialogue("Mara", "That's religious kit.", "cyan")
+        else:
+            print_slow(
+                "Her eyes move across Jean — his posture, his hands, the way his weight "
+                "sits — and return to her work.",
+                delay=0.04,
+            )
+            time.sleep(0.5)
+            dialogue("Mara", "You were a man of the church.", "cyan")
+        time.sleep(0.5)
+        print_slow("Not a question.", delay=0.05)
+        time.sleep(1)
+        dialogue("Jean", "It was.", "white")
+        time.sleep(1)
+        print_slow(
+            "She doesn't follow up. She files it. The sorting continues.",
+            delay=0.04,
+        )
+        time.sleep(1.5)
+
+        self._set_gate()
+
+    def _set_gate(self):
+        story = getattr(getattr(self.player, "universe", None), "story", None)
+        if story is not None:
+            story["nomad_camp_reached"] = "1"

--- a/src/story/ch03.py
+++ b/src/story/ch03.py
@@ -247,7 +247,7 @@ class NomadCampArrivalEvent(Event):
         time.sleep(0.5)
         print_slow("Not a question.", delay=0.05)
         time.sleep(1)
-        dialogue("Jean", "It was.", "white")
+        dialogue("Jean", "It was.", "cyan")
         time.sleep(1)
         print_slow(
             "She doesn't follow up. She files it. The sorting continues.",


### PR DESCRIPTION
## Summary
This PR adds narrative content for Chapter 3's nomad camp encounter and updates the corrupted channel tiles to reflect the post-cleansing state of the underground pools. It also includes refinements to the Conclave Elder's dialogue sequence.

## Key Changes

- **New NomadCampArrivalEvent class** (`src/story/ch03.py`): Implements the first encounter at the nomad camp (tile 2,5 on Eastern Descent), introducing characters Mara, Devet, and Liss while Gorran observes silently. The event:
  - Fires once on first entry and sets the `nomad_camp_reached` story gate
  - Features conditional dialogue based on whether the player has a mace (religious equipment)
  - Uses slow-printed narrative prose with atmospheric descriptions
  - Respects the `skip_dialog` flag for speedrunning

- **Pool tile cleansing descriptions** (`src/story/ch02.py`): Added `_cleanse_pool_tiles()` method that updates 9 corrupted channel tiles with post-cleansing descriptions. These descriptions:
  - Preserve geological evidence (acid pitting, dissolved stone, staining)
  - Remove all active corruption, slime, and rumbling references
  - Reflect the restored clarity and silence of the channels

- **Conclave Elder dialogue expansion** (`src/npc/_friends.py`): Enhanced the Elder's interaction sequence:
  - Expanded initial encounter with more detailed narrative and character observation
  - Added repeat visit dialogue lines with varied approaches to the same question
  - Sets new story gate `conclave_elder_disc_acknowledged` to track quest acknowledgment
  - Improved prose quality and character consistency ("him" → "Jean")

- **Eastern Descent map update** (`src/resources/maps/eastern-descent.json`): Registered the NomadCampArrivalEvent on tile (2,5)

- **Import additions** (`src/story/ch03.py`): Added `dialogue` function import and `await_input` function import to support the new event's narrative flow

https://claude.ai/code/session_01KdJbFPQEP26mfGYxzc44bn