### PR TITLE
Strip destination tile description from teleportation interaction output

### DIFF
--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -1317,6 +1317,11 @@ class GameService:
                 "message": f"Cannot {action} this target.",
             }
 
+        # Record pre-action location to detect passageway teleportation
+        _pre_map_name = player.map.get("name") if player.map else None
+        _pre_x = player.location_x
+        _pre_y = player.location_y
+
         # Execute action and capture output
         f = io.StringIO()
         events_triggered = []
@@ -1462,6 +1467,16 @@ class GameService:
             r"\n\s*\n", "\n", clean_output
         )  # Replace multiple newlines with single
         clean_output = clean_output.strip()
+
+        # If a teleport occurred, strip the destination tile's description from the
+        # interaction output — the frontend fetches the new room via /world/current-room.
+        _post_map_name = player.map.get("name") if player.map else None
+        if _post_map_name != _pre_map_name or player.location_x != _pre_x or player.location_y != _pre_y:
+            dest_tile = player.universe.get_tile(player.location_x, player.location_y)
+            if dest_tile and hasattr(dest_tile, "description"):
+                dest_desc = ansi_escape.sub("", dest_tile.description).strip()
+                if dest_desc:
+                    clean_output = clean_output.replace(dest_desc, "").strip()
 
         # Strip internal LLM diagnostic lines that must never reach the UI.
         pre_filter_output = clean_output


### PR DESCRIPTION
## Summary
This change improves the user experience when interacting with passageway tiles that trigger teleportation. The frontend already fetches the new room details via `/world/current-room`, so the destination tile's description is now stripped from the interaction output to avoid duplication.

## Key Changes
- Added pre-action location tracking (map name, x, y coordinates) before executing the interaction
- Added post-action location comparison to detect if teleportation occurred
- When teleportation is detected, the destination tile's description is removed from the interaction output
- ANSI escape codes are stripped from the destination description before matching to ensure reliable removal

## Implementation Details
- The destination tile description is fetched from the universe and cleaned of ANSI formatting before removal
- The check handles cases where the player's map, x, or y coordinate changes, indicating teleportation
- This prevents the destination description from appearing twice in the UI (once in the interaction output and once when the frontend loads the new room)

https://claude.ai/code/session_017XRpoS1cXDPQSGnp7SbBKo