### PR TITLE
Remove power attribute from amber lump item

### DIFF
--- a/src/items.py
+++ b/src/items.py
@@ -3540,7 +3540,6 @@ class DriedCrystalSap(Consumable):
             maintype="Consumable",
             subtype="Natural",
             discovery_message="a small waxy amber lump!",
-            power=20,
         )
         self.merchandise = False
         self.interactions = ["use", "drop"]


### PR DESCRIPTION
## Summary
Removed the `power=20` attribute from the amber lump consumable item initialization.

## Changes
- Removed the `power=20` parameter from the amber lump item's `__init__` method

## Details
The amber lump item (a natural consumable) previously had a power value of 20 assigned during initialization. This attribute has been removed, likely to adjust the item's balance or because the power attribute is no longer used for this item type.

https://claude.ai/code/session_01GZNbez33sBTWM8B8sc8JyH