### PR TITLE
Auto-scroll room description to top on location change

### DIFF
--- a/frontend/src/components/CollapsibleRoomDescription.jsx
+++ b/frontend/src/components/CollapsibleRoomDescription.jsx
@@ -1,9 +1,16 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import RoomContents from './RoomContents'
 import { colors, fonts, accessibility } from '../styles/theme'
 
 export default function CollapsibleRoomDescription({ location, onInteract, defaultOpen = true }) {
   const [isOpen, setIsOpen] = useState(defaultOpen)
+  const scrollContainerRef = useRef(null)
+
+  useEffect(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = 0
+    }
+  }, [location?.id])
 
   if (!location) return null
 
@@ -46,7 +53,7 @@ export default function CollapsibleRoomDescription({ location, onInteract, defau
       </button>
 
       {isOpen && (
-        <div style={{ maxHeight: '200px', overflowY: 'auto' }}>
+        <div ref={scrollContainerRef} style={{ maxHeight: '200px', overflowY: 'auto' }}>
           <RoomContents location={location} onInteract={onInteract} />
         </div>
       )}

--- a/frontend/src/components/CollapsibleRoomDescription.jsx
+++ b/frontend/src/components/CollapsibleRoomDescription.jsx
@@ -7,10 +7,10 @@ export default function CollapsibleRoomDescription({ location, onInteract, defau
   const scrollContainerRef = useRef(null)
 
   useEffect(() => {
-    if (scrollContainerRef.current) {
+    if (isOpen && scrollContainerRef.current) {
       scrollContainerRef.current.scrollTop = 0
     }
-  }, [location?.id])
+  }, [location, isOpen])
 
   if (!location) return null
 

--- a/frontend/src/components/CollapsibleRoomDescription.test.jsx
+++ b/frontend/src/components/CollapsibleRoomDescription.test.jsx
@@ -58,4 +58,15 @@ describe('CollapsibleRoomDescription', () => {
     render(<CollapsibleRoomDescription location={{ description: 'Some place.' }} defaultOpen={true} />)
     expect(screen.getByText('Current Location')).toBeDefined()
   })
+
+  it('scrolls description to top when location changes', () => {
+    const { rerender } = render(<CollapsibleRoomDescription location={{ id: 'loc1', name: 'Grotto 1', description: 'First location' }} defaultOpen={true} />)
+    const scrollContainer = screen.getByTestId('room-contents').parentElement
+    scrollContainer.scrollTop = 100
+    expect(scrollContainer.scrollTop).toBe(100)
+
+    rerender(<CollapsibleRoomDescription location={{ id: 'loc2', name: 'Grotto 2', description: 'Second location' }} defaultOpen={true} />)
+
+    expect(scrollContainer.scrollTop).toBe(0)
+  })
 })


### PR DESCRIPTION
## Summary
Added automatic scroll-to-top functionality for the collapsible room description component when the user navigates to a different location.

## Key Changes
- Added `useRef` and `useEffect` hooks to `CollapsibleRoomDescription` component
- Implemented a `useEffect` hook that resets scroll position to 0 whenever the `location` or `isOpen` state changes
- Attached a ref to the scrollable container div to enable programmatic scroll control
- Added test case to verify scroll position resets when location changes

## Implementation Details
- The scroll container ref is attached to the div with `maxHeight: '200px'` and `overflowY: 'auto'`
- The effect only executes the scroll reset when `isOpen` is true and the ref is available, preventing unnecessary operations
- The dependency array includes both `location` and `isOpen` to handle location changes and panel reopening scenarios

https://claude.ai/code/session_01MXZsW8zZGSiLAhiRWe15iA