### PR TITLE
Improve article handling for teleport messages and tile naming

### DIFF
--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -256,6 +256,8 @@ class GameService:
                 bgm = "verdette_caverns"
             elif "mineral" in name_lower:
                 bgm = "mineral_pools"
+            elif "grondia" in name_lower:
+                bgm = "grondia"
         return bgm
 
     def _calculate_exits(

--- a/src/objects.py
+++ b/src/objects.py
@@ -835,7 +835,18 @@ class Passageway(Object):
             for event in self.events_before:
                 event.process()
         if self.teleport_map and self.teleport_tile:
-            print(f"Jean steps through the {self.name.lower()}...")
+            # Build a natural article phrase.
+            # Possessives (Jambo's Tent) are proper nouns — no article.
+            # Names already starting with "The" strip the duplicate and preserve rest.
+            # Generic noun phrases (Archive Door, Tent Flap) get "the " prepended.
+            _n = self.name
+            if "'" in _n:
+                _ref = _n
+            elif _n.lower().startswith("the "):
+                _ref = f"the {_n[4:]}"
+            else:
+                _ref = f"the {_n.lower()}"
+            print(f"Jean steps through {_ref}...")
             time.sleep(0.5)
             player.teleport(self.teleport_map, self.teleport_tile)
             if self.events_after:

--- a/src/universe.py
+++ b/src/universe.py
@@ -215,6 +215,10 @@ class Universe:  # "globals" for the game state can be stored here, as well as a
                 except Exception:
                     from tiles import MapTile as tile_cls  # fallback
             tile_instance = tile_cls(self, this_map, x, y)
+            # Store tile name from JSON title; only if the class didn't set its own.
+            # MapTile.__init__ never sets self.name, so getattr returns None for generic tiles.
+            if not getattr(tile_instance, "name", None):
+                tile_instance.name = title
             # Override description from JSON only if one was provided (tile subclasses
             # may hardcode their own description via super().__init__; respect that as default)
             if description:


### PR DESCRIPTION
## Summary
This PR improves the user-facing text and tile naming system by implementing smarter article handling for teleport messages and ensuring generic tiles receive proper names from their JSON definitions.

## Key Changes

- **Enhanced teleport message grammar**: Replaced hardcoded "the" article with intelligent article selection that:
  - Preserves possessive names (e.g., "Jambo's Tent") without articles
  - Handles names already starting with "The" by stripping the duplicate
  - Prepends "the" to generic noun phrases (e.g., "the archive door")

- **Automatic tile naming from JSON**: Generic tile instances now receive their `name` attribute from the JSON `title` field if the tile class doesn't define its own name, ensuring consistent naming across the game world

- **BGM mapping expansion**: Added "Grondia" location to the background music resolution logic for proper audio context

## Implementation Details

The article logic in `objects.py` checks for possessives first (apostrophes), then handles "The" prefix specially to avoid duplication, and defaults to lowercase with "the" prepended. The tile naming in `universe.py` only assigns the JSON title if the tile instance doesn't already have a name set, respecting hardcoded values from tile subclasses.

https://claude.ai/code/session_01DWx1rrSkaajKchXWnGxBWW