### PR TITLE
Add shop dialog UI and API endpoints for merchant transactions

### DIFF
--- a/config_shop_testing.ini
+++ b/config_shop_testing.ini
@@ -1,0 +1,8 @@
+[game]
+testmode            = True
+skipdialog          = True
+skipintro           = True
+startmap            = shop-testing
+startposition       = (0, 0)
+starting_gold       = 200
+starting_equipment  = Shortsword:0, LeatherArmor:0

--- a/docs/development/jambo-shop-dialog-mockup.html
+++ b/docs/development/jambo-shop-dialog-mockup.html
@@ -1,0 +1,1136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Jambo Shop Dialog — Mockup</title>
+<style>
+  /* ── Design Tokens (from theme.js) ─────────────────────── */
+  :root {
+    --primary:      #00ff88;
+    --primary-20:   #00ff8833;
+    --primary-10:   #00ff881A;
+    --secondary:    #ffaa00;
+    --secondary-10: #ffaa001A;
+    --danger:       #ff4444;
+    --danger-10:    #ff44441A;
+    --gold:         #ffcc00;
+    --accent:       #00ccff;
+    --bg-main:      #0a0a0a;
+    --bg-panel:     rgba(0,0,0,0.4);
+    --bg-overlay:   rgba(0,0,0,0.75);
+    --text-main:    #e0e0e0;
+    --text-muted:   #888888;
+    --text-bright:  #ffffff;
+    --text-warning: #ffcc88;
+    --text-dim:     #666666;
+    --border-main:  rgba(255,170,0,0.3);
+    --border-light: rgba(255,170,0,0.1);
+    --font:         'Courier New', monospace;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    background: var(--bg-main);
+    font-family: var(--font);
+    color: var(--text-main);
+    padding: 40px 20px;
+  }
+
+  /* ── Page Layout ───────────────────────────────────────── */
+  .page-header {
+    text-align: center;
+    margin-bottom: 48px;
+  }
+  .page-header h1 {
+    color: var(--gold);
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    letter-spacing: 3px;
+    margin-bottom: 6px;
+  }
+  .page-header p {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+  }
+
+  .section {
+    margin-bottom: 64px;
+  }
+  .section-label {
+    color: var(--secondary);
+    font-size: 0.7rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    border-bottom: 1px solid var(--border-main);
+    padding-bottom: 6px;
+    margin-bottom: 24px;
+  }
+  .annotation {
+    color: var(--secondary);
+    font-size: 0.7rem;
+    margin-top: 14px;
+    padding: 10px 14px;
+    background: rgba(255,170,0,0.05);
+    border-left: 2px solid var(--secondary);
+    border-radius: 0 4px 4px 0;
+    line-height: 1.6;
+  }
+
+  /* ── Fake Game Background ───────────────────────────────── */
+  .game-bg {
+    position: relative;
+    background:
+      radial-gradient(ellipse at 20% 50%, rgba(0,255,136,0.04) 0%, transparent 50%),
+      radial-gradient(ellipse at 80% 20%, rgba(0,204,255,0.03) 0%, transparent 50%),
+      repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 2px,
+        rgba(255,255,255,0.01) 2px,
+        rgba(255,255,255,0.01) 4px
+      ),
+      #0a0a0a;
+    border: 1px solid rgba(255,255,255,0.05);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    min-height: 520px;
+  }
+
+  /* ── Modal Shell (mirrors BaseDialog) ──────────────────── */
+  .modal-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0,0,0,0.75);
+    backdrop-filter: blur(3px);
+    border-radius: 8px;
+  }
+  .modal {
+    width: 90%;
+    max-width: 620px;
+    background: var(--bg-main);
+    border: 3px solid var(--primary);
+    border-radius: 8px;
+    padding: 16px;
+    box-shadow: 0 0 20px rgba(0,255,136,0.4);
+    font-family: var(--font);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-height: 86vh;
+  }
+
+  /* ── Dialog Header ──────────────────────────────────────── */
+  .modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 2px solid rgba(0,255,136,0.25);
+    padding-bottom: 10px;
+  }
+  .modal-title {
+    font-size: 1.1rem;
+    font-weight: bold;
+    color: var(--primary);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+  .modal-subtitle {
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    margin-top: 2px;
+    font-style: italic;
+  }
+  .close-btn {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.3rem;
+    cursor: pointer;
+    padding: 4px 6px;
+    border-radius: 4px;
+    line-height: 1;
+    transition: color 0.2s;
+  }
+  .close-btn:hover { color: var(--text-warning); }
+
+  /* ── NPC Strip ──────────────────────────────────────────── */
+  .npc-strip {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    background: rgba(0,204,255,0.05);
+    border: 1px solid rgba(0,204,255,0.2);
+    border-radius: 6px;
+  }
+  .npc-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #2a1a00, #3d2800);
+    border: 2px solid var(--gold);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.3rem;
+    flex-shrink: 0;
+    box-shadow: 0 0 8px rgba(255,204,0,0.3);
+  }
+  .npc-info { flex: 1; }
+  .npc-name {
+    color: var(--accent);
+    font-size: 0.8rem;
+    font-weight: bold;
+  }
+  .npc-tagline {
+    color: var(--text-muted);
+    font-size: 0.65rem;
+    font-style: italic;
+    margin-top: 2px;
+  }
+  .player-gold {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--gold);
+    font-size: 0.85rem;
+    font-weight: bold;
+  }
+
+  /* ── Tab Bar ────────────────────────────────────────────── */
+  .tab-bar {
+    display: flex;
+    gap: 4px;
+    background: rgba(0,0,0,0.3);
+    padding: 4px;
+    border-radius: 6px;
+    border: 1px solid var(--border-main);
+  }
+  .tab-btn {
+    flex: 1;
+    padding: 7px 12px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: var(--text-muted);
+    font-family: var(--font);
+    font-size: 0.75rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    cursor: pointer;
+    transition: all 0.2s;
+    text-align: center;
+  }
+  .tab-btn.active {
+    background: rgba(0,255,136,0.12);
+    border-color: var(--primary);
+    color: var(--primary);
+  }
+  .tab-btn:not(.active):hover {
+    background: rgba(255,255,255,0.04);
+    border-color: var(--border-main);
+    color: var(--text-main);
+  }
+  .tab-btn.sell-active {
+    background: rgba(255,170,0,0.12);
+    border-color: var(--secondary);
+    color: var(--secondary);
+  }
+
+  /* ── Item List ──────────────────────────────────────────── */
+  .item-list {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    overflow: hidden;
+    flex: 1;
+  }
+  .item-list-header {
+    display: grid;
+    grid-template-columns: 2fr 60px 70px 90px;
+    gap: 0;
+    padding: 6px 14px;
+    background: rgba(0,0,0,0.5);
+    border-bottom: 1px solid var(--border-main);
+  }
+  .item-list-header span {
+    color: var(--text-dim);
+    font-size: 0.6rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+  .item-list-header span:nth-child(2),
+  .item-list-header span:nth-child(3),
+  .item-list-header span:nth-child(4) {
+    text-align: right;
+  }
+
+  .item-row {
+    display: grid;
+    grid-template-columns: 2fr 60px 70px 90px;
+    gap: 0;
+    align-items: center;
+    padding: 10px 14px;
+    border-bottom: 1px solid rgba(255,170,0,0.08);
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .item-row:last-child { border-bottom: none; }
+  .item-row:hover {
+    background: rgba(0,255,136,0.05);
+  }
+  .item-row.selected {
+    background: rgba(0,255,136,0.1);
+    border-left: 3px solid var(--primary);
+    padding-left: 11px;
+  }
+  .item-row.selected-danger {
+    background: rgba(255,68,68,0.08);
+    border-left: 3px solid var(--danger);
+    padding-left: 11px;
+  }
+  .item-row.sell-selected {
+    background: rgba(255,170,0,0.1);
+    border-left: 3px solid var(--secondary);
+    padding-left: 11px;
+  }
+
+  .item-name {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.82rem;
+    color: var(--text-main);
+    font-weight: 500;
+  }
+  .item-icon { font-size: 1rem; line-height: 1; }
+  .item-name .qty-badge {
+    font-size: 0.6rem;
+    background: rgba(255,204,0,0.2);
+    color: var(--gold);
+    border: 1px solid rgba(255,204,0,0.3);
+    padding: 1px 5px;
+    border-radius: 8px;
+    font-weight: bold;
+  }
+
+  .item-weight {
+    text-align: right;
+    font-size: 0.72rem;
+    color: var(--text-muted);
+  }
+  .item-type {
+    text-align: right;
+    font-size: 0.65rem;
+    color: var(--text-dim);
+    text-transform: uppercase;
+  }
+  .item-price {
+    text-align: right;
+    font-size: 0.8rem;
+    font-weight: bold;
+    color: var(--gold);
+  }
+  .item-price .offer-label {
+    font-size: 0.6rem;
+    color: var(--text-muted);
+    font-weight: normal;
+    display: block;
+    margin-bottom: 1px;
+  }
+  .item-price.cant-afford {
+    color: var(--danger);
+  }
+
+  /* ── Action Row (below selected item) ─────────────────── */
+  .action-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    background: rgba(0,255,136,0.05);
+    border-top: 1px solid rgba(0,255,136,0.2);
+    border-radius: 0 0 8px 8px;
+    gap: 12px;
+  }
+  .action-row.sell-action {
+    background: rgba(255,170,0,0.05);
+    border-top-color: rgba(255,170,0,0.2);
+  }
+  .action-row.danger-action {
+    background: rgba(255,68,68,0.05);
+    border-top-color: rgba(255,68,68,0.2);
+  }
+  .action-item-name {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+  .action-item-name strong {
+    color: var(--text-main);
+    display: block;
+    font-size: 0.82rem;
+  }
+  .btn {
+    padding: 7px 20px;
+    border-radius: 5px;
+    font-family: var(--font);
+    font-size: 0.75rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    cursor: pointer;
+    border: none;
+    transition: all 0.2s;
+    white-space: nowrap;
+  }
+  .btn-buy {
+    background: rgba(0,255,136,0.2);
+    border: 2px solid var(--primary);
+    color: var(--primary);
+  }
+  .btn-buy:hover {
+    background: rgba(0,255,136,0.35);
+    box-shadow: 0 0 10px rgba(0,255,136,0.3);
+  }
+  .btn-sell {
+    background: rgba(255,170,0,0.2);
+    border: 2px solid var(--secondary);
+    color: var(--secondary);
+  }
+  .btn-sell:hover {
+    background: rgba(255,170,0,0.35);
+    box-shadow: 0 0 10px rgba(255,170,0,0.3);
+  }
+  .btn-disabled {
+    background: rgba(255,68,68,0.08);
+    border: 2px solid rgba(255,68,68,0.3);
+    color: rgba(255,68,68,0.5);
+    cursor: not-allowed;
+  }
+  .cant-afford-msg {
+    font-size: 0.65rem;
+    color: var(--danger);
+    margin-top: 3px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  /* ── Quantity Picker ────────────────────────────────────── */
+  .qty-picker {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(0,0,0,0.4);
+    border: 1px solid rgba(0,255,136,0.3);
+    border-radius: 6px;
+    padding: 4px 8px;
+  }
+  .qty-step-btn {
+    width: 26px;
+    height: 26px;
+    border-radius: 4px;
+    border: 1px solid rgba(0,255,136,0.4);
+    background: rgba(0,255,136,0.1);
+    color: var(--primary);
+    font-size: 1rem;
+    font-weight: bold;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s;
+    font-family: var(--font);
+    line-height: 1;
+  }
+  .qty-step-btn:hover {
+    background: rgba(0,255,136,0.25);
+  }
+  .qty-input {
+    width: 38px;
+    text-align: center;
+    background: rgba(0,0,0,0.5);
+    border: 1px solid rgba(0,255,136,0.3);
+    border-radius: 3px;
+    color: var(--text-bright);
+    font-family: var(--font);
+    font-size: 0.85rem;
+    font-weight: bold;
+    padding: 3px 4px;
+  }
+  .qty-max {
+    font-size: 0.6rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+  .qty-total {
+    font-size: 0.65rem;
+    color: var(--gold);
+    margin-left: 4px;
+    white-space: nowrap;
+  }
+
+  /* ── Sell Tab Merchant Gold ─────────────────────────────── */
+  .merch-gold-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 7px 12px;
+    background: rgba(255,170,0,0.06);
+    border: 1px solid rgba(255,170,0,0.2);
+    border-radius: 6px;
+    font-size: 0.72rem;
+  }
+  .merch-gold-bar .label { color: var(--text-muted); }
+  .merch-gold-bar .amount { color: var(--gold); font-weight: bold; }
+  .merch-gold-note { color: var(--text-dim); font-size: 0.62rem; }
+
+  /* ── Divider ────────────────────────────────────────────── */
+  .divider {
+    border: none;
+    border-top: 1px dashed rgba(255,255,255,0.07);
+    margin: 4px 0;
+  }
+
+  /* ─────────────────────────────────────────────────────────
+     STANDALONE CLOSE-UPS (outside the game bg)
+  ───────────────────────────────────────────────────────── */
+  .closeup-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+  }
+  .closeup-card {
+    background: #111;
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    padding: 14px;
+  }
+  .closeup-title {
+    color: var(--text-muted);
+    font-size: 0.6rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    margin-bottom: 10px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border-light);
+  }
+</style>
+</head>
+<body>
+
+<div class="page-header">
+  <h1>Jambo Shop Dialog — UI Mockup</h1>
+  <p>Heart of Virtue · Retro Terminal Design Language · Branch: claude/jambo-shop-ui-mockup-I2uda</p>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════
+     STATE 1: BUY TAB — Default Browsing
+══════════════════════════════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">State 1 — Buy Tab: Default Browsing (Antidote selected)</div>
+
+  <div class="game-bg" style="min-height:600px;">
+    <div class="modal-overlay">
+      <div class="modal">
+
+        <!-- Header -->
+        <div class="modal-header">
+          <div>
+            <div class="modal-title">🏪 Jambo Heals U</div>
+            <div class="modal-subtitle">Apothecary &amp; Consumables</div>
+          </div>
+          <button class="close-btn">✕</button>
+        </div>
+
+        <!-- NPC Strip -->
+        <div class="npc-strip">
+          <div class="npc-avatar">🧕</div>
+          <div class="npc-info">
+            <div class="npc-name">Jambo</div>
+            <div class="npc-tagline">"When you blue, Jambo Heals U!"</div>
+          </div>
+          <div class="player-gold">💰 42</div>
+        </div>
+
+        <!-- Tab Bar -->
+        <div class="tab-bar">
+          <button class="tab-btn active">⬇ Buy</button>
+          <button class="tab-btn">⬆ Sell</button>
+        </div>
+
+        <!-- Item List -->
+        <div class="item-list">
+          <div class="item-list-header">
+            <span>Item</span>
+            <span>Type</span>
+            <span>Weight</span>
+            <span>Price</span>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">🧪</span> Restorative <span class="qty-badge">×4</span></div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.2 kg</div>
+            <div class="item-price">30 💰</div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">💧</span> Draught</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.1 kg</div>
+            <div class="item-price">15 💰</div>
+          </div>
+
+          <div class="item-row selected">
+            <div class="item-name"><span class="item-icon">💊</span> Antidote</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.2 kg</div>
+            <div class="item-price">20 💰</div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">🌿</span> Salve</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.3 kg</div>
+            <div class="item-price">45 💰</div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">💉</span> Elixir</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.4 kg</div>
+            <div class="item-price">80 💰</div>
+          </div>
+
+          <!-- Action Row (expands when row is selected) -->
+          <div class="action-row">
+            <div class="action-item-name">
+              Selected:
+              <strong>💊 Antidote</strong>
+            </div>
+            <button class="btn btn-buy">Buy · 20 💰</button>
+          </div>
+        </div>
+
+      </div><!-- /modal -->
+    </div><!-- /overlay -->
+  </div><!-- /game-bg -->
+
+  <div class="annotation">
+    <strong>Layout:</strong> Modal mirrors BaseDialog — fixed overlay, blur(3px), #0a0a0a bg, 3px solid #00ff88 border, glow.<br>
+    <strong>NPC strip:</strong> Jambo's name + tagline + player gold pinned to top-right. Cyan accent border (items.entities.npc).<br>
+    <strong>Tab bar:</strong> Horizontal (Buy / Sell). Active tab: lime bg + border. Inactive: muted.<br>
+    <strong>Item rows:</strong> Click any row → highlights with lime left-border (3px) + tinted bg. Action row expands at list bottom.<br>
+    <strong>Buy button:</strong> Shows selected item name + price inline. Lime border/text. Hover: brighter + glow.
+  </div>
+</div>
+
+
+<!-- ══════════════════════════════════════════════════════════
+     STATE 2: BUY TAB — Insufficient Gold
+══════════════════════════════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">State 2 — Buy Tab: Insufficient Gold (Elixir selected, costs 80 💰, player has 42 💰)</div>
+
+  <div class="game-bg" style="min-height:600px;">
+    <div class="modal-overlay">
+      <div class="modal">
+
+        <div class="modal-header">
+          <div>
+            <div class="modal-title">🏪 Jambo Heals U</div>
+            <div class="modal-subtitle">Apothecary &amp; Consumables</div>
+          </div>
+          <button class="close-btn">✕</button>
+        </div>
+
+        <div class="npc-strip">
+          <div class="npc-avatar">🧕</div>
+          <div class="npc-info">
+            <div class="npc-name">Jambo</div>
+            <div class="npc-tagline">"When you blue, Jambo Heals U!"</div>
+          </div>
+          <div class="player-gold" style="color: var(--danger);">💰 42</div>
+        </div>
+
+        <div class="tab-bar">
+          <button class="tab-btn active">⬇ Buy</button>
+          <button class="tab-btn">⬆ Sell</button>
+        </div>
+
+        <div class="item-list">
+          <div class="item-list-header">
+            <span>Item</span>
+            <span>Type</span>
+            <span>Weight</span>
+            <span>Price</span>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">🧪</span> Restorative <span class="qty-badge">×4</span></div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.2 kg</div>
+            <div class="item-price">30 💰</div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">💧</span> Draught</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.1 kg</div>
+            <div class="item-price">15 💰</div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">💊</span> Antidote</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.2 kg</div>
+            <div class="item-price">20 💰</div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">🌿</span> Salve</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.3 kg</div>
+            <div class="item-price">45 💰</div>
+          </div>
+
+          <!-- Selected but can't afford -->
+          <div class="item-row selected-danger">
+            <div class="item-name"><span class="item-icon">💉</span> Elixir</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.4 kg</div>
+            <div class="item-price cant-afford">80 💰</div>
+          </div>
+
+          <!-- Action row — disabled state -->
+          <div class="action-row danger-action">
+            <div>
+              <div class="action-item-name">
+                Selected:
+                <strong>💉 Elixir</strong>
+              </div>
+              <div class="cant-afford-msg">⚠ Not enough gold (need 38 more)</div>
+            </div>
+            <button class="btn btn-disabled" disabled>Buy · 80 💰</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <div class="annotation">
+    <strong>Trigger:</strong> Player gold (42) &lt; item price (80).<br>
+    <strong>Visual signals:</strong> (1) Selected row gets danger red left-border instead of lime. (2) Price text turns red. (3) Player gold display turns red. (4) Action row background is red-tinted. (5) Buy button is disabled: grey border, muted text, cursor:not-allowed.<br>
+    <strong>Message:</strong> "Not enough gold (need N more)" — N = price − player_gold. Orange warning icon. No dismiss needed — automatically clears when selection changes.
+  </div>
+</div>
+
+
+<!-- ══════════════════════════════════════════════════════════
+     STATE 3: BUY TAB — Quantity Picker
+══════════════════════════════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">State 3 — Buy Tab: Quantity Picker (Restorative ×4 in stock, buying 2)</div>
+
+  <div class="game-bg" style="min-height:600px;">
+    <div class="modal-overlay">
+      <div class="modal">
+
+        <div class="modal-header">
+          <div>
+            <div class="modal-title">🏪 Jambo Heals U</div>
+            <div class="modal-subtitle">Apothecary &amp; Consumables</div>
+          </div>
+          <button class="close-btn">✕</button>
+        </div>
+
+        <div class="npc-strip">
+          <div class="npc-avatar">🧕</div>
+          <div class="npc-info">
+            <div class="npc-name">Jambo</div>
+            <div class="npc-tagline">"When you blue, Jambo Heals U!"</div>
+          </div>
+          <div class="player-gold">💰 42</div>
+        </div>
+
+        <div class="tab-bar">
+          <button class="tab-btn active">⬇ Buy</button>
+          <button class="tab-btn">⬆ Sell</button>
+        </div>
+
+        <div class="item-list">
+          <div class="item-list-header">
+            <span>Item</span>
+            <span>Type</span>
+            <span>Weight</span>
+            <span>Price ea.</span>
+          </div>
+
+          <!-- Selected stackable item -->
+          <div class="item-row selected">
+            <div class="item-name"><span class="item-icon">🧪</span> Restorative <span class="qty-badge">×4</span></div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.2 kg</div>
+            <div class="item-price">30 💰</div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">💧</span> Draught</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.1 kg</div>
+            <div class="item-price">15 💰</div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">💊</span> Antidote</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.2 kg</div>
+            <div class="item-price">20 💰</div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">🌿</span> Salve</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.3 kg</div>
+            <div class="item-price">45 💰</div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">💉</span> Elixir</div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.4 kg</div>
+            <div class="item-price">80 💰</div>
+          </div>
+
+          <!-- Quantity Picker Action Row -->
+          <div class="action-row">
+            <div class="action-item-name">
+              🧪 Restorative
+              <div style="margin-top:4px; display:flex; align-items:center; gap:6px;">
+                <div class="qty-picker">
+                  <button class="qty-step-btn">−</button>
+                  <input class="qty-input" type="number" value="2" min="1" max="4" readonly>
+                  <button class="qty-step-btn">+</button>
+                  <span class="qty-max">/ 4</span>
+                </div>
+                <span class="qty-total">= 60 💰</span>
+              </div>
+            </div>
+            <button class="btn btn-buy">Buy 2 · 60 💰</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <div class="annotation">
+    <strong>Trigger:</strong> Player clicks a stackable item row (item.quantity &gt; 1 in merchant stock).<br>
+    <strong>Quantity picker:</strong> Appears inline in the action row. − button (min 1) / + button (max = stock count). Input field accepts direct edit. Live total = qty × price_ea shown beside picker.<br>
+    <strong>Buy button:</strong> Updates label live: "Buy N · total_cost 💰". Checks affordability at each qty change — disables if total exceeds player gold.<br>
+    <strong>Single items</strong> (qty = 1) skip the picker and show the standard Buy button directly.
+  </div>
+</div>
+
+
+<!-- ══════════════════════════════════════════════════════════
+     STATE 4: SELL TAB — Player Items
+══════════════════════════════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">State 4 — Sell Tab: Player Inventory with 50% Offer Prices (Iron Dagger selected)</div>
+
+  <div class="game-bg" style="min-height:640px;">
+    <div class="modal-overlay">
+      <div class="modal">
+
+        <div class="modal-header">
+          <div>
+            <div class="modal-title">🏪 Jambo Heals U</div>
+            <div class="modal-subtitle">Apothecary &amp; Consumables</div>
+          </div>
+          <button class="close-btn">✕</button>
+        </div>
+
+        <!-- NPC strip w/ Jambo's gold -->
+        <div class="npc-strip" style="border-color: rgba(255,170,0,0.3); background: rgba(255,170,0,0.05);">
+          <div class="npc-avatar">🧕</div>
+          <div class="npc-info">
+            <div class="npc-name" style="color: var(--secondary);">Jambo</div>
+            <div class="npc-tagline">Sell your goods — Jambo pays fair!</div>
+          </div>
+          <div class="player-gold">💰 42</div>
+        </div>
+
+        <!-- Tab Bar (Sell active) -->
+        <div class="tab-bar">
+          <button class="tab-btn">⬇ Buy</button>
+          <button class="tab-btn sell-active">⬆ Sell</button>
+        </div>
+
+        <!-- Merchant gold bar -->
+        <div class="merch-gold-bar">
+          <span class="label">Jambo's gold:</span>
+          <span class="amount">800 💰</span>
+          <span class="merch-gold-note">Max single purchase Jambo can make</span>
+        </div>
+
+        <!-- Item List (player's sellable items) -->
+        <div class="item-list">
+          <div class="item-list-header" style="grid-template-columns: 2fr 60px 70px 90px;">
+            <span>Your Item</span>
+            <span>Type</span>
+            <span>Weight</span>
+            <span>Offer</span>
+          </div>
+
+          <!-- Selected item -->
+          <div class="item-row sell-selected">
+            <div class="item-name"><span class="item-icon">🗡️</span> Iron Dagger</div>
+            <div class="item-type">Dagger</div>
+            <div class="item-weight">0.5 kg</div>
+            <div class="item-price" style="color: var(--secondary);">
+              <span class="offer-label">Offer:</span>
+              12 💰
+            </div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">🧪</span> Restorative <span class="qty-badge">×2</span></div>
+            <div class="item-type">Potion</div>
+            <div class="item-weight">0.2 kg</div>
+            <div class="item-price" style="color: var(--secondary);">
+              <span class="offer-label">Offer ea.:</span>
+              15 💰
+            </div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">🥩</span> Ration</div>
+            <div class="item-type">Food</div>
+            <div class="item-weight">0.1 kg</div>
+            <div class="item-price" style="color: var(--secondary);">
+              <span class="offer-label">Offer:</span>
+              3 💰
+            </div>
+          </div>
+
+          <div class="item-row">
+            <div class="item-name"><span class="item-icon">🍵</span> Bitter Leaf Tea</div>
+            <div class="item-type">Tonic</div>
+            <div class="item-weight">0.15 kg</div>
+            <div class="item-price" style="color: var(--secondary);">
+              <span class="offer-label">Offer:</span>
+              8 💰
+            </div>
+          </div>
+
+          <!-- Action row (sell) -->
+          <div class="action-row sell-action">
+            <div>
+              <div class="action-item-name">
+                Selling:
+                <strong>🗡️ Iron Dagger</strong>
+              </div>
+              <div style="font-size:0.62rem; color:var(--text-dim); margin-top:2px;">
+                Value 25 💰 → Jambo offers 50% = 12 💰
+              </div>
+            </div>
+            <button class="btn btn-sell">Sell · +12 💰</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <div class="annotation">
+    <strong>Tab switch:</strong> Sell tab uses orange accent (--secondary) instead of lime throughout — tab border, NPC strip border, selected row border, action row tint, sell button.<br>
+    <strong>Offer pricing:</strong> Each row shows "Offer:" sub-label + 50% of item value (base_sell_modifier = 0.5). Full value not displayed — only the offer.<br>
+    <strong>Merchant gold bar:</strong> Shows Jambo's current gold. If player tries to sell an item worth more than Jambo's gold, sell button disables with "Jambo can't afford this" message.<br>
+    <strong>Sell button:</strong> "+12 💰" with plus sign reinforces that player receives gold. Orange border/text to match sell context.<br>
+    <strong>Non-sellable items</strong> (quest items, equipped items) are greyed out with a 🔒 badge and non-clickable.
+  </div>
+</div>
+
+
+<!-- ══════════════════════════════════════════════════════════
+     CLOSE-UP: Component Details
+══════════════════════════════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">Component Close-ups &amp; Dimensions</div>
+
+  <div class="closeup-grid">
+
+    <!-- Item row states -->
+    <div class="closeup-card">
+      <div class="closeup-title">Item Row — All States</div>
+      <!-- Default -->
+      <div class="item-row" style="border-radius:6px 6px 0 0;">
+        <div class="item-name"><span class="item-icon">💧</span> Draught</div>
+        <div class="item-type">Potion</div>
+        <div class="item-weight">0.1 kg</div>
+        <div class="item-price">15 💰</div>
+      </div>
+      <!-- Hover (simulated) -->
+      <div class="item-row" style="background:rgba(0,255,136,0.05);">
+        <div class="item-name"><span class="item-icon">💊</span> Antidote</div>
+        <div class="item-type">Potion</div>
+        <div class="item-weight">0.2 kg</div>
+        <div class="item-price">20 💰</div>
+      </div>
+      <!-- Selected buy -->
+      <div class="item-row selected">
+        <div class="item-name"><span class="item-icon">🌿</span> Salve</div>
+        <div class="item-type">Potion</div>
+        <div class="item-weight">0.3 kg</div>
+        <div class="item-price">45 💰</div>
+      </div>
+      <!-- Selected + can't afford -->
+      <div class="item-row selected-danger">
+        <div class="item-name"><span class="item-icon">💉</span> Elixir</div>
+        <div class="item-type">Potion</div>
+        <div class="item-weight">0.4 kg</div>
+        <div class="item-price cant-afford">80 💰</div>
+      </div>
+      <!-- Sell selected -->
+      <div class="item-row sell-selected" style="border-radius:0 0 6px 6px; border-bottom:none;">
+        <div class="item-name"><span class="item-icon">🗡️</span> Iron Dagger</div>
+        <div class="item-type">Dagger</div>
+        <div class="item-weight">0.5 kg</div>
+        <div class="item-price" style="color:var(--secondary);">12 💰</div>
+      </div>
+      <div style="margin-top:8px; font-size:0.6rem; color:var(--text-dim); line-height:1.5;">
+        Row height: ~44px · Left border: 3px · Grid: 2fr 60px 70px 90px
+      </div>
+    </div>
+
+    <!-- Button states -->
+    <div class="closeup-card">
+      <div class="closeup-title">Action Buttons — All States</div>
+      <div style="display:flex; flex-direction:column; gap:10px; margin-top:4px;">
+        <button class="btn btn-buy">Buy · 20 💰</button>
+        <button class="btn btn-buy">Buy 2 · 60 💰</button>
+        <button class="btn btn-disabled" disabled>Buy · 80 💰</button>
+        <button class="btn btn-sell">Sell · +12 💰</button>
+        <div style="font-size:0.6rem; color:var(--text-dim); margin-top:4px; line-height:1.5;">
+          Buy: #00ff88 border/text, rgba(0,255,136,0.2) bg<br>
+          Sell: #ffaa00 border/text, rgba(255,170,0,0.2) bg<br>
+          Disabled: rgba(255,68,68,0.3) border, muted red text
+        </div>
+      </div>
+    </div>
+
+    <!-- Qty picker -->
+    <div class="closeup-card">
+      <div class="closeup-title">Quantity Picker — Close-up</div>
+      <div style="padding: 10px 0;">
+        <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+          <div class="qty-picker">
+            <button class="qty-step-btn">−</button>
+            <input class="qty-input" type="number" value="2" readonly>
+            <button class="qty-step-btn">+</button>
+            <span class="qty-max">/ 4</span>
+          </div>
+          <span class="qty-total">= 60 💰</span>
+        </div>
+      </div>
+      <div style="font-size:0.6rem; color:var(--text-dim); margin-top:8px; line-height:1.6;">
+        Appears in action row when item.quantity &gt; 1<br>
+        Buttons: 26×26px, lime border, rgba(0,255,136,0.1) bg<br>
+        Input: 38px wide, direct keyboard edit supported<br>
+        Max: merchant stock qty · Min: 1<br>
+        Total updates live on every change
+      </div>
+    </div>
+
+    <!-- Jambo gold bar -->
+    <div class="closeup-card">
+      <div class="closeup-title">Merchant Gold Bar (Sell Tab only)</div>
+      <div style="margin-top:8px;">
+        <div class="merch-gold-bar">
+          <span class="label">Jambo's gold:</span>
+          <span class="amount">800 💰</span>
+          <span class="merch-gold-note">Max he can pay</span>
+        </div>
+        <!-- Low gold variant -->
+        <div class="merch-gold-bar" style="margin-top:8px; border-color:rgba(255,68,68,0.3); background:rgba(255,68,68,0.05);">
+          <span class="label">Jambo's gold:</span>
+          <span class="amount" style="color:var(--danger);">8 💰</span>
+          <span class="merch-gold-note" style="color:rgba(255,68,68,0.6);">Jambo is running low</span>
+        </div>
+      </div>
+      <div style="font-size:0.6rem; color:var(--text-dim); margin-top:10px; line-height:1.6;">
+        Normal: orange accent border<br>
+        Low (&lt; 50gp): switches to danger red accent<br>
+        Jambo starts with 800 gold (from npc config)
+      </div>
+    </div>
+
+  </div><!-- /closeup-grid -->
+
+  <div class="annotation" style="margin-top:16px;">
+    <strong>All close-ups above</strong> are lifted directly from the states shown above — same CSS, no modifications. Use these as the reference when implementing React components.
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════
+     Color / Token Reference
+══════════════════════════════════════════════════════════ -->
+<div class="section">
+  <div class="section-label">Shop-Specific Color Mapping</div>
+  <div style="display:grid; grid-template-columns: repeat(auto-fill, minmax(200px,1fr)); gap:12px;">
+    <div class="closeup-card" style="display:flex; align-items:center; gap:12px;">
+      <div style="width:32px;height:32px;border-radius:4px;background:#00ff88;flex-shrink:0;"></div>
+      <div>
+        <div style="font-size:0.75rem;font-weight:bold;">#00ff88 — Primary</div>
+        <div style="font-size:0.6rem;color:var(--text-muted);">Buy tab, selected row, buy button</div>
+      </div>
+    </div>
+    <div class="closeup-card" style="display:flex; align-items:center; gap:12px;">
+      <div style="width:32px;height:32px;border-radius:4px;background:#ffaa00;flex-shrink:0;"></div>
+      <div>
+        <div style="font-size:0.75rem;font-weight:bold;">#ffaa00 — Secondary</div>
+        <div style="font-size:0.6rem;color:var(--text-muted);">Sell tab, offer prices, sell button</div>
+      </div>
+    </div>
+    <div class="closeup-card" style="display:flex; align-items:center; gap:12px;">
+      <div style="width:32px;height:32px;border-radius:4px;background:#ffcc00;flex-shrink:0;"></div>
+      <div>
+        <div style="font-size:0.75rem;font-weight:bold;">#ffcc00 — Gold</div>
+        <div style="font-size:0.6rem;color:var(--text-muted);">Player gold, item prices, qty totals</div>
+      </div>
+    </div>
+    <div class="closeup-card" style="display:flex; align-items:center; gap:12px;">
+      <div style="width:32px;height:32px;border-radius:4px;background:#ff4444;flex-shrink:0;"></div>
+      <div>
+        <div style="font-size:0.75rem;font-weight:bold;">#ff4444 — Danger</div>
+        <div style="font-size:0.6rem;color:var(--text-muted);">Can't afford state, disabled button</div>
+      </div>
+    </div>
+    <div class="closeup-card" style="display:flex; align-items:center; gap:12px;">
+      <div style="width:32px;height:32px;border-radius:4px;background:#00ccff;flex-shrink:0;"></div>
+      <div>
+        <div style="font-size:0.75rem;font-weight:bold;">#00ccff — Accent</div>
+        <div style="font-size:0.6rem;color:var(--text-muted);">NPC name, NPC strip border</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/docs/development/jambo-shop-dialog-mockup.html
+++ b/docs/development/jambo-shop-dialog-mockup.html
@@ -3,30 +3,35 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Jambo Shop Dialog — Mockup</title>
+<title>Jambo Shop Dialog — UI Mockup (Rev 2)</title>
 <style>
   /* ── Design Tokens (from theme.js) ─────────────────────── */
   :root {
-    --primary:      #00ff88;
-    --primary-20:   #00ff8833;
-    --primary-10:   #00ff881A;
-    --secondary:    #ffaa00;
-    --secondary-10: #ffaa001A;
-    --danger:       #ff4444;
-    --danger-10:    #ff44441A;
-    --gold:         #ffcc00;
-    --accent:       #00ccff;
-    --bg-main:      #0a0a0a;
-    --bg-panel:     rgba(0,0,0,0.4);
-    --bg-overlay:   rgba(0,0,0,0.75);
-    --text-main:    #e0e0e0;
-    --text-muted:   #888888;
-    --text-bright:  #ffffff;
-    --text-warning: #ffcc88;
-    --text-dim:     #666666;
-    --border-main:  rgba(255,170,0,0.3);
-    --border-light: rgba(255,170,0,0.1);
-    --font:         'Courier New', monospace;
+    --primary:       #00ff88;
+    --primary-10:    rgba(0,255,136,0.10);
+    --primary-20:    rgba(0,255,136,0.20);
+    --secondary:     #ffaa00;
+    --secondary-10:  rgba(255,170,0,0.10);
+    --secondary-20:  rgba(255,170,0,0.20);
+    --danger:        #ff4444;
+    --danger-10:     rgba(255,68,68,0.10);
+    --danger-20:     rgba(255,68,68,0.20);
+    --accent:        #00ccff;
+    --accent-10:     rgba(0,204,255,0.10);
+    --accent-20:     rgba(0,204,255,0.20);
+    --accent-40:     rgba(0,204,255,0.40);
+    --gold:          #ffcc00;
+    --bg-main:       #0a0a0a;
+    --bg-panel:      rgba(0,0,0,0.40);
+    --border-main:   rgba(255,170,0,0.30);
+    --border-light:  rgba(255,170,0,0.10);
+    --text-main:     #e0e0e0;
+    --text-muted:    #888888;
+    --text-bright:   #ffffff;
+    --text-warning:  #ffcc88;
+    --text-dim:      #666666;
+    --text-danger:   #ffaaaa;
+    --font:          'Courier New', monospace;
   }
 
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -36,6 +41,17 @@
     font-family: var(--font);
     color: var(--text-main);
     padding: 40px 20px;
+  }
+
+  /* ── Spinner removal for number inputs ─────────────────── */
+  input[type=number]::-webkit-inner-spin-button,
+  input[type=number]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  input[type=number] {
+    -moz-appearance: textfield;
+    appearance: textfield;
   }
 
   /* ── Page Layout ───────────────────────────────────────── */
@@ -50,14 +66,18 @@
     letter-spacing: 3px;
     margin-bottom: 6px;
   }
+  .page-header .rev {
+    color: var(--primary);
+    font-size: 0.7rem;
+    font-weight: bold;
+    margin-bottom: 4px;
+  }
   .page-header p {
     color: var(--text-muted);
-    font-size: 0.75rem;
+    font-size: 0.72rem;
   }
 
-  .section {
-    margin-bottom: 64px;
-  }
+  .section { margin-bottom: 64px; }
   .section-label {
     color: var(--secondary);
     font-size: 0.7rem;
@@ -86,11 +106,8 @@
       radial-gradient(ellipse at 20% 50%, rgba(0,255,136,0.04) 0%, transparent 50%),
       radial-gradient(ellipse at 80% 20%, rgba(0,204,255,0.03) 0%, transparent 50%),
       repeating-linear-gradient(
-        0deg,
-        transparent,
-        transparent 2px,
-        rgba(255,255,255,0.01) 2px,
-        rgba(255,255,255,0.01) 4px
+        0deg, transparent, transparent 2px,
+        rgba(255,255,255,0.01) 2px, rgba(255,255,255,0.01) 4px
       ),
       #0a0a0a;
     border: 1px solid rgba(255,255,255,0.05);
@@ -99,10 +116,10 @@
     align-items: center;
     justify-content: center;
     padding: 24px;
-    min-height: 520px;
+    min-height: 580px;
   }
 
-  /* ── Modal Shell (mirrors BaseDialog) ──────────────────── */
+  /* ── Modal Shell ────────────────────────────────────────── */
   .modal-overlay {
     position: absolute;
     inset: 0;
@@ -124,8 +141,8 @@
     font-family: var(--font);
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    max-height: 86vh;
+    gap: 10px;
+    max-height: 88vh;
   }
 
   /* ── Dialog Header ──────────────────────────────────────── */
@@ -144,7 +161,7 @@
     letter-spacing: 1px;
   }
   .modal-subtitle {
-    font-size: 0.65rem;
+    font-size: 0.62rem;
     color: var(--text-muted);
     margin-top: 2px;
     font-style: italic;
@@ -157,10 +174,8 @@
     cursor: pointer;
     padding: 4px 6px;
     border-radius: 4px;
-    line-height: 1;
-    transition: color 0.2s;
+    font-family: var(--font);
   }
-  .close-btn:hover { color: var(--text-warning); }
 
   /* ── NPC Strip ──────────────────────────────────────────── */
   .npc-strip {
@@ -168,81 +183,106 @@
     align-items: center;
     gap: 12px;
     padding: 8px 12px;
-    background: rgba(0,204,255,0.05);
+    background: var(--accent-10);
     border: 1px solid rgba(0,204,255,0.2);
     border-radius: 6px;
   }
   .npc-avatar {
-    width: 40px;
-    height: 40px;
+    width: 40px; height: 40px;
     border-radius: 50%;
     background: linear-gradient(135deg, #2a1a00, #3d2800);
     border: 2px solid var(--gold);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.3rem;
-    flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.3rem; flex-shrink: 0;
     box-shadow: 0 0 8px rgba(255,204,0,0.3);
   }
   .npc-info { flex: 1; }
-  .npc-name {
-    color: var(--accent);
-    font-size: 0.8rem;
-    font-weight: bold;
-  }
-  .npc-tagline {
-    color: var(--text-muted);
-    font-size: 0.65rem;
-    font-style: italic;
-    margin-top: 2px;
-  }
+  .npc-name { color: var(--accent); font-size: 0.8rem; font-weight: bold; }
+  .npc-tagline { color: var(--text-muted); font-size: 0.62rem; font-style: italic; margin-top: 2px; }
   .player-gold {
+    display: flex; align-items: center; gap: 6px;
+    color: var(--gold); font-size: 0.85rem; font-weight: bold;
+    white-space: nowrap;
+  }
+
+  /* ── Weight Bar ─────────────────────────────────────────── */
+  .weight-bar-wrap {
+    padding: 8px 12px;
+    background: rgba(0,0,0,0.3);
+    border: 1px solid var(--border-main);
+    border-radius: 6px;
     display: flex;
-    align-items: center;
-    gap: 6px;
-    color: var(--gold);
-    font-size: 0.85rem;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .weight-bar-labels {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: 0.65rem;
+  }
+  .weight-bar-labels .wleft {
+    color: var(--text-muted);
+    display: flex; align-items: center; gap: 5px;
+  }
+  .weight-bar-labels .wleft .val { color: var(--text-main); font-weight: bold; }
+  .weight-bar-labels .wleft .pending-val {
+    color: var(--secondary);
     font-weight: bold;
   }
+  .weight-bar-labels .wmax { color: var(--text-dim); }
+
+  .weight-bar-track {
+    width: 100%;
+    height: 8px;
+    background: rgba(255,255,255,0.06);
+    border-radius: 4px;
+    overflow: hidden;
+    display: flex;
+  }
+  .weight-bar-fill {
+    height: 100%;
+    border-radius: 4px 0 0 4px;
+    transition: width 0.3s ease;
+    flex-shrink: 0;
+  }
+  .weight-bar-pending {
+    height: 100%;
+    flex-shrink: 0;
+  }
+  /* Color states for fill bar */
+  .fill-ok    { background: var(--primary); box-shadow: 0 0 4px rgba(0,255,136,0.4); }
+  .fill-warn  { background: var(--secondary); box-shadow: 0 0 4px rgba(255,170,0,0.4); }
+  .fill-over  { background: var(--danger); box-shadow: 0 0 4px rgba(255,68,68,0.4); }
+  .pending-ok { background: rgba(255,170,0,0.7); }
+  .pending-over { background: rgba(255,68,68,0.8); }
 
   /* ── Tab Bar ────────────────────────────────────────────── */
   .tab-bar {
-    display: flex;
-    gap: 4px;
+    display: flex; gap: 4px;
     background: rgba(0,0,0,0.3);
     padding: 4px;
     border-radius: 6px;
     border: 1px solid var(--border-main);
   }
   .tab-btn {
-    flex: 1;
-    padding: 7px 12px;
+    flex: 1; padding: 7px 12px;
     background: transparent;
     border: 1px solid transparent;
     border-radius: 4px;
     color: var(--text-muted);
     font-family: var(--font);
-    font-size: 0.75rem;
-    font-weight: bold;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    cursor: pointer;
-    transition: all 0.2s;
-    text-align: center;
+    font-size: 0.75rem; font-weight: bold;
+    text-transform: uppercase; letter-spacing: 1px;
+    cursor: pointer; text-align: center;
   }
-  .tab-btn.active {
-    background: rgba(0,255,136,0.12);
+  .tab-btn.active-buy {
+    background: var(--primary-10);
     border-color: var(--primary);
     color: var(--primary);
   }
-  .tab-btn:not(.active):hover {
-    background: rgba(255,255,255,0.04);
-    border-color: var(--border-main);
-    color: var(--text-main);
-  }
-  .tab-btn.sell-active {
-    background: rgba(255,170,0,0.12);
+  .tab-btn.active-sell {
+    background: var(--secondary-10);
     border-color: var(--secondary);
     color: var(--secondary);
   }
@@ -253,301 +293,235 @@
     border: 1px solid var(--border-main);
     border-radius: 8px;
     overflow: hidden;
-    flex: 1;
   }
+
+  /* Column grid: name | type | weight | price */
+  .cols { grid-template-columns: 2fr 58px 68px 86px; }
+
   .item-list-header {
     display: grid;
-    grid-template-columns: 2fr 60px 70px 90px;
     gap: 0;
-    padding: 6px 14px;
+    padding: 5px 14px;
     background: rgba(0,0,0,0.5);
     border-bottom: 1px solid var(--border-main);
   }
   .item-list-header span {
     color: var(--text-dim);
-    font-size: 0.6rem;
-    font-weight: bold;
-    text-transform: uppercase;
-    letter-spacing: 1px;
+    font-size: 0.58rem; font-weight: bold;
+    text-transform: uppercase; letter-spacing: 1px;
   }
-  .item-list-header span:nth-child(2),
-  .item-list-header span:nth-child(3),
-  .item-list-header span:nth-child(4) {
-    text-align: right;
+  .item-list-header span:not(:first-child) { text-align: right; }
+
+  /* Section subheader inside the list */
+  .list-section-header {
+    padding: 4px 14px;
+    font-size: 0.58rem; font-weight: bold;
+    text-transform: uppercase; letter-spacing: 1.5px;
+    display: flex; align-items: center; gap: 6px;
+  }
+  .list-section-header.buyback-hdr {
+    background: rgba(0,204,255,0.07);
+    color: var(--accent);
+    border-bottom: 1px solid rgba(0,204,255,0.15);
+  }
+  .list-section-header.stock-hdr {
+    background: rgba(0,0,0,0.2);
+    color: var(--text-dim);
+    border-bottom: 1px dashed rgba(255,255,255,0.05);
   }
 
   .item-row {
     display: grid;
-    grid-template-columns: 2fr 60px 70px 90px;
     gap: 0;
     align-items: center;
     padding: 10px 14px;
-    border-bottom: 1px solid rgba(255,170,0,0.08);
+    border-bottom: 1px solid rgba(255,170,0,0.07);
     cursor: pointer;
-    transition: all 0.15s;
+    transition: background 0.12s;
   }
   .item-row:last-child { border-bottom: none; }
-  .item-row:hover {
-    background: rgba(0,255,136,0.05);
+  .item-row:hover { background: rgba(0,255,136,0.04); }
+
+  /* Selection states */
+  .row-selected    { background: var(--primary-10);   border-left: 3px solid var(--primary);   padding-left: 11px; }
+  .row-danger      { background: var(--danger-10);    border-left: 3px solid var(--danger);    padding-left: 11px; }
+  .row-sell        { background: var(--secondary-10); border-left: 3px solid var(--secondary); padding-left: 11px; }
+  .row-buyback     { background: var(--accent-10);    border-left: 3px solid var(--accent);    padding-left: 11px; }
+  /* Buyback row default (unselected) */
+  .row-buyback-idle {
+    background: rgba(0,204,255,0.04);
+    border-left: 1px solid transparent;
   }
-  .item-row.selected {
-    background: rgba(0,255,136,0.1);
-    border-left: 3px solid var(--primary);
-    padding-left: 11px;
-  }
-  .item-row.selected-danger {
-    background: rgba(255,68,68,0.08);
-    border-left: 3px solid var(--danger);
-    padding-left: 11px;
-  }
-  .item-row.sell-selected {
-    background: rgba(255,170,0,0.1);
-    border-left: 3px solid var(--secondary);
-    padding-left: 11px;
-  }
+  .row-buyback-idle:hover { background: rgba(0,204,255,0.09); }
 
   .item-name {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 0.82rem;
-    color: var(--text-main);
-    font-weight: 500;
+    display: flex; align-items: center; gap: 7px;
+    font-size: 0.82rem; color: var(--text-main); font-weight: 500;
+    min-width: 0;
   }
-  .item-icon { font-size: 1rem; line-height: 1; }
-  .item-name .qty-badge {
-    font-size: 0.6rem;
-    background: rgba(255,204,0,0.2);
-    color: var(--gold);
-    border: 1px solid rgba(255,204,0,0.3);
-    padding: 1px 5px;
-    border-radius: 8px;
-    font-weight: bold;
+  .item-name .icon { font-size: 0.95rem; line-height: 1; flex-shrink: 0; }
+  .item-name .name-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .qty-badge {
+    font-size: 0.58rem;
+    background: rgba(255,204,0,0.15);
+    color: var(--gold); border: 1px solid rgba(255,204,0,0.3);
+    padding: 1px 5px; border-radius: 8px; font-weight: bold; flex-shrink: 0;
+  }
+  /* Buyback badge */
+  .buyback-badge {
+    font-size: 0.55rem;
+    background: rgba(0,204,255,0.15);
+    color: var(--accent); border: 1px solid rgba(0,204,255,0.35);
+    padding: 1px 5px; border-radius: 8px; font-weight: bold;
+    flex-shrink: 0; letter-spacing: 0.5px;
+    display: flex; align-items: center; gap: 2px;
   }
 
-  .item-weight {
-    text-align: right;
-    font-size: 0.72rem;
-    color: var(--text-muted);
-  }
-  .item-type {
-    text-align: right;
-    font-size: 0.65rem;
-    color: var(--text-dim);
-    text-transform: uppercase;
-  }
+  .item-type  { text-align: right; font-size: 0.62rem; color: var(--text-dim); text-transform: uppercase; }
+  .item-weight { text-align: right; font-size: 0.7rem; color: var(--text-muted); }
   .item-price {
-    text-align: right;
-    font-size: 0.8rem;
-    font-weight: bold;
-    color: var(--gold);
+    text-align: right; font-size: 0.78rem; font-weight: bold; color: var(--gold);
   }
-  .item-price .offer-label {
-    font-size: 0.6rem;
-    color: var(--text-muted);
-    font-weight: normal;
-    display: block;
-    margin-bottom: 1px;
-  }
-  .item-price.cant-afford {
-    color: var(--danger);
+  .item-price.price-danger  { color: var(--danger); }
+  .item-price.price-sell    { color: var(--secondary); }
+  .item-price.price-buyback { color: var(--accent); }
+  .offer-label {
+    font-size: 0.58rem; color: var(--text-muted); font-weight: normal;
+    display: block; margin-bottom: 1px;
   }
 
-  /* ── Action Row (below selected item) ─────────────────── */
+  /* ── Action Row ─────────────────────────────────────────── */
   .action-row {
-    display: flex;
-    align-items: center;
+    display: flex; align-items: center;
     justify-content: space-between;
     padding: 10px 14px;
-    background: rgba(0,255,136,0.05);
     border-top: 1px solid rgba(0,255,136,0.2);
-    border-radius: 0 0 8px 8px;
+    background: rgba(0,255,136,0.05);
     gap: 12px;
+    border-radius: 0 0 8px 8px;
   }
-  .action-row.sell-action {
-    background: rgba(255,170,0,0.05);
-    border-top-color: rgba(255,170,0,0.2);
-  }
-  .action-row.danger-action {
-    background: rgba(255,68,68,0.05);
-    border-top-color: rgba(255,68,68,0.2);
-  }
+  .action-row.ar-sell    { border-top-color: rgba(255,170,0,0.2); background: var(--secondary-10); }
+  .action-row.ar-danger  { border-top-color: rgba(255,68,68,0.2);  background: var(--danger-10); }
+  .action-row.ar-buyback { border-top-color: rgba(0,204,255,0.2);  background: var(--accent-10); }
+
   .action-item-name {
-    font-size: 0.75rem;
-    color: var(--text-muted);
+    font-size: 0.72rem; color: var(--text-muted); min-width: 0;
   }
   .action-item-name strong {
-    color: var(--text-main);
-    display: block;
-    font-size: 0.82rem;
-  }
-  .btn {
-    padding: 7px 20px;
-    border-radius: 5px;
-    font-family: var(--font);
-    font-size: 0.75rem;
-    font-weight: bold;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    cursor: pointer;
-    border: none;
-    transition: all 0.2s;
-    white-space: nowrap;
-  }
-  .btn-buy {
-    background: rgba(0,255,136,0.2);
-    border: 2px solid var(--primary);
-    color: var(--primary);
-  }
-  .btn-buy:hover {
-    background: rgba(0,255,136,0.35);
-    box-shadow: 0 0 10px rgba(0,255,136,0.3);
-  }
-  .btn-sell {
-    background: rgba(255,170,0,0.2);
-    border: 2px solid var(--secondary);
-    color: var(--secondary);
-  }
-  .btn-sell:hover {
-    background: rgba(255,170,0,0.35);
-    box-shadow: 0 0 10px rgba(255,170,0,0.3);
-  }
-  .btn-disabled {
-    background: rgba(255,68,68,0.08);
-    border: 2px solid rgba(255,68,68,0.3);
-    color: rgba(255,68,68,0.5);
-    cursor: not-allowed;
+    color: var(--text-main); display: block;
+    font-size: 0.82rem; white-space: nowrap;
+    overflow: hidden; text-overflow: ellipsis;
   }
   .cant-afford-msg {
-    font-size: 0.65rem;
-    color: var(--danger);
+    font-size: 0.63rem; color: var(--danger);
+    margin-top: 3px; display: flex; align-items: center; gap: 4px;
+  }
+  .buyback-note {
+    font-size: 0.6rem; color: rgba(0,204,255,0.7);
     margin-top: 3px;
-    display: flex;
-    align-items: center;
-    gap: 4px;
+    display: flex; align-items: center; gap: 4px;
+  }
+
+  /* ── Buttons ────────────────────────────────────────────── */
+  .btn {
+    padding: 7px 18px; border-radius: 5px;
+    font-family: var(--font); font-size: 0.72rem; font-weight: bold;
+    text-transform: uppercase; letter-spacing: 1px;
+    cursor: pointer; white-space: nowrap; flex-shrink: 0;
+  }
+  .btn-buy {
+    background: var(--primary-20); border: 2px solid var(--primary); color: var(--primary);
+  }
+  .btn-sell {
+    background: var(--secondary-20); border: 2px solid var(--secondary); color: var(--secondary);
+  }
+  .btn-buyback {
+    background: var(--accent-20); border: 2px solid var(--accent); color: var(--accent);
+  }
+  .btn-disabled {
+    background: var(--danger-10); border: 2px solid rgba(255,68,68,0.3);
+    color: rgba(255,68,68,0.45); cursor: not-allowed;
   }
 
   /* ── Quantity Picker ────────────────────────────────────── */
   .qty-picker {
-    display: flex;
-    align-items: center;
-    gap: 8px;
+    display: flex; align-items: center; gap: 7px;
     background: rgba(0,0,0,0.4);
     border: 1px solid rgba(0,255,136,0.3);
-    border-radius: 6px;
-    padding: 4px 8px;
+    border-radius: 6px; padding: 4px 8px;
   }
   .qty-step-btn {
-    width: 26px;
-    height: 26px;
-    border-radius: 4px;
+    width: 26px; height: 26px; border-radius: 4px;
     border: 1px solid rgba(0,255,136,0.4);
-    background: rgba(0,255,136,0.1);
-    color: var(--primary);
-    font-size: 1rem;
-    font-weight: bold;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 0.15s;
-    font-family: var(--font);
-    line-height: 1;
-  }
-  .qty-step-btn:hover {
-    background: rgba(0,255,136,0.25);
+    background: rgba(0,255,136,0.1); color: var(--primary);
+    font-size: 1rem; font-weight: bold; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--font); line-height: 1;
   }
   .qty-input {
-    width: 38px;
-    text-align: center;
+    width: 36px; text-align: center;
     background: rgba(0,0,0,0.5);
     border: 1px solid rgba(0,255,136,0.3);
-    border-radius: 3px;
-    color: var(--text-bright);
-    font-family: var(--font);
-    font-size: 0.85rem;
-    font-weight: bold;
-    padding: 3px 4px;
+    border-radius: 3px; color: var(--text-bright);
+    font-family: var(--font); font-size: 0.85rem;
+    font-weight: bold; padding: 3px 4px;
+    /* No native spinners — handled by +/- buttons */
   }
-  .qty-max {
-    font-size: 0.6rem;
-    color: var(--text-muted);
-    white-space: nowrap;
-  }
-  .qty-total {
-    font-size: 0.65rem;
-    color: var(--gold);
-    margin-left: 4px;
-    white-space: nowrap;
-  }
+  .qty-max  { font-size: 0.6rem; color: var(--text-muted); white-space: nowrap; }
+  .qty-total { font-size: 0.65rem; color: var(--gold); margin-left: 4px; white-space: nowrap; }
 
-  /* ── Sell Tab Merchant Gold ─────────────────────────────── */
+  /* ── Merchant Gold Bar (Sell tab) ───────────────────────── */
   .merch-gold-bar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+    display: flex; align-items: center; justify-content: space-between;
     padding: 7px 12px;
     background: rgba(255,170,0,0.06);
     border: 1px solid rgba(255,170,0,0.2);
-    border-radius: 6px;
-    font-size: 0.72rem;
+    border-radius: 6px; font-size: 0.7rem;
   }
-  .merch-gold-bar .label { color: var(--text-muted); }
-  .merch-gold-bar .amount { color: var(--gold); font-weight: bold; }
-  .merch-gold-note { color: var(--text-dim); font-size: 0.62rem; }
+  .merch-gold-bar .mlabel { color: var(--text-muted); }
+  .merch-gold-bar .mamount { color: var(--gold); font-weight: bold; }
+  .merch-gold-bar .mnote { color: var(--text-dim); font-size: 0.6rem; }
 
-  /* ── Divider ────────────────────────────────────────────── */
-  .divider {
-    border: none;
-    border-top: 1px dashed rgba(255,255,255,0.07);
-    margin: 4px 0;
-  }
-
-  /* ─────────────────────────────────────────────────────────
-     STANDALONE CLOSE-UPS (outside the game bg)
-  ───────────────────────────────────────────────────────── */
+  /* ── Close-up grid ──────────────────────────────────────── */
   .closeup-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 20px;
-    margin-top: 20px;
+    gap: 20px; margin-top: 20px;
   }
   .closeup-card {
-    background: #111;
-    border: 1px solid var(--border-main);
-    border-radius: 8px;
-    padding: 14px;
+    background: #111; border: 1px solid var(--border-main);
+    border-radius: 8px; padding: 14px;
   }
   .closeup-title {
-    color: var(--text-muted);
-    font-size: 0.6rem;
-    font-weight: bold;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    margin-bottom: 10px;
-    padding-bottom: 6px;
+    color: var(--text-muted); font-size: 0.6rem; font-weight: bold;
+    text-transform: uppercase; letter-spacing: 1.5px;
+    margin-bottom: 10px; padding-bottom: 6px;
     border-bottom: 1px solid var(--border-light);
+  }
+  .dim-note {
+    font-size: 0.6rem; color: var(--text-dim); margin-top: 8px; line-height: 1.6;
   }
 </style>
 </head>
 <body>
 
 <div class="page-header">
+  <div class="rev">Rev 2 — Weight bar · Spinner fix · Buyback flair</div>
   <h1>Jambo Shop Dialog — UI Mockup</h1>
   <p>Heart of Virtue · Retro Terminal Design Language · Branch: claude/jambo-shop-ui-mockup-I2uda</p>
 </div>
 
+
 <!-- ══════════════════════════════════════════════════════════
-     STATE 1: BUY TAB — Default Browsing
+     STATE 1: BUY TAB — Default + Buyback row
 ══════════════════════════════════════════════════════════ -->
 <div class="section">
-  <div class="section-label">State 1 — Buy Tab: Default Browsing (Antidote selected)</div>
+  <div class="section-label">State 1 — Buy Tab: Default Browsing · Buyback item present · Antidote selected (+0.2 kg pending)</div>
 
-  <div class="game-bg" style="min-height:600px;">
+  <div class="game-bg" style="min-height:640px;">
     <div class="modal-overlay">
       <div class="modal">
 
-        <!-- Header -->
         <div class="modal-header">
           <div>
             <div class="modal-title">🏪 Jambo Heals U</div>
@@ -566,87 +540,112 @@
           <div class="player-gold">💰 42</div>
         </div>
 
+        <!-- Weight Bar (current 9.6, max 15.0 → 64%; pending +0.2 = +1.3%) -->
+        <div class="weight-bar-wrap">
+          <div class="weight-bar-labels">
+            <div class="wleft">
+              ⚖️&nbsp;
+              <span class="val">9.6</span>
+              <span style="color:var(--text-dim);">&nbsp;+</span>
+              <span class="pending-val">(+0.2)</span>
+              <span style="color:var(--text-dim);">&nbsp;kg</span>
+            </div>
+            <div class="wmax">max 15.0 kg</div>
+          </div>
+          <div class="weight-bar-track">
+            <!-- Current fill: 9.6/15.0 = 64% → lime (ok) -->
+            <div class="weight-bar-fill fill-ok" style="width:64%;"></div>
+            <!-- Pending: 0.2/15.0 = 1.33% → orange -->
+            <div class="weight-bar-pending pending-ok" style="width:1.3%;"></div>
+          </div>
+        </div>
+
         <!-- Tab Bar -->
         <div class="tab-bar">
-          <button class="tab-btn active">⬇ Buy</button>
+          <button class="tab-btn active-buy">⬇ Buy</button>
           <button class="tab-btn">⬆ Sell</button>
         </div>
 
         <!-- Item List -->
         <div class="item-list">
-          <div class="item-list-header">
-            <span>Item</span>
-            <span>Type</span>
-            <span>Weight</span>
-            <span>Price</span>
+          <div class="item-list-header cols">
+            <span>Item</span><span>Type</span><span>Weight</span><span>Price</span>
           </div>
 
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">🧪</span> Restorative <span class="qty-badge">×4</span></div>
+          <!-- BUYBACK section -->
+          <div class="list-section-header buyback-hdr">
+            ↩ Buyback Available <span style="color:var(--text-dim);font-weight:normal;letter-spacing:0;">(until next beat)</span>
+          </div>
+          <div class="item-row row-buyback-idle cols">
+            <div class="item-name">
+              <span class="icon">🗡️</span>
+              <span class="name-text">Iron Dagger</span>
+              <span class="buyback-badge">↩ BUYBACK</span>
+            </div>
+            <div class="item-type">Dagger</div>
+            <div class="item-weight">0.5 kg</div>
+            <div class="item-price price-buyback">12 💰</div>
+          </div>
+
+          <!-- Regular stock section -->
+          <div class="list-section-header stock-hdr">Jambo's Stock</div>
+
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">🧪</span><span class="name-text">Restorative</span><span class="qty-badge">×4</span></div>
             <div class="item-type">Potion</div>
             <div class="item-weight">0.2 kg</div>
             <div class="item-price">30 💰</div>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">💧</span> Draught</div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">💧</span><span class="name-text">Draught</span></div>
             <div class="item-type">Potion</div>
             <div class="item-weight">0.1 kg</div>
             <div class="item-price">15 💰</div>
           </div>
-
-          <div class="item-row selected">
-            <div class="item-name"><span class="item-icon">💊</span> Antidote</div>
+          <div class="item-row row-selected cols">
+            <div class="item-name"><span class="icon">💊</span><span class="name-text">Antidote</span></div>
             <div class="item-type">Potion</div>
             <div class="item-weight">0.2 kg</div>
             <div class="item-price">20 💰</div>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">🌿</span> Salve</div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">🌿</span><span class="name-text">Salve</span></div>
             <div class="item-type">Potion</div>
             <div class="item-weight">0.3 kg</div>
             <div class="item-price">45 💰</div>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">💉</span> Elixir</div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">💉</span><span class="name-text">Elixir</span></div>
             <div class="item-type">Potion</div>
             <div class="item-weight">0.4 kg</div>
             <div class="item-price">80 💰</div>
           </div>
 
-          <!-- Action Row (expands when row is selected) -->
           <div class="action-row">
-            <div class="action-item-name">
-              Selected:
-              <strong>💊 Antidote</strong>
-            </div>
+            <div class="action-item-name">Selected: <strong>💊 Antidote</strong></div>
             <button class="btn btn-buy">Buy · 20 💰</button>
           </div>
         </div>
 
-      </div><!-- /modal -->
-    </div><!-- /overlay -->
-  </div><!-- /game-bg -->
+      </div>
+    </div>
+  </div>
 
   <div class="annotation">
-    <strong>Layout:</strong> Modal mirrors BaseDialog — fixed overlay, blur(3px), #0a0a0a bg, 3px solid #00ff88 border, glow.<br>
-    <strong>NPC strip:</strong> Jambo's name + tagline + player gold pinned to top-right. Cyan accent border (items.entities.npc).<br>
-    <strong>Tab bar:</strong> Horizontal (Buy / Sell). Active tab: lime bg + border. Inactive: muted.<br>
-    <strong>Item rows:</strong> Click any row → highlights with lime left-border (3px) + tinted bg. Action row expands at list bottom.<br>
-    <strong>Buy button:</strong> Shows selected item name + price inline. Lime border/text. Hover: brighter + glow.
+    <strong>Weight bar:</strong> Three-layer segmented track — current weight (lime fill), pending purchase increase (orange segment), remaining capacity (dark track). Label shows raw numbers: <em>9.6 + (+0.2) kg · max 15.0 kg</em>. Bar color switches: &lt;75% → lime; 75–90% → orange; &gt;90% → red. Pending segment always orange regardless of fill color.<br>
+    <strong>Buyback section:</strong> Appears above regular stock when player has recently sold items. Cyan accent — <code>↩ BUYBACK</code> badge on each row. Price is the sell price Jambo paid (not the original item value). Section subheader shows "until next beat" caveat. Flushed automatically when the game beat advances.<br>
+    <strong>Research note for implementation:</strong> Backend needs a transient buyback ledger keyed to the session/player: { item_id, qty, buyback_price, beat_acquired }. On game_tick_events() call, items whose beat_acquired &lt; current_beat are removed. The merchant serializer must expose this list separately from regular stock. Needs API endpoint investigation before implementation.
   </div>
 </div>
 
 
 <!-- ══════════════════════════════════════════════════════════
-     STATE 2: BUY TAB — Insufficient Gold
+     STATE 2: Insufficient Gold
 ══════════════════════════════════════════════════════════ -->
 <div class="section">
-  <div class="section-label">State 2 — Buy Tab: Insufficient Gold (Elixir selected, costs 80 💰, player has 42 💰)</div>
+  <div class="section-label">State 2 — Buy Tab: Insufficient Gold (Elixir 80 💰, player has 42 💰)</div>
 
-  <div class="game-bg" style="min-height:600px;">
+  <div class="game-bg" style="min-height:640px;">
     <div class="modal-overlay">
       <div class="modal">
 
@@ -664,66 +663,73 @@
             <div class="npc-name">Jambo</div>
             <div class="npc-tagline">"When you blue, Jambo Heals U!"</div>
           </div>
-          <div class="player-gold" style="color: var(--danger);">💰 42</div>
+          <!-- Gold turns red when can't afford selection -->
+          <div class="player-gold" style="color:var(--danger);">💰 42</div>
+        </div>
+
+        <!-- Weight bar: no pending (can't buy, so no pending) -->
+        <div class="weight-bar-wrap">
+          <div class="weight-bar-labels">
+            <div class="wleft">
+              ⚖️&nbsp;<span class="val">9.6</span><span style="color:var(--text-dim);">&nbsp;kg</span>
+            </div>
+            <div class="wmax">max 15.0 kg</div>
+          </div>
+          <div class="weight-bar-track">
+            <div class="weight-bar-fill fill-ok" style="width:64%;"></div>
+          </div>
         </div>
 
         <div class="tab-bar">
-          <button class="tab-btn active">⬇ Buy</button>
+          <button class="tab-btn active-buy">⬇ Buy</button>
           <button class="tab-btn">⬆ Sell</button>
         </div>
 
         <div class="item-list">
-          <div class="item-list-header">
-            <span>Item</span>
-            <span>Type</span>
-            <span>Weight</span>
-            <span>Price</span>
+          <div class="item-list-header cols">
+            <span>Item</span><span>Type</span><span>Weight</span><span>Price</span>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">🧪</span> Restorative <span class="qty-badge">×4</span></div>
-            <div class="item-type">Potion</div>
-            <div class="item-weight">0.2 kg</div>
-            <div class="item-price">30 💰</div>
+          <div class="list-section-header buyback-hdr">
+            ↩ Buyback Available <span style="color:var(--text-dim);font-weight:normal;letter-spacing:0;">(until next beat)</span>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">💧</span> Draught</div>
-            <div class="item-type">Potion</div>
-            <div class="item-weight">0.1 kg</div>
-            <div class="item-price">15 💰</div>
+          <div class="item-row row-buyback-idle cols">
+            <div class="item-name">
+              <span class="icon">🗡️</span><span class="name-text">Iron Dagger</span>
+              <span class="buyback-badge">↩ BUYBACK</span>
+            </div>
+            <div class="item-type">Dagger</div>
+            <div class="item-weight">0.5 kg</div>
+            <div class="item-price price-buyback">12 💰</div>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">💊</span> Antidote</div>
-            <div class="item-type">Potion</div>
-            <div class="item-weight">0.2 kg</div>
-            <div class="item-price">20 💰</div>
+          <div class="list-section-header stock-hdr">Jambo's Stock</div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">🧪</span><span class="name-text">Restorative</span><span class="qty-badge">×4</span></div>
+            <div class="item-type">Potion</div><div class="item-weight">0.2 kg</div><div class="item-price">30 💰</div>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">🌿</span> Salve</div>
-            <div class="item-type">Potion</div>
-            <div class="item-weight">0.3 kg</div>
-            <div class="item-price">45 💰</div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">💧</span><span class="name-text">Draught</span></div>
+            <div class="item-type">Potion</div><div class="item-weight">0.1 kg</div><div class="item-price">15 💰</div>
           </div>
-
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">💊</span><span class="name-text">Antidote</span></div>
+            <div class="item-type">Potion</div><div class="item-weight">0.2 kg</div><div class="item-price">20 💰</div>
+          </div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">🌿</span><span class="name-text">Salve</span></div>
+            <div class="item-type">Potion</div><div class="item-weight">0.3 kg</div><div class="item-price">45 💰</div>
+          </div>
           <!-- Selected but can't afford -->
-          <div class="item-row selected-danger">
-            <div class="item-name"><span class="item-icon">💉</span> Elixir</div>
+          <div class="item-row row-danger cols">
+            <div class="item-name"><span class="icon">💉</span><span class="name-text">Elixir</span></div>
             <div class="item-type">Potion</div>
             <div class="item-weight">0.4 kg</div>
-            <div class="item-price cant-afford">80 💰</div>
+            <div class="item-price price-danger">80 💰</div>
           </div>
 
-          <!-- Action row — disabled state -->
-          <div class="action-row danger-action">
+          <div class="action-row ar-danger">
             <div>
-              <div class="action-item-name">
-                Selected:
-                <strong>💉 Elixir</strong>
-              </div>
-              <div class="cant-afford-msg">⚠ Not enough gold (need 38 more)</div>
+              <div class="action-item-name">Selected: <strong>💉 Elixir</strong></div>
+              <div class="cant-afford-msg">⚠ Not enough gold — need 38 more</div>
             </div>
             <button class="btn btn-disabled" disabled>Buy · 80 💰</button>
           </div>
@@ -734,20 +740,21 @@
   </div>
 
   <div class="annotation">
-    <strong>Trigger:</strong> Player gold (42) &lt; item price (80).<br>
-    <strong>Visual signals:</strong> (1) Selected row gets danger red left-border instead of lime. (2) Price text turns red. (3) Player gold display turns red. (4) Action row background is red-tinted. (5) Buy button is disabled: grey border, muted text, cursor:not-allowed.<br>
-    <strong>Message:</strong> "Not enough gold (need N more)" — N = price − player_gold. Orange warning icon. No dismiss needed — automatically clears when selection changes.
+    <strong>Weight bar:</strong> No pending segment shown when the player cannot afford the item — the purchase is impossible so projecting weight increase would be misleading.<br>
+    <strong>Player gold:</strong> Turns danger red when selected item costs more than current gold.<br>
+    <strong>Danger row:</strong> Red left-border + red-tinted bg. Price text turns red. Action row gets danger tint. Buy button disabled (cursor: not-allowed, muted red styling).<br>
+    <strong>"Need N more":</strong> N is computed as <code>price − player_gold</code>, giving actionable feedback (player knows exactly how much more to earn/sell).
   </div>
 </div>
 
 
 <!-- ══════════════════════════════════════════════════════════
-     STATE 3: BUY TAB — Quantity Picker
+     STATE 3: Qty Picker — Prominent Pending Weight Segment
 ══════════════════════════════════════════════════════════ -->
 <div class="section">
-  <div class="section-label">State 3 — Buy Tab: Quantity Picker (Restorative ×4 in stock, buying 2)</div>
+  <div class="section-label">State 3 — Buy Tab: Quantity Picker · 2× Restorative selected · Weight bar shows +0.4 kg pending</div>
 
-  <div class="game-bg" style="min-height:600px;">
+  <div class="game-bg" style="min-height:640px;">
     <div class="modal-overlay">
       <div class="modal">
 
@@ -768,63 +775,81 @@
           <div class="player-gold">💰 42</div>
         </div>
 
+        <!-- Weight bar: current 9.6 + pending 0.4 (2× Restorative) = 10.0/15.0 -->
+        <!-- 9.6/15.0 = 64%, 0.4/15.0 = 2.7% -->
+        <div class="weight-bar-wrap">
+          <div class="weight-bar-labels">
+            <div class="wleft">
+              ⚖️&nbsp;
+              <span class="val">9.6</span>
+              <span style="color:var(--text-dim);">&nbsp;+</span>
+              <span class="pending-val">(+0.4)</span>
+              <span style="color:var(--text-dim);">&nbsp;kg</span>
+              <span style="color:var(--text-dim);font-size:0.58rem;">&nbsp;→ 10.0 kg after</span>
+            </div>
+            <div class="wmax">max 15.0 kg</div>
+          </div>
+          <div class="weight-bar-track">
+            <div class="weight-bar-fill fill-ok" style="width:64%;"></div>
+            <!-- 2x Restorative: 0.4/15.0 = 2.7% -->
+            <div class="weight-bar-pending pending-ok" style="width:2.7%;"></div>
+          </div>
+        </div>
+
         <div class="tab-bar">
-          <button class="tab-btn active">⬇ Buy</button>
+          <button class="tab-btn active-buy">⬇ Buy</button>
           <button class="tab-btn">⬆ Sell</button>
         </div>
 
         <div class="item-list">
-          <div class="item-list-header">
-            <span>Item</span>
-            <span>Type</span>
-            <span>Weight</span>
-            <span>Price ea.</span>
+          <div class="item-list-header cols">
+            <span>Item</span><span>Type</span><span>Weight</span><span>Price ea.</span>
           </div>
-
-          <!-- Selected stackable item -->
-          <div class="item-row selected">
-            <div class="item-name"><span class="item-icon">🧪</span> Restorative <span class="qty-badge">×4</span></div>
+          <div class="list-section-header buyback-hdr">
+            ↩ Buyback Available <span style="color:var(--text-dim);font-weight:normal;letter-spacing:0;">(until next beat)</span>
+          </div>
+          <div class="item-row row-buyback-idle cols">
+            <div class="item-name">
+              <span class="icon">🗡️</span><span class="name-text">Iron Dagger</span>
+              <span class="buyback-badge">↩ BUYBACK</span>
+            </div>
+            <div class="item-type">Dagger</div><div class="item-weight">0.5 kg</div>
+            <div class="item-price price-buyback">12 💰</div>
+          </div>
+          <div class="list-section-header stock-hdr">Jambo's Stock</div>
+          <!-- Restorative selected (stackable) -->
+          <div class="item-row row-selected cols">
+            <div class="item-name"><span class="icon">🧪</span><span class="name-text">Restorative</span><span class="qty-badge">×4</span></div>
             <div class="item-type">Potion</div>
             <div class="item-weight">0.2 kg</div>
             <div class="item-price">30 💰</div>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">💧</span> Draught</div>
-            <div class="item-type">Potion</div>
-            <div class="item-weight">0.1 kg</div>
-            <div class="item-price">15 💰</div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">💧</span><span class="name-text">Draught</span></div>
+            <div class="item-type">Potion</div><div class="item-weight">0.1 kg</div><div class="item-price">15 💰</div>
+          </div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">💊</span><span class="name-text">Antidote</span></div>
+            <div class="item-type">Potion</div><div class="item-weight">0.2 kg</div><div class="item-price">20 💰</div>
+          </div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">🌿</span><span class="name-text">Salve</span></div>
+            <div class="item-type">Potion</div><div class="item-weight">0.3 kg</div><div class="item-price">45 💰</div>
+          </div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">💉</span><span class="name-text">Elixir</span></div>
+            <div class="item-type">Potion</div><div class="item-weight">0.4 kg</div><div class="item-price">80 💰</div>
           </div>
 
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">💊</span> Antidote</div>
-            <div class="item-type">Potion</div>
-            <div class="item-weight">0.2 kg</div>
-            <div class="item-price">20 💰</div>
-          </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">🌿</span> Salve</div>
-            <div class="item-type">Potion</div>
-            <div class="item-weight">0.3 kg</div>
-            <div class="item-price">45 💰</div>
-          </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">💉</span> Elixir</div>
-            <div class="item-type">Potion</div>
-            <div class="item-weight">0.4 kg</div>
-            <div class="item-price">80 💰</div>
-          </div>
-
-          <!-- Quantity Picker Action Row -->
+          <!-- Qty picker action row -->
           <div class="action-row">
             <div class="action-item-name">
               🧪 Restorative
-              <div style="margin-top:4px; display:flex; align-items:center; gap:6px;">
+              <div style="margin-top:5px;display:flex;align-items:center;gap:6px;">
                 <div class="qty-picker">
                   <button class="qty-step-btn">−</button>
-                  <input class="qty-input" type="number" value="2" min="1" max="4" readonly>
+                  <!-- No native spinners: appearance:textfield, no webkit arrows -->
+                  <input class="qty-input" type="number" value="2" min="1" max="4">
                   <button class="qty-step-btn">+</button>
                   <span class="qty-max">/ 4</span>
                 </div>
@@ -840,19 +865,19 @@
   </div>
 
   <div class="annotation">
-    <strong>Trigger:</strong> Player clicks a stackable item row (item.quantity &gt; 1 in merchant stock).<br>
-    <strong>Quantity picker:</strong> Appears inline in the action row. − button (min 1) / + button (max = stock count). Input field accepts direct edit. Live total = qty × price_ea shown beside picker.<br>
-    <strong>Buy button:</strong> Updates label live: "Buy N · total_cost 💰". Checks affordability at each qty change — disables if total exceeds player gold.<br>
-    <strong>Single items</strong> (qty = 1) skip the picker and show the standard Buy button directly.
+    <strong>Pending weight label:</strong> When a quantity is selected, the label updates live to show both the raw pending add and the resulting total: <em>9.6 + (+0.4) kg → 10.0 kg after</em>. The pending segment in the track scales proportionally (qty × item_weight / max_weight).<br>
+    <strong>Quantity picker:</strong> Native browser up/down arrows removed via <code>appearance: textfield</code> + <code>-webkit-appearance: none</code>. Only the +/− buttons control quantity. Direct keyboard input still works.<br>
+    <strong>Live updates:</strong> Pending bar segment, qty total cost, and Buy button label all update on every +/− press.<br>
+    <strong>Overweight guard:</strong> If qty × item_weight would push player over max_weight, the pending segment turns red and the Buy button disables with "Exceeds carry limit" message.
   </div>
 </div>
 
 
 <!-- ══════════════════════════════════════════════════════════
-     STATE 4: SELL TAB — Player Items
+     STATE 4: Sell Tab
 ══════════════════════════════════════════════════════════ -->
 <div class="section">
-  <div class="section-label">State 4 — Sell Tab: Player Inventory with 50% Offer Prices (Iron Dagger selected)</div>
+  <div class="section-label">State 4 — Sell Tab: Player Items with 50% Offer Prices · Iron Dagger selected</div>
 
   <div class="game-bg" style="min-height:640px;">
     <div class="modal-overlay">
@@ -866,89 +891,94 @@
           <button class="close-btn">✕</button>
         </div>
 
-        <!-- NPC strip w/ Jambo's gold -->
-        <div class="npc-strip" style="border-color: rgba(255,170,0,0.3); background: rgba(255,170,0,0.05);">
+        <div class="npc-strip" style="background:var(--secondary-10);border-color:rgba(255,170,0,0.25);">
           <div class="npc-avatar">🧕</div>
           <div class="npc-info">
-            <div class="npc-name" style="color: var(--secondary);">Jambo</div>
+            <div class="npc-name" style="color:var(--secondary);">Jambo</div>
             <div class="npc-tagline">Sell your goods — Jambo pays fair!</div>
           </div>
           <div class="player-gold">💰 42</div>
         </div>
 
-        <!-- Tab Bar (Sell active) -->
+        <!-- Weight bar on sell tab: current weight, no pending
+             After selling Iron Dagger: 9.6 − 0.5 = 9.1 kg
+             Show "will free" (lime tinted) vs normal fill — simpler: just show current -->
+        <div class="weight-bar-wrap">
+          <div class="weight-bar-labels">
+            <div class="wleft">
+              ⚖️&nbsp;<span class="val">9.6</span>
+              <span style="color:var(--text-dim);">&nbsp;−</span>
+              <!-- Selling frees weight: shown in green -->
+              <span style="color:var(--primary);font-weight:bold;">(−0.5)</span>
+              <span style="color:var(--text-dim);">&nbsp;kg</span>
+              <span style="color:var(--text-dim);font-size:0.58rem;">&nbsp;→ 9.1 kg after</span>
+            </div>
+            <div class="wmax">max 15.0 kg</div>
+          </div>
+          <div class="weight-bar-track">
+            <!-- Fill: 9.6/15.0 = 64% but subtract pending sale = 9.1/15.0 = 60.7%  -->
+            <!-- Show solid fill at current, with a "freeing" lighter segment -->
+            <div class="weight-bar-fill fill-ok" style="width:60.7%;"></div>
+            <!-- Freed segment: 0.5/15.0 = 3.3% shown as muted lime to indicate relief -->
+            <div class="weight-bar-pending" style="width:3.3%;background:rgba(0,255,136,0.25);"></div>
+          </div>
+        </div>
+
         <div class="tab-bar">
           <button class="tab-btn">⬇ Buy</button>
-          <button class="tab-btn sell-active">⬆ Sell</button>
+          <button class="tab-btn active-sell">⬆ Sell</button>
         </div>
 
         <!-- Merchant gold bar -->
         <div class="merch-gold-bar">
-          <span class="label">Jambo's gold:</span>
-          <span class="amount">800 💰</span>
-          <span class="merch-gold-note">Max single purchase Jambo can make</span>
+          <span class="mlabel">Jambo's gold:</span>
+          <span class="mamount">800 💰</span>
+          <span class="mnote">Max he can pay per purchase</span>
         </div>
 
-        <!-- Item List (player's sellable items) -->
         <div class="item-list">
-          <div class="item-list-header" style="grid-template-columns: 2fr 60px 70px 90px;">
-            <span>Your Item</span>
-            <span>Type</span>
-            <span>Weight</span>
-            <span>Offer</span>
+          <div class="item-list-header cols">
+            <span>Your Item</span><span>Type</span><span>Weight</span><span>Offer</span>
           </div>
 
-          <!-- Selected item -->
-          <div class="item-row sell-selected">
-            <div class="item-name"><span class="item-icon">🗡️</span> Iron Dagger</div>
+          <!-- Selected -->
+          <div class="item-row row-sell cols">
+            <div class="item-name"><span class="icon">🗡️</span><span class="name-text">Iron Dagger</span></div>
             <div class="item-type">Dagger</div>
             <div class="item-weight">0.5 kg</div>
-            <div class="item-price" style="color: var(--secondary);">
-              <span class="offer-label">Offer:</span>
-              12 💰
+            <div class="item-price price-sell">
+              <span class="offer-label">Offer:</span>12 💰
             </div>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">🧪</span> Restorative <span class="qty-badge">×2</span></div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">🧪</span><span class="name-text">Restorative</span><span class="qty-badge">×2</span></div>
             <div class="item-type">Potion</div>
             <div class="item-weight">0.2 kg</div>
-            <div class="item-price" style="color: var(--secondary);">
-              <span class="offer-label">Offer ea.:</span>
-              15 💰
+            <div class="item-price price-sell">
+              <span class="offer-label">Offer ea.:</span>15 💰
             </div>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">🥩</span> Ration</div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">🥩</span><span class="name-text">Ration</span></div>
             <div class="item-type">Food</div>
             <div class="item-weight">0.1 kg</div>
-            <div class="item-price" style="color: var(--secondary);">
-              <span class="offer-label">Offer:</span>
-              3 💰
+            <div class="item-price price-sell">
+              <span class="offer-label">Offer:</span>3 💰
             </div>
           </div>
-
-          <div class="item-row">
-            <div class="item-name"><span class="item-icon">🍵</span> Bitter Leaf Tea</div>
+          <div class="item-row cols">
+            <div class="item-name"><span class="icon">🍵</span><span class="name-text">Bitter Leaf Tea</span></div>
             <div class="item-type">Tonic</div>
             <div class="item-weight">0.15 kg</div>
-            <div class="item-price" style="color: var(--secondary);">
-              <span class="offer-label">Offer:</span>
-              8 💰
+            <div class="item-price price-sell">
+              <span class="offer-label">Offer:</span>8 💰
             </div>
           </div>
 
-          <!-- Action row (sell) -->
-          <div class="action-row sell-action">
+          <div class="action-row ar-sell">
             <div>
-              <div class="action-item-name">
-                Selling:
-                <strong>🗡️ Iron Dagger</strong>
-              </div>
-              <div style="font-size:0.62rem; color:var(--text-dim); margin-top:2px;">
-                Value 25 💰 → Jambo offers 50% = 12 💰
-              </div>
+              <div class="action-item-name">Selling: <strong>🗡️ Iron Dagger</strong></div>
+              <div style="font-size:0.6rem;color:var(--text-dim);margin-top:2px;">Value 25 💰 · Jambo offers 50% = 12 💰</div>
             </div>
             <button class="btn btn-sell">Sell · +12 💰</button>
           </div>
@@ -959,176 +989,238 @@
   </div>
 
   <div class="annotation">
-    <strong>Tab switch:</strong> Sell tab uses orange accent (--secondary) instead of lime throughout — tab border, NPC strip border, selected row border, action row tint, sell button.<br>
-    <strong>Offer pricing:</strong> Each row shows "Offer:" sub-label + 50% of item value (base_sell_modifier = 0.5). Full value not displayed — only the offer.<br>
-    <strong>Merchant gold bar:</strong> Shows Jambo's current gold. If player tries to sell an item worth more than Jambo's gold, sell button disables with "Jambo can't afford this" message.<br>
-    <strong>Sell button:</strong> "+12 💰" with plus sign reinforces that player receives gold. Orange border/text to match sell context.<br>
-    <strong>Non-sellable items</strong> (quest items, equipped items) are greyed out with a 🔒 badge and non-clickable.
+    <strong>Weight bar on sell:</strong> Pending segment logic is reversed — the item being sold <em>frees</em> weight. Shows a faded lime segment (the weight that will be freed) after the current fill. Label shows <em>9.6 − (−0.5) kg → 9.1 kg after</em> with the freed amount in lime green.<br>
+    <strong>Sell tab orange theme:</strong> NPC strip, tab, action row, sell button, and item prices all use <code>--secondary</code> (orange) throughout.<br>
+    <strong>Merchant gold bar:</strong> Shows Jambo's available funds — sell button disables if item offer price &gt; Jambo's gold.<br>
+    <strong>Sold items enter buyback:</strong> After a successful sale, the item appears in the buyback section of the Buy tab at the same price Jambo paid. The buyback record is cleared when the game beat advances.
   </div>
 </div>
 
 
 <!-- ══════════════════════════════════════════════════════════
-     CLOSE-UP: Component Details
+     COMPONENT CLOSE-UPS
 ══════════════════════════════════════════════════════════ -->
 <div class="section">
   <div class="section-label">Component Close-ups &amp; Dimensions</div>
-
   <div class="closeup-grid">
 
-    <!-- Item row states -->
-    <div class="closeup-card">
-      <div class="closeup-title">Item Row — All States</div>
-      <!-- Default -->
-      <div class="item-row" style="border-radius:6px 6px 0 0;">
-        <div class="item-name"><span class="item-icon">💧</span> Draught</div>
-        <div class="item-type">Potion</div>
-        <div class="item-weight">0.1 kg</div>
-        <div class="item-price">15 💰</div>
+    <!-- Weight bar all states -->
+    <div class="closeup-card" style="grid-column: span 2;">
+      <div class="closeup-title">Weight Bar — All States</div>
+      <div style="display:flex;flex-direction:column;gap:14px;margin-top:4px;">
+
+        <!-- Normal (no pending) -->
+        <div>
+          <div style="font-size:0.6rem;color:var(--text-dim);margin-bottom:4px;">Normal — no item selected</div>
+          <div class="weight-bar-wrap" style="background:transparent;border:none;padding:0;gap:3px;">
+            <div class="weight-bar-labels">
+              <div class="wleft">⚖️&nbsp;<span class="val">9.6</span><span style="color:var(--text-dim);"> kg</span></div>
+              <div class="wmax">max 15.0 kg</div>
+            </div>
+            <div class="weight-bar-track"><div class="weight-bar-fill fill-ok" style="width:64%;"></div></div>
+          </div>
+        </div>
+
+        <!-- Pending buy (lime + orange) -->
+        <div>
+          <div style="font-size:0.6rem;color:var(--text-dim);margin-bottom:4px;">Buy pending — Antidote (+0.2 kg)</div>
+          <div class="weight-bar-wrap" style="background:transparent;border:none;padding:0;gap:3px;">
+            <div class="weight-bar-labels">
+              <div class="wleft">⚖️&nbsp;<span class="val">9.6</span><span style="color:var(--text-dim);"> + </span><span class="pending-val">(+0.2)</span><span style="color:var(--text-dim);"> kg</span></div>
+              <div class="wmax">max 15.0 kg</div>
+            </div>
+            <div class="weight-bar-track">
+              <div class="weight-bar-fill fill-ok" style="width:64%;"></div>
+              <div class="weight-bar-pending pending-ok" style="width:1.3%;"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Near-limit buy (orange + orange) -->
+        <div>
+          <div style="font-size:0.6rem;color:var(--text-dim);margin-bottom:4px;">Near-limit — 77% full, 2× Restorative (+0.4 kg) → 79.7%</div>
+          <div class="weight-bar-wrap" style="background:transparent;border:none;padding:0;gap:3px;">
+            <div class="weight-bar-labels">
+              <div class="wleft">⚖️&nbsp;<span class="val">11.6</span><span style="color:var(--text-dim);"> + </span><span class="pending-val">(+0.4)</span><span style="color:var(--text-dim);"> kg</span></div>
+              <div class="wmax">max 15.0 kg</div>
+            </div>
+            <div class="weight-bar-track">
+              <div class="weight-bar-fill fill-warn" style="width:77.3%;"></div>
+              <div class="weight-bar-pending pending-ok" style="width:2.7%;"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Overweight pending (red + red) -->
+        <div>
+          <div style="font-size:0.6rem;color:var(--text-dim);margin-bottom:4px;">Overweight — 91% full, Elixir (+0.4 kg) would exceed limit</div>
+          <div class="weight-bar-wrap" style="background:transparent;border:none;padding:0;gap:3px;">
+            <div class="weight-bar-labels">
+              <div class="wleft">⚖️&nbsp;<span class="val">13.7</span><span style="color:var(--text-dim);"> + </span><span style="color:var(--danger);font-weight:bold;">(+0.4 ⚠)</span><span style="color:var(--text-dim);"> kg</span></div>
+              <div class="wmax">max 15.0 kg</div>
+            </div>
+            <div class="weight-bar-track">
+              <div class="weight-bar-fill fill-over" style="width:91.3%;"></div>
+              <div class="weight-bar-pending pending-over" style="width:2.7%;"></div>
+            </div>
+          </div>
+          <div style="font-size:0.62rem;color:var(--danger);margin-top:4px;">⚠ Exceeds carry limit — Buy button disables</div>
+        </div>
+
+        <!-- Sell pending (lime + faded lime) -->
+        <div>
+          <div style="font-size:0.6rem;color:var(--text-dim);margin-bottom:4px;">Sell pending — Iron Dagger (−0.5 kg freed)</div>
+          <div class="weight-bar-wrap" style="background:transparent;border:none;padding:0;gap:3px;">
+            <div class="weight-bar-labels">
+              <div class="wleft">⚖️&nbsp;<span class="val">9.6</span><span style="color:var(--text-dim);"> − </span><span style="color:var(--primary);font-weight:bold;">(−0.5)</span><span style="color:var(--text-dim);"> kg</span></div>
+              <div class="wmax">max 15.0 kg</div>
+            </div>
+            <div class="weight-bar-track">
+              <div class="weight-bar-fill fill-ok" style="width:60.7%;"></div>
+              <div class="weight-bar-pending" style="width:3.3%;background:rgba(0,255,136,0.25);"></div>
+            </div>
+          </div>
+        </div>
+
       </div>
-      <!-- Hover (simulated) -->
-      <div class="item-row" style="background:rgba(0,255,136,0.05);">
-        <div class="item-name"><span class="item-icon">💊</span> Antidote</div>
-        <div class="item-type">Potion</div>
-        <div class="item-weight">0.2 kg</div>
-        <div class="item-price">20 💰</div>
-      </div>
-      <!-- Selected buy -->
-      <div class="item-row selected">
-        <div class="item-name"><span class="item-icon">🌿</span> Salve</div>
-        <div class="item-type">Potion</div>
-        <div class="item-weight">0.3 kg</div>
-        <div class="item-price">45 💰</div>
-      </div>
-      <!-- Selected + can't afford -->
-      <div class="item-row selected-danger">
-        <div class="item-name"><span class="item-icon">💉</span> Elixir</div>
-        <div class="item-type">Potion</div>
-        <div class="item-weight">0.4 kg</div>
-        <div class="item-price cant-afford">80 💰</div>
-      </div>
-      <!-- Sell selected -->
-      <div class="item-row sell-selected" style="border-radius:0 0 6px 6px; border-bottom:none;">
-        <div class="item-name"><span class="item-icon">🗡️</span> Iron Dagger</div>
-        <div class="item-type">Dagger</div>
-        <div class="item-weight">0.5 kg</div>
-        <div class="item-price" style="color:var(--secondary);">12 💰</div>
-      </div>
-      <div style="margin-top:8px; font-size:0.6rem; color:var(--text-dim); line-height:1.5;">
-        Row height: ~44px · Left border: 3px · Grid: 2fr 60px 70px 90px
+      <div class="dim-note">
+        Bar height: 8px · Border-radius: 4px · Track background: rgba(255,255,255,0.06)<br>
+        Thresholds: &lt;75% lime, 75–90% orange, &gt;90% red. Pending always orange (buy) or faded lime (sell).<br>
+        Overweight pending: buy button disabled + "Exceeds carry limit" error replaces pending label.
       </div>
     </div>
 
-    <!-- Button states -->
+    <!-- Buyback row flair -->
     <div class="closeup-card">
-      <div class="closeup-title">Action Buttons — All States</div>
-      <div style="display:flex; flex-direction:column; gap:10px; margin-top:4px;">
-        <button class="btn btn-buy">Buy · 20 💰</button>
-        <button class="btn btn-buy">Buy 2 · 60 💰</button>
-        <button class="btn btn-disabled" disabled>Buy · 80 💰</button>
-        <button class="btn btn-sell">Sell · +12 💰</button>
-        <div style="font-size:0.6rem; color:var(--text-dim); margin-top:4px; line-height:1.5;">
-          Buy: #00ff88 border/text, rgba(0,255,136,0.2) bg<br>
-          Sell: #ffaa00 border/text, rgba(255,170,0,0.2) bg<br>
-          Disabled: rgba(255,68,68,0.3) border, muted red text
+      <div class="closeup-title">Buyback Row — States</div>
+      <div style="background:rgba(0,0,0,0.4);border:1px solid var(--border-main);border-radius:6px;overflow:hidden;margin-top:4px;">
+        <!-- Idle buyback row -->
+        <div class="item-row row-buyback-idle cols" style="border-radius:0;">
+          <div class="item-name">
+            <span class="icon">🗡️</span>
+            <span class="name-text">Iron Dagger</span>
+            <span class="buyback-badge">↩ BUYBACK</span>
+          </div>
+          <div class="item-type">Dagger</div>
+          <div class="item-weight">0.5 kg</div>
+          <div class="item-price price-buyback">12 💰</div>
+        </div>
+        <!-- Selected buyback row -->
+        <div class="item-row row-buyback cols" style="border-radius:0;border-bottom:none;">
+          <div class="item-name">
+            <span class="icon">🗡️</span>
+            <span class="name-text">Iron Dagger</span>
+            <span class="buyback-badge">↩ BUYBACK</span>
+          </div>
+          <div class="item-type">Dagger</div>
+          <div class="item-weight">0.5 kg</div>
+          <div class="item-price price-buyback">12 💰</div>
         </div>
       </div>
+      <!-- Buyback action row -->
+      <div class="action-row ar-buyback" style="border-radius:0 0 6px 6px;border-top:1px solid rgba(0,204,255,0.2);">
+        <div>
+          <div class="action-item-name">Buying back: <strong>🗡️ Iron Dagger</strong></div>
+          <div class="buyback-note">⏱ Expires next game beat</div>
+        </div>
+        <button class="btn btn-buyback">Buyback · 12 💰</button>
+      </div>
+      <div class="dim-note">
+        Idle: cyan tint bg (rgba(0,204,255,0.04)), no left border<br>
+        Selected: cyan left-border 3px + cyan-10 bg<br>
+        Badge: <code>↩ BUYBACK</code>, cyan border, small text<br>
+        Price = what Jambo paid (sell price), not original item value<br>
+        Button: cyan border/text, <code>btn-buyback</code> variant<br>
+        Section cleared when game_tick advances past the beat it was created
+      </div>
     </div>
 
-    <!-- Qty picker -->
+    <!-- Qty picker (no spinners) -->
     <div class="closeup-card">
-      <div class="closeup-title">Quantity Picker — Close-up</div>
-      <div style="padding: 10px 0;">
-        <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+      <div class="closeup-title">Qty Picker — No Native Spinners</div>
+      <div style="padding:12px 0 4px;">
+        <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
           <div class="qty-picker">
             <button class="qty-step-btn">−</button>
-            <input class="qty-input" type="number" value="2" readonly>
+            <input class="qty-input" type="number" value="2" min="1" max="4">
             <button class="qty-step-btn">+</button>
             <span class="qty-max">/ 4</span>
           </div>
           <span class="qty-total">= 60 💰</span>
         </div>
       </div>
-      <div style="font-size:0.6rem; color:var(--text-dim); margin-top:8px; line-height:1.6;">
-        Appears in action row when item.quantity &gt; 1<br>
-        Buttons: 26×26px, lime border, rgba(0,255,136,0.1) bg<br>
-        Input: 38px wide, direct keyboard edit supported<br>
-        Max: merchant stock qty · Min: 1<br>
-        Total updates live on every change
+      <div class="dim-note">
+        CSS: <code>input[type=number]::-webkit-inner-spin-button,</code><br>
+        <code>::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }</code><br>
+        <code>input[type=number] { -moz-appearance: textfield; appearance: textfield; }</code><br><br>
+        Step buttons: 26×26px, lime border, rgba(0,255,136,0.1) bg<br>
+        Input: 36px wide, keyboard-editable, no native UI chrome<br>
+        Min: 1 · Max: stock qty · Default: 1
       </div>
     </div>
 
-    <!-- Jambo gold bar -->
+    <!-- Button variants -->
     <div class="closeup-card">
-      <div class="closeup-title">Merchant Gold Bar (Sell Tab only)</div>
-      <div style="margin-top:8px;">
-        <div class="merch-gold-bar">
-          <span class="label">Jambo's gold:</span>
-          <span class="amount">800 💰</span>
-          <span class="merch-gold-note">Max he can pay</span>
-        </div>
-        <!-- Low gold variant -->
-        <div class="merch-gold-bar" style="margin-top:8px; border-color:rgba(255,68,68,0.3); background:rgba(255,68,68,0.05);">
-          <span class="label">Jambo's gold:</span>
-          <span class="amount" style="color:var(--danger);">8 💰</span>
-          <span class="merch-gold-note" style="color:rgba(255,68,68,0.6);">Jambo is running low</span>
-        </div>
+      <div class="closeup-title">All Button Variants</div>
+      <div style="display:flex;flex-direction:column;gap:9px;margin-top:8px;">
+        <button class="btn btn-buy">Buy · 20 💰</button>
+        <button class="btn btn-buy">Buy 2 · 60 💰</button>
+        <button class="btn btn-sell">Sell · +12 💰</button>
+        <button class="btn btn-buyback">Buyback · 12 💰</button>
+        <button class="btn btn-disabled" disabled>Buy · 80 💰 (disabled)</button>
       </div>
-      <div style="font-size:0.6rem; color:var(--text-dim); margin-top:10px; line-height:1.6;">
-        Normal: orange accent border<br>
-        Low (&lt; 50gp): switches to danger red accent<br>
-        Jambo starts with 800 gold (from npc config)
+      <div class="dim-note">
+        Buy: #00ff88 · Sell: #ffaa00 · Buyback: #00ccff · Disabled: danger red muted<br>
+        All: padding 7px 18px · font-size 0.72rem · uppercase · letter-spacing 1px
       </div>
     </div>
 
-  </div><!-- /closeup-grid -->
-
-  <div class="annotation" style="margin-top:16px;">
-    <strong>All close-ups above</strong> are lifted directly from the states shown above — same CSS, no modifications. Use these as the reference when implementing React components.
   </div>
 </div>
 
+
 <!-- ══════════════════════════════════════════════════════════
-     Color / Token Reference
+     Color Token Reference
 ══════════════════════════════════════════════════════════ -->
 <div class="section">
-  <div class="section-label">Shop-Specific Color Mapping</div>
-  <div style="display:grid; grid-template-columns: repeat(auto-fill, minmax(200px,1fr)); gap:12px;">
-    <div class="closeup-card" style="display:flex; align-items:center; gap:12px;">
+  <div class="section-label">Shop Color Mapping</div>
+  <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(190px,1fr));gap:12px;">
+    <div class="closeup-card" style="display:flex;align-items:center;gap:12px;">
       <div style="width:32px;height:32px;border-radius:4px;background:#00ff88;flex-shrink:0;"></div>
-      <div>
-        <div style="font-size:0.75rem;font-weight:bold;">#00ff88 — Primary</div>
-        <div style="font-size:0.6rem;color:var(--text-muted);">Buy tab, selected row, buy button</div>
-      </div>
+      <div><div style="font-size:0.75rem;font-weight:bold;">#00ff88 Primary</div><div style="font-size:0.6rem;color:var(--text-muted);">Buy tab, selected row, buy btn</div></div>
     </div>
-    <div class="closeup-card" style="display:flex; align-items:center; gap:12px;">
+    <div class="closeup-card" style="display:flex;align-items:center;gap:12px;">
       <div style="width:32px;height:32px;border-radius:4px;background:#ffaa00;flex-shrink:0;"></div>
-      <div>
-        <div style="font-size:0.75rem;font-weight:bold;">#ffaa00 — Secondary</div>
-        <div style="font-size:0.6rem;color:var(--text-muted);">Sell tab, offer prices, sell button</div>
-      </div>
+      <div><div style="font-size:0.75rem;font-weight:bold;">#ffaa00 Secondary</div><div style="font-size:0.6rem;color:var(--text-muted);">Sell tab, offers, sell btn, pending bar</div></div>
     </div>
-    <div class="closeup-card" style="display:flex; align-items:center; gap:12px;">
+    <div class="closeup-card" style="display:flex;align-items:center;gap:12px;">
       <div style="width:32px;height:32px;border-radius:4px;background:#ffcc00;flex-shrink:0;"></div>
-      <div>
-        <div style="font-size:0.75rem;font-weight:bold;">#ffcc00 — Gold</div>
-        <div style="font-size:0.6rem;color:var(--text-muted);">Player gold, item prices, qty totals</div>
-      </div>
+      <div><div style="font-size:0.75rem;font-weight:bold;">#ffcc00 Gold</div><div style="font-size:0.6rem;color:var(--text-muted);">Player gold, item prices, qty totals</div></div>
     </div>
-    <div class="closeup-card" style="display:flex; align-items:center; gap:12px;">
+    <div class="closeup-card" style="display:flex;align-items:center;gap:12px;">
       <div style="width:32px;height:32px;border-radius:4px;background:#ff4444;flex-shrink:0;"></div>
-      <div>
-        <div style="font-size:0.75rem;font-weight:bold;">#ff4444 — Danger</div>
-        <div style="font-size:0.6rem;color:var(--text-muted);">Can't afford state, disabled button</div>
-      </div>
+      <div><div style="font-size:0.75rem;font-weight:bold;">#ff4444 Danger</div><div style="font-size:0.6rem;color:var(--text-muted);">Can't afford, overweight, disabled</div></div>
     </div>
-    <div class="closeup-card" style="display:flex; align-items:center; gap:12px;">
+    <div class="closeup-card" style="display:flex;align-items:center;gap:12px;">
       <div style="width:32px;height:32px;border-radius:4px;background:#00ccff;flex-shrink:0;"></div>
-      <div>
-        <div style="font-size:0.75rem;font-weight:bold;">#00ccff — Accent</div>
-        <div style="font-size:0.6rem;color:var(--text-muted);">NPC name, NPC strip border</div>
-      </div>
+      <div><div style="font-size:0.75rem;font-weight:bold;">#00ccff Accent</div><div style="font-size:0.6rem;color:var(--text-muted);">Buyback badge, buyback btn, NPC name</div></div>
     </div>
+  </div>
+</div>
+
+<!-- Backend Research Note -->
+<div class="section">
+  <div class="section-label">Backend Research Note — Buyback System</div>
+  <div style="padding:14px;background:rgba(0,204,255,0.05);border:1px solid rgba(0,204,255,0.2);border-radius:8px;font-size:0.72rem;line-height:1.8;color:var(--text-main);">
+    <div style="color:var(--accent);font-weight:bold;margin-bottom:8px;">⚠ Research required before planning implementation</div>
+    <strong>What needs to exist backend-side:</strong><br>
+    1. A transient <strong>buyback ledger</strong> per merchant session — list of <code>{ item_id, item_data, qty, buyback_price, beat_acquired }</code> records.<br>
+    2. The ledger is populated when <code>ShopInterface.sell()</code> is called — item transferred to Jambo's possession at a <em>tagged</em> price equal to what the player received.<br>
+    3. On every <code>game_tick_events()</code> call, stale ledger entries (where <code>beat_acquired &lt; current_beat</code>) are flushed and the items enter regular inventory rotation.<br>
+    4. The merchant serializer must expose buyback items as a separate list (e.g. <code>buyback_items: [...]</code>) distinct from <code>stock</code>, so the frontend can render them with the buyback treatment.<br>
+    5. New API endpoint needed: <code>POST /api/shop/buyback</code> — takes <code>{ merchant_id, item_id }</code>, validates the ledger entry, transfers item back to player at buyback price.<br><br>
+    <strong>Files to investigate:</strong>
+    <code>src/npc/_shop.py</code> (MerchantShopMixin), <code>src/interface.py</code> (ShopInterface), <code>src/api/routes/</code> (no shop routes exist yet), <code>src/api/services/game_service.py</code>.
   </div>
 </div>
 

--- a/docs/development/shop-acceptance-test-plan.md
+++ b/docs/development/shop-acceptance-test-plan.md
@@ -1,0 +1,504 @@
+# Shop System — Acceptance Test Plan
+
+**Branch:** `claude/jambo-shop-ui-mockup-I2uda`  
+**Feature:** Jambo shop dialog (backend API + React UI)  
+**Config:** `config_shop_testing.ini`
+
+---
+
+## Test Environment Setup
+
+### Start the API server
+
+```bash
+CONFIG_FILE=config_shop_testing.ini python tools/run_api.py
+```
+
+The server starts with:
+- Player at `(0, 0)` on `shop-testing` map (a single tile with Jambo)
+- 200 gold in inventory
+- Shortsword (auto-equipped, weight 2 kg) + Leather Armor (auto-equipped, weight 2.5 kg)
+
+### Start the frontend dev server
+
+```bash
+cd frontend && npm run dev
+```
+
+### Obtain a session token
+
+All API requests require `Authorization: Bearer <session_id>`.
+
+```bash
+# Register/login
+curl -s -X POST http://localhost:5000/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"shoptest","password":"test123","email":"t@t.com"}' \
+  | jq '.session_id'
+```
+
+Or in test mode (no DB needed):
+
+```bash
+curl -s -X POST http://localhost:5000/api/test/session \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"shoptest"}' \
+  | jq '.session_id'
+```
+
+Set the token:
+```bash
+export TOKEN="<session_id from above>"
+```
+
+### Obtain Jambo's npc_id
+
+```bash
+JAMBO_ID=$(curl -s http://localhost:5000/api/world \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq -r '.location.npcs[0].id')
+echo "Jambo npc_id: $JAMBO_ID"
+```
+
+---
+
+## Reference Prices
+
+| Item | Buy price | Sell offer | Weight |
+|---|---|---|---|
+| Restorative (×1) | 100 💰 | 50 💰 | 0.25 kg |
+| Draught (×1) | 75 💰 | 37 💰 | 0.25 kg |
+| Antidote (×1) | 175 💰 | 87 💰 | 0.25 kg |
+| Shortsword (equipped) | — | blocked | 2.0 kg |
+| Leather Armor (equipped) | — | blocked | 2.5 kg |
+
+Player start state: **200 💰**, **4.5 kg** carried.
+
+---
+
+## API Test Cases
+
+### TC-001 — GET shop state (happy path)
+
+```bash
+curl -s "http://localhost:5000/api/shop/state?npc_id=$JAMBO_ID" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+```
+
+**Expected:**
+- `success: true`
+- `shop_state.npc_name = "Jambo"`
+- `shop_state.shop_name = "Jambo Heals U"`
+- `shop_state.buy_modifier = 1.0`
+- `shop_state.sell_modifier = 0.5`
+- `shop_state.stock` contains Restorative (×5), Draught (×4), Antidote (×3) and random extras
+- `shop_state.buyback_items = []` (no sales yet)
+- `shop_state.player_gold = 200`
+- `shop_state.merchant_gold = 800`
+- `sell_inventory` contains Shortsword and Leather Armor entries **— wait, these are equipped; they should NOT appear**
+
+> **PASS CRITERION:** `sell_inventory` must be an empty list — equipped items are filtered.
+
+---
+
+### TC-002 — GET shop state: missing npc_id
+
+```bash
+curl -s "http://localhost:5000/api/shop/state" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+```
+
+**Expected:** `400`, `success: false`, error mentions `npc_id`.
+
+---
+
+### TC-003 — GET shop state: wrong npc_id
+
+```bash
+curl -s "http://localhost:5000/api/shop/state?npc_id=000000" \
+  -H "Authorization: Bearer $TOKEN" | jq .
+```
+
+**Expected:** `404`, `success: false`, error mentions "Merchant not found".
+
+---
+
+### TC-004 — Buy 1× Restorative (happy path)
+
+First capture a Restorative item_id from the stock list:
+
+```bash
+RESTORATIVE_ID=$(curl -s "http://localhost:5000/api/shop/state?npc_id=$JAMBO_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq -r '.shop_state.stock[] | select(.name=="Restorative") | .id')
+```
+
+```bash
+curl -s -X POST http://localhost:5000/api/shop/buy \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"npc_id\":\"$JAMBO_ID\",\"item_id\":\"$RESTORATIVE_ID\",\"quantity\":1}" | jq .
+```
+
+**Expected:**
+- `success: true`
+- `gold_spent = 100`
+- `shop_state.player_gold = 100` (200 − 100)
+- `shop_state.stock` Restorative count drops from 5 → 4
+- `sell_inventory` now contains the purchased Restorative
+
+---
+
+### TC-005 — Buy: insufficient gold
+
+(Run after TC-004 — player has 100 gold left. Try to buy an Antidote costing 175.)
+
+```bash
+ANTIDOTE_ID=$(curl -s "http://localhost:5000/api/shop/state?npc_id=$JAMBO_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq -r '.shop_state.stock[] | select(.name=="Antidote") | .id')
+
+curl -s -X POST http://localhost:5000/api/shop/buy \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"npc_id\":\"$JAMBO_ID\",\"item_id\":\"$ANTIDOTE_ID\",\"quantity\":1}" | jq .
+```
+
+**Expected:** `400`, `success: false`, error = `"Not enough gold — need 75 more"`.
+
+---
+
+### TC-006 — Buy: quantity > 1
+
+(Fresh state or after TC-004 with 100 gold — buy 1 Draught costing 75.)
+
+```bash
+DRAUGHT_ID=$(curl -s "http://localhost:5000/api/shop/state?npc_id=$JAMBO_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq -r '.shop_state.stock[] | select(.name=="Draught") | .id')
+
+curl -s -X POST http://localhost:5000/api/shop/buy \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"npc_id\":\"$JAMBO_ID\",\"item_id\":\"$DRAUGHT_ID\",\"quantity\":2}" | jq .
+```
+
+**Expected:**
+- `success: true`, `gold_spent = 150` (75 × 2)
+- `shop_state.stock` Draught count drops by 2
+
+---
+
+### TC-007 — Sell 1× Restorative (happy path)
+
+(Run after TC-004 — player has a Restorative in sell_inventory.)
+
+```bash
+# Get the player's Restorative item_id from sell_inventory
+PLAYER_RESTORATIVE_ID=$(curl -s "http://localhost:5000/api/shop/state?npc_id=$JAMBO_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq -r '.sell_inventory[] | select(.name=="Restorative") | .id')
+
+curl -s -X POST http://localhost:5000/api/shop/sell \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"npc_id\":\"$JAMBO_ID\",\"item_id\":\"$PLAYER_RESTORATIVE_ID\",\"quantity\":1}" | jq .
+```
+
+**Expected:**
+- `success: true`, `gold_gained = 50`
+- `shop_state.player_gold` increases by 50
+- `shop_state.buyback_items` now has 1 entry for Restorative at price 50
+- Restorative disappears from `sell_inventory`
+- The buyback entry has `is_buyback: true`
+
+---
+
+### TC-008 — Sell: cannot sell equipped item
+
+```bash
+# Get Shortsword id from player inventory via world state
+SWORD_ID=$(curl -s http://localhost:5000/api/inventory \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq -r '.inventory[] | select(.name=="Shortsword") | .id')
+
+curl -s -X POST http://localhost:5000/api/shop/sell \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"npc_id\":\"$JAMBO_ID\",\"item_id\":\"$SWORD_ID\",\"quantity\":1}" | jq .
+```
+
+**Expected:** `400`, `success: false`, error = `"Cannot sell equipped items"`.
+
+---
+
+### TC-009 — Buyback (happy path)
+
+(Run after TC-007 — buyback_items has a Restorative at price 50.)
+
+```bash
+BUYBACK_ID=$(curl -s "http://localhost:5000/api/shop/state?npc_id=$JAMBO_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq -r '.shop_state.buyback_items[0].id')
+
+curl -s -X POST http://localhost:5000/api/shop/buyback \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"npc_id\":\"$JAMBO_ID\",\"item_id\":\"$BUYBACK_ID\"}" | jq .
+```
+
+**Expected:**
+- `success: true`, `gold_spent = 50`
+- `shop_state.buyback_items = []` (entry removed after buyback)
+- Restorative reappears in `sell_inventory`
+
+---
+
+### TC-010 — Buyback: wrong item_id
+
+```bash
+curl -s -X POST http://localhost:5000/api/shop/buyback \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"npc_id\":\"$JAMBO_ID\",\"item_id\":\"000000\"}" | jq .
+```
+
+**Expected:** `400`, `success: false`, error mentions "expired" or "not found".
+
+---
+
+### TC-011 — Buyback expiry on game_tick advance
+
+This requires moving the player (increments `game_tick`).
+
+```bash
+# 1. Sell a Restorative to create a buyback entry (requires buying one first)
+# ... (TC-004 then TC-007)
+
+# 2. Confirm buyback entry exists
+curl -s "http://localhost:5000/api/shop/state?npc_id=$JAMBO_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq '.shop_state.buyback_items | length'
+# Expected: 1
+
+# 3. Buyback entries are scoped to the current game_tick.
+#    Because the shop-testing map has no exits, game_tick cannot increment
+#    without a combat event. Simulate a tick change by calling a world move
+#    on a map that has exits, OR verify this behavior via unit test.
+```
+
+> **NOTE:** The shop-testing map is intentionally a single tile with no exits (to keep the player next to Jambo). TC-011 is best verified via a unit test or by temporarily adding an exit and moving back.
+
+---
+
+### TC-012 — Unauthenticated request
+
+```bash
+curl -s "http://localhost:5000/api/shop/state?npc_id=$JAMBO_ID" | jq .
+```
+
+**Expected:** `401`, `success: false`, error = `"Missing authorization"`.
+
+---
+
+## Frontend UI Test Cases
+
+### UI-001 — Open shop via "trade" keyword
+
+1. Open the game in the browser at `http://localhost:3000`
+2. Log in; verify the player is at the Market Stall with Jambo present
+3. Click **Interact** → select **Jambo** → click **trade**
+4. **PASS:** `ShopDialog` opens with title "🏪 JAMBO HEALS U" on the **Buy** tab
+
+---
+
+### UI-002 — Open shop via "sell" keyword (opens on Sell tab)
+
+1. Click **Interact** → select **Jambo** → click **sell**
+2. **PASS:** `ShopDialog` opens directly on the **Sell** tab
+
+---
+
+### UI-003 — Open shop via "buy" keyword (opens on Buy tab)
+
+1. Click **Interact** → select **Jambo** → click **buy**
+2. **PASS:** `ShopDialog` opens on the **Buy** tab
+
+---
+
+### UI-004 — NPC strip and player gold
+
+1. Open shop (any keyword)
+2. **PASS:** 
+   - Jambo avatar visible (🧕), name "Jambo", tagline `"When you blue, Jambo Heals U!"`
+   - Player gold shows **200 💰**
+
+---
+
+### UI-005 — Weight bar shows current weight
+
+1. Open shop
+2. **PASS:** Weight bar shows current carried weight (≈ 4.5 kg from Shortsword + Leather Armor) against player max
+
+---
+
+### UI-006 — Weight bar pending delta on item selection (buy)
+
+1. Open shop on Buy tab
+2. Click a Restorative row
+3. **PASS:**
+   - Weight bar shows a pending orange segment (`+0.25 kg`)
+   - Text: `4.5 + (+0.25) → 4.75 kg after`
+
+---
+
+### UI-007 — Buy tab: stock items visible
+
+1. Open shop on Buy tab
+2. **PASS:**
+   - Restorative ×5, Draught ×4, Antidote ×3 visible in item list
+   - Prices displayed: 100 💰, 75 💰, 175 💰
+   - No equipped items (Shortsword, Leather Armor) in the list
+
+---
+
+### UI-008 — Buy action with sufficient gold
+
+1. Open shop → Buy tab → select Restorative
+2. Click **Buy · 100 💰**
+3. **PASS:**
+   - Transaction message: "Purchased 1× Restorative for 100 gold."
+   - Player gold updates to **100 💰** in NPC strip
+   - Restorative count in stock drops to ×4
+
+---
+
+### UI-009 — Insufficient gold: Buy button disabled
+
+1. After TC-008/UI-008 (100 gold remaining), select Antidote (costs 175)
+2. **PASS:**
+   - Buy button is **disabled** (red border/color)
+   - Message below selected item: `⚠ Not enough gold — need 75 more`
+
+---
+
+### UI-010 — Quantity picker appears for stackable items
+
+1. Open shop → Buy tab → select Restorative (×4 or more in stock)
+2. **PASS:**
+   - `QtyPicker` component appears with `−` / `+` buttons and a number input
+   - No native browser up/down spinner arrows on the input
+   - `−` button disabled at qty=1
+
+---
+
+### UI-011 — Quantity picker: price updates live
+
+1. With Restorative selected, set qty to 2 using `+`
+2. **PASS:** Button label updates to `Buy 2 · 200 💰`
+
+---
+
+### UI-012 — Sell tab: equipped items not listed
+
+1. Open shop → Sell tab
+2. **PASS:**
+   - Neither Shortsword nor Leather Armor appears in the sell inventory
+   - "Nothing to sell" message OR only items bought from Jambo are listed
+
+---
+
+### UI-013 — Sell tab: merchant gold bar
+
+1. Open shop → Sell tab
+2. **PASS:** Merchant gold bar shows Jambo's current gold (800 at start)
+
+---
+
+### UI-014 — Sell flow end-to-end
+
+1. Buy a Restorative (from UI-008)
+2. Open Sell tab → select the Restorative → click **Sell · +50 💰**
+3. **PASS:**
+   - Transaction message: "Sold 1× Restorative for 50 gold."
+   - Player gold increases by 50
+   - Restorative disappears from sell inventory
+
+---
+
+### UI-015 — Buyback section appears after selling
+
+1. After UI-014 (just sold a Restorative)
+2. Switch to Buy tab
+3. **PASS:**
+   - A `↩ Buyback Available (until next beat)` section header appears in **cyan**
+   - Restorative row shows `↩ BUYBACK` badge in cyan
+   - Price shown is **50 💰** (the sell price, not the buy price)
+
+---
+
+### UI-016 — Weight bar delta on sell selection
+
+1. After UI-014, open Sell tab → select an item
+2. **PASS:**
+   - Weight bar shows a **faded green segment** indicating weight that will be freed
+   - No "Exceeds carry limit" warning
+
+---
+
+### UI-017 — Buyback flow end-to-end
+
+1. After UI-015, switch to Buy tab → click the buyback Restorative row → click **Buyback · 50 💰**
+2. **PASS:**
+   - Transaction message: "Purchased …" or equivalent
+   - Buyback section disappears
+   - Player gold decreases by 50
+   - Restorative reappears in sell inventory
+
+---
+
+### UI-018 — Tab state resets on switch
+
+1. Buy tab → select an item → switch to Sell tab
+2. **PASS:** No item is selected on the Sell tab; qty resets to 1
+
+---
+
+### UI-019 — Close button
+
+1. Open shop → click **×** (BaseDialog close)
+2. **PASS:** Dialog closes; InteractPanel does not reopen automatically
+
+---
+
+### UI-020 — Mobile layout (isMobile = true)
+
+*Resize browser to < 480 px width or use DevTools device emulation.*
+
+1. Open shop
+2. **PASS:**
+   - Item rows have min-height ≥ 44 px (accessible touch targets)
+   - Quantity step buttons are 44 × 44 px
+   - Tab buttons have larger padding (≥ 10 px vertical)
+   - Action row stacks vertically (button full-width below item label)
+   - Modal max-height is 92 vh with scroll
+
+---
+
+## Edge Case Notes
+
+| Scenario | Where to test |
+|---|---|
+| Buyback entry expires on game_tick advance | Unit test or TC-011 workaround |
+| Player at exact weight limit (overweight) | Send raw API call with mock high weight; UI shows "Exceeds carry limit" |
+| Merchant runs out of gold (sell many items) | Buy 16 Draughts with another session, then sell; merchant gold → 0 |
+| Buying a full stack (e.g. Restorative ×5 all at once) | qty picker max = 5 (or affordability-capped); buy all → stock empty |
+| Stale session after shop transaction | Load page in second tab; gold sync via `onRefetch` keeps both tabs consistent |
+
+---
+
+## Definition of Done
+
+All TC-001 – TC-012 API tests pass with the correct HTTP status codes and response bodies.  
+All UI-001 – UI-020 pass with no console errors.  
+No regressions in the existing test suite (`python -m pytest -q` — 1083 passed).

--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -107,6 +107,18 @@ export const feedback = {
     apiClient.post('/feedback/issue', { type, title, fields, anonymous }),
 }
 
+// Shop endpoints
+export const shop = {
+  getState: (npcId) =>
+    apiClient.get('/shop/state', { params: { npc_id: npcId } }),
+  buy: (npcId, itemId, quantity) =>
+    apiClient.post('/shop/buy', { npc_id: npcId, item_id: itemId, quantity }),
+  sell: (npcId, itemId, quantity) =>
+    apiClient.post('/shop/sell', { npc_id: npcId, item_id: itemId, quantity }),
+  buyback: (npcId, itemId) =>
+    apiClient.post('/shop/buyback', { npc_id: npcId, item_id: itemId }),
+}
+
 export default {
   auth,
   player,
@@ -116,4 +128,5 @@ export default {
   equipment,
   saves,
   feedback,
+  shop,
 }

--- a/frontend/src/components/InteractPanel.jsx
+++ b/frontend/src/components/InteractPanel.jsx
@@ -13,12 +13,15 @@ import { renderTextWithLinks, getEntityColor } from '../utils/entityUtils'
  * InteractPanel - Dedicated panel for interacting with objects, NPCs, and items
  * Provides target selection, detailed item/object info, and action execution
  */
+const SHOP_KEYWORDS = new Set(['buy', 'sell', 'trade'])
+
 function InteractPanel({
     location,
     onInteractionComplete,
     onEventsTriggered,
     onRefetch,
     onClose,
+    onOpenShop,
     initialTarget = null,
     history = [],
     onTypingChange
@@ -212,6 +215,13 @@ function InteractPanel({
         // Handle take_all specially for ground items
         if (action === 'take_all_ground') {
             await handleTakeAll()
+            return
+        }
+
+        // Route shop keywords to ShopDialog instead of world.interact
+        if (SHOP_KEYWORDS.has(action.toLowerCase()) && onOpenShop && selectedTarget) {
+            const initialTab = action.toLowerCase() === 'sell' ? 'sell' : 'buy'
+            onOpenShop(selectedTarget.id, selectedTarget.name, initialTab)
             return
         }
 

--- a/frontend/src/components/LeftPanel.jsx
+++ b/frontend/src/components/LeftPanel.jsx
@@ -19,6 +19,7 @@ import CombatCheckDialog from './CombatCheckDialog'
 import SuggestedMovesPanel from './SuggestedMovesPanel'
 import FeedbackDialog from './FeedbackDialog'
 import CooldownTray from './CooldownTray'
+import ShopDialog from './ShopDialog'
 
 const BETA_MODE = import.meta.env.VITE_BETA_MODE === 'true'
 
@@ -43,6 +44,7 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
   const [showActions, setShowActions] = useState(false)
   const [showInteract, setShowInteract] = useState(false)
   const [interactTarget, setInteractTarget] = useState(null)
+  const [shopContext, setShopContext] = useState(null)
 
   const handleOpenInteract = (target = null) => {
     // If clicking the main interact button while panel is open, close it
@@ -815,6 +817,23 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
           onInteractionTypingChange={onInteractionTypingChange}
           onRefetch={onRefetch}
           onTypingChange={onInteractionTypingChange}
+          onOpenShop={(npcId, npcName, initialTab) => {
+            setShowInteract(false)
+            setInteractTarget(null)
+            setShopContext({ npcId, npcName, initialTab })
+          }}
+        />
+      )}
+
+      {shopContext && player && (
+        <ShopDialog
+          npcId={shopContext.npcId}
+          npcName={shopContext.npcName}
+          initialTab={shopContext.initialTab}
+          player={player}
+          onClose={() => setShopContext(null)}
+          onRefetch={onRefetch}
+          isMobile={isMobile}
         />
       )}
 

--- a/frontend/src/components/ShopDialog.jsx
+++ b/frontend/src/components/ShopDialog.jsx
@@ -1,0 +1,762 @@
+import { useState, useMemo } from 'react'
+import BaseDialog from './BaseDialog'
+import { useShop } from '../hooks/useShop'
+import { colors, spacing, accessibility } from '../styles/theme'
+import { getItemIcon } from '../utils/itemUtils'
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function WeightBar({ current, max, pendingDelta, isMobile }) {
+  const currentPct = max > 0 ? Math.min(100, (current / max) * 100) : 0
+  const isSellDelta = pendingDelta < 0
+  const pendingPct = max > 0
+    ? isSellDelta
+      ? Math.min(currentPct, (Math.abs(pendingDelta) / max) * 100)
+      : Math.min(100 - currentPct, (Math.abs(pendingDelta) / max) * 100)
+    : 0
+  const projectedTotal = current + pendingDelta
+  const isOverweight = projectedTotal > max
+
+  const fillColor =
+    currentPct >= 90 ? colors.danger
+    : currentPct >= 75 ? colors.secondary
+    : colors.primary
+
+  const pendingColor = isOverweight ? colors.danger : 'rgba(255,170,0,0.7)'
+
+  const isBuy = pendingDelta > 0
+
+  return (
+    <div style={{
+      padding: `6px ${spacing.md}`,
+      background: 'rgba(0,0,0,0.3)',
+      border: `1px solid ${colors.border.main}`,
+      borderRadius: '6px',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '4px',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.65rem' }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px', color: colors.text.muted }}>
+          <span>⚖️</span>
+          <span style={{ color: colors.text.main, fontWeight: 'bold' }}>{current.toFixed(1)}</span>
+          {pendingDelta !== 0 && (
+            <>
+              <span style={{ color: colors.text.dim }}>+</span>
+              <span style={{
+                color: isSellDelta ? colors.primary : isOverweight ? colors.danger : colors.secondary,
+                fontWeight: 'bold',
+              }}>
+                ({isSellDelta ? '−' : '+'}{Math.abs(pendingDelta).toFixed(2)})
+              </span>
+              {!isMobile && (
+                <span style={{ color: colors.text.dim, fontSize: '0.58rem' }}>
+                  → {projectedTotal.toFixed(1)} kg after
+                </span>
+              )}
+            </>
+          )}
+          {!isMobile && pendingDelta === 0 && <span style={{ color: colors.text.dim }}>&nbsp;kg</span>}
+        </div>
+        <span style={{ color: colors.text.dim, fontSize: '0.62rem' }}>max {max.toFixed(1)} kg</span>
+      </div>
+      <div style={{
+        width: '100%',
+        height: '8px',
+        background: 'rgba(255,255,255,0.06)',
+        borderRadius: '4px',
+        overflow: 'hidden',
+        display: 'flex',
+      }}>
+        <div style={{
+          width: `${currentPct - (isSellDelta ? pendingPct : 0)}%`,
+          height: '100%',
+          background: fillColor,
+          boxShadow: `0 0 4px ${fillColor}66`,
+          flexShrink: 0,
+          transition: 'width 0.2s ease',
+        }} />
+        {pendingDelta !== 0 && (
+          <div style={{
+            width: `${pendingPct}%`,
+            height: '100%',
+            background: isSellDelta ? 'rgba(0,255,136,0.25)' : pendingColor,
+            flexShrink: 0,
+            transition: 'width 0.2s ease',
+          }} />
+        )}
+      </div>
+      {isOverweight && (
+        <div style={{ fontSize: '0.62rem', color: colors.danger }}>
+          ⚠ Exceeds carry limit
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ItemRow({ item, isSelected, tab, onClick, isMobile }) {
+  const count = item.count || 1
+  const isBuyback = item.is_buyback
+
+  const borderColor = isSelected
+    ? isBuyback ? colors.accent
+      : tab === 'sell' ? colors.secondary
+      : colors.primary
+    : 'transparent'
+
+  const bgColor = isSelected
+    ? isBuyback ? 'rgba(0,204,255,0.10)'
+      : tab === 'sell' ? 'rgba(255,170,0,0.10)'
+      : 'rgba(0,255,136,0.10)'
+    : isBuyback ? 'rgba(0,204,255,0.04)'
+    : 'transparent'
+
+  const priceColor = isBuyback ? colors.accent
+    : tab === 'sell' ? colors.secondary
+    : colors.gold
+
+  const displayPrice = tab === 'sell' ? item.offer : item.price
+
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '2fr 58px 68px 86px',
+        alignItems: 'center',
+        padding: `0 14px`,
+        minHeight: isMobile ? accessibility.touchTarget : '44px',
+        borderLeft: `3px solid ${borderColor}`,
+        paddingLeft: isSelected ? '11px' : '14px',
+        background: bgColor,
+        borderBottom: '1px solid rgba(255,170,0,0.07)',
+        cursor: 'pointer',
+        transition: 'background 0.12s',
+      }}
+    >
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: '7px',
+        fontSize: '0.82rem', color: colors.text.main, fontWeight: 500,
+        minWidth: 0,
+      }}>
+        <span style={{ fontSize: '0.95rem', flexShrink: 0 }}>
+          {getItemIcon(item)}
+        </span>
+        <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {item.name}
+        </span>
+        {count > 1 && (
+          <span style={{
+            fontSize: '0.58rem',
+            background: 'rgba(255,204,0,0.15)',
+            color: colors.gold,
+            border: `1px solid rgba(255,204,0,0.3)`,
+            padding: '1px 5px', borderRadius: '8px', fontWeight: 'bold', flexShrink: 0,
+          }}>
+            ×{count}
+          </span>
+        )}
+        {isBuyback && (
+          <span style={{
+            fontSize: '0.55rem',
+            background: 'rgba(0,204,255,0.15)',
+            color: colors.accent,
+            border: `1px solid rgba(0,204,255,0.35)`,
+            padding: '1px 5px', borderRadius: '8px', fontWeight: 'bold',
+            flexShrink: 0, letterSpacing: '0.5px',
+            display: 'flex', alignItems: 'center', gap: '2px',
+          }}>
+            ↩ BUYBACK
+          </span>
+        )}
+      </div>
+      <div style={{ textAlign: 'right', fontSize: '0.62rem', color: colors.text.dim, textTransform: 'uppercase' }}>
+        {item.subtype || item.type || ''}
+      </div>
+      <div style={{ textAlign: 'right', fontSize: '0.7rem', color: colors.text.muted }}>
+        {(item.weight || 0).toFixed(2)} kg
+      </div>
+      <div style={{ textAlign: 'right', fontSize: '0.78rem', fontWeight: 'bold', color: priceColor }}>
+        {tab === 'sell' && (
+          <div style={{ fontSize: '0.58rem', color: colors.text.muted, fontWeight: 'normal', marginBottom: '1px' }}>
+            Offer:
+          </div>
+        )}
+        {displayPrice} 💰
+      </div>
+    </div>
+  )
+}
+
+function QtyPicker({ value, max, onChange, isMobile }) {
+  const btnSize = isMobile ? accessibility.touchTarget : '26px'
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '7px' }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: '6px',
+        background: 'rgba(0,0,0,0.4)',
+        border: '1px solid rgba(0,255,136,0.3)',
+        borderRadius: '6px', padding: '4px 8px',
+      }}>
+        <button
+          onClick={() => onChange(Math.max(1, value - 1))}
+          disabled={value <= 1}
+          style={{
+            width: btnSize, height: btnSize, minWidth: btnSize,
+            borderRadius: '4px',
+            border: '1px solid rgba(0,255,136,0.4)',
+            background: 'rgba(0,255,136,0.1)', color: colors.primary,
+            fontSize: '1rem', fontWeight: 'bold', cursor: value <= 1 ? 'not-allowed' : 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            opacity: value <= 1 ? 0.4 : 1,
+            fontFamily: 'monospace', lineHeight: 1,
+          }}
+        >−</button>
+        <input
+          type="number"
+          value={value}
+          min={1}
+          max={max}
+          onChange={(e) => {
+            const v = Math.max(1, Math.min(max, parseInt(e.target.value, 10) || 1))
+            onChange(v)
+          }}
+          style={{
+            width: '36px', textAlign: 'center',
+            background: 'rgba(0,0,0,0.5)',
+            border: '1px solid rgba(0,255,136,0.3)',
+            borderRadius: '3px', color: colors.text.bright,
+            fontFamily: 'monospace', fontSize: '0.85rem',
+            fontWeight: 'bold', padding: '3px 4px',
+            // Remove native browser spinners
+            WebkitAppearance: 'none',
+            MozAppearance: 'textfield',
+            appearance: 'textfield',
+          }}
+        />
+        <button
+          onClick={() => onChange(Math.min(max, value + 1))}
+          disabled={value >= max}
+          style={{
+            width: btnSize, height: btnSize, minWidth: btnSize,
+            borderRadius: '4px',
+            border: '1px solid rgba(0,255,136,0.4)',
+            background: 'rgba(0,255,136,0.1)', color: colors.primary,
+            fontSize: '1rem', fontWeight: 'bold', cursor: value >= max ? 'not-allowed' : 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            opacity: value >= max ? 0.4 : 1,
+            fontFamily: 'monospace', lineHeight: 1,
+          }}
+        >+</button>
+        <span style={{ fontSize: '0.6rem', color: colors.text.muted, whiteSpace: 'nowrap' }}>/ {max}</span>
+      </div>
+    </div>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+/**
+ * ShopDialog — full shop modal overlay.
+ *
+ * Props:
+ *   npcId      {string}   str(id(npc)) of the merchant
+ *   npcName    {string}   Display name of the merchant
+ *   initialTab {string}   'buy' | 'sell'
+ *   player     {object}   Current player state (gold, weight)
+ *   onClose    {function}
+ *   onRefetch  {function} Called after each successful transaction to sync parent
+ *   isMobile   {boolean}
+ */
+export default function ShopDialog({ npcId, npcName, initialTab = 'buy', player, onClose, onRefetch, isMobile }) {
+  const { shopState, sellInventory, isLoading, error, txnMessage, buy, sell, buyback } = useShop(npcId)
+
+  const [activeTab, setActiveTab] = useState(initialTab)
+  const [selectedId, setSelectedId] = useState(null)
+  const [quantity, setQuantity] = useState(1)
+
+  // ── Derived values ─────────────────────────────────────────────────────────
+
+  const allBuyItems = useMemo(() => {
+    if (!shopState) return []
+    return [...(shopState.buyback_items || []), ...(shopState.stock || [])]
+  }, [shopState])
+
+  const selectedItem = useMemo(() => {
+    if (!selectedId) return null
+    const list = activeTab === 'buy' ? allBuyItems : sellInventory
+    return list.find(i => i.id === selectedId) || null
+  }, [selectedId, activeTab, allBuyItems, sellInventory])
+
+  // ── Weight delta for the weight bar ───────────────────────────────────────
+
+  const pendingWeight = useMemo(() => {
+    if (!selectedItem) return 0
+    const w = (selectedItem.weight || 0) * quantity
+    return activeTab === 'buy' ? w : -w
+  }, [selectedItem, quantity, activeTab])
+
+  // ── Buy validation ─────────────────────────────────────────────────────────
+
+  const playerGold = shopState?.player_gold ?? (player?.gold ?? 0)
+  const playerWeightCurrent = shopState?.player_weight_current ?? (player?.weight_current ?? 0)
+  const playerWeightMax = shopState?.player_weight_max ?? (player?.weight_tolerance ?? 100)
+  const merchantGold = shopState?.merchant_gold ?? 0
+
+  const buyTotal = selectedItem && activeTab === 'buy'
+    ? (selectedItem.price || 0) * quantity
+    : 0
+  const sellTotal = selectedItem && activeTab === 'sell'
+    ? (selectedItem.offer || 0) * quantity
+    : 0
+
+  const cannotAffordBuy = activeTab === 'buy' && selectedItem && playerGold < buyTotal
+  const wouldExceedWeight = activeTab === 'buy' && selectedItem
+    && (playerWeightCurrent + pendingWeight) > playerWeightMax
+  const merchantCantAfford = activeTab === 'sell' && selectedItem && merchantGold < sellTotal
+
+  const buyDisabledReason =
+    cannotAffordBuy ? `Not enough gold — need ${buyTotal - playerGold} more`
+    : wouldExceedWeight ? 'Exceeds carry limit'
+    : null
+
+  // ── Max qty for picker ──────────────────────────────────────────────────────
+
+  const maxQty = useMemo(() => {
+    if (!selectedItem) return 1
+    const available = selectedItem.count || 1
+    if (activeTab === 'buy' && !selectedItem.is_buyback) {
+      const unitPrice = selectedItem.price || 1
+      const affordable = unitPrice > 0 ? Math.floor(playerGold / unitPrice) : available
+      return Math.max(1, Math.min(available, affordable))
+    }
+    if (activeTab === 'sell') {
+      const unitOffer = selectedItem.offer || 1
+      const merchantCan = unitOffer > 0 ? Math.floor(merchantGold / unitOffer) : available
+      return Math.max(1, Math.min(available, merchantCan))
+    }
+    return Math.max(1, available)
+  }, [selectedItem, activeTab, playerGold, merchantGold])
+
+  // ── Handlers ───────────────────────────────────────────────────────────────
+
+  const handleSelectItem = (id) => {
+    setSelectedId(prev => prev === id ? null : id)
+    setQuantity(1)
+  }
+
+  const handleTabChange = (tab) => {
+    setActiveTab(tab)
+    setSelectedId(null)
+    setQuantity(1)
+  }
+
+  const handleBuy = async () => {
+    if (!selectedItem || buyDisabledReason) return
+    const result = await buy(selectedItem.id, quantity)
+    if (result.success) {
+      setSelectedId(null)
+      setQuantity(1)
+      if (onRefetch) await onRefetch()
+    }
+  }
+
+  const handleSell = async () => {
+    if (!selectedItem || merchantCantAfford) return
+    const result = await sell(selectedItem.id, quantity)
+    if (result.success) {
+      setSelectedId(null)
+      setQuantity(1)
+      if (onRefetch) await onRefetch()
+    }
+  }
+
+  const handleBuyback = async () => {
+    if (!selectedItem) return
+    const result = await buyback(selectedItem.id)
+    if (result.success) {
+      setSelectedId(null)
+      setQuantity(1)
+      if (onRefetch) await onRefetch()
+    }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  const shopName = shopState?.shop_name || `${npcName}'s Shop`
+  const tagline = npcName === 'Jambo' ? '"When you blue, Jambo Heals U!"' : `${npcName} — open for business`
+
+  const hasBuyback = (shopState?.buyback_items || []).length > 0
+  const buyItems = shopState?.stock || []
+
+  return (
+    <BaseDialog
+      title={`🏪 ${shopName.toUpperCase()}`}
+      onClose={onClose}
+      maxWidth="640px"
+      width="95%"
+      padding={isMobile ? '12px' : '16px'}
+      zIndex={1500}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: spacing.sm }}>
+
+        {/* NPC Strip */}
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: '12px',
+          padding: '8px 12px',
+          background: 'rgba(0,204,255,0.05)',
+          border: '1px solid rgba(0,204,255,0.2)',
+          borderRadius: '6px',
+        }}>
+          <div style={{
+            width: '40px', height: '40px', borderRadius: '50%',
+            background: 'linear-gradient(135deg, #2a1a00, #3d2800)',
+            border: `2px solid ${colors.gold}`,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: '1.3rem', flexShrink: 0,
+            boxShadow: '0 0 8px rgba(255,204,0,0.3)',
+          }}>🧕</div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ color: colors.accent, fontSize: '0.8rem', fontWeight: 'bold' }}>{npcName}</div>
+            <div style={{ color: colors.text.muted, fontSize: '0.62rem', fontStyle: 'italic', marginTop: '2px' }}>
+              {tagline}
+            </div>
+          </div>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: '6px',
+            color: cannotAffordBuy && selectedItem ? colors.danger : colors.gold,
+            fontSize: '0.85rem', fontWeight: 'bold', whiteSpace: 'nowrap',
+          }}>
+            💰 {isLoading ? '…' : playerGold}
+          </div>
+        </div>
+
+        {/* Weight Bar */}
+        <WeightBar
+          current={playerWeightCurrent}
+          max={playerWeightMax}
+          pendingDelta={pendingWeight}
+          isMobile={isMobile}
+        />
+
+        {/* Tab Bar */}
+        <div style={{
+          display: 'flex', gap: '4px',
+          background: 'rgba(0,0,0,0.3)', padding: '4px',
+          borderRadius: '6px', border: `1px solid ${colors.border.main}`,
+        }}>
+          {['buy', 'sell'].map(tab => {
+            const isActive = activeTab === tab
+            const activeColor = tab === 'sell' ? colors.secondary : colors.primary
+            return (
+              <button
+                key={tab}
+                onClick={() => handleTabChange(tab)}
+                style={{
+                  flex: 1,
+                  padding: isMobile ? '10px 12px' : '7px 12px',
+                  background: isActive ? (tab === 'sell' ? 'rgba(255,170,0,0.12)' : 'rgba(0,255,136,0.12)') : 'transparent',
+                  border: `1px solid ${isActive ? activeColor : 'transparent'}`,
+                  borderRadius: '4px',
+                  color: isActive ? activeColor : colors.text.muted,
+                  fontFamily: 'monospace', fontSize: '0.75rem',
+                  fontWeight: 'bold', textTransform: 'uppercase',
+                  letterSpacing: '1px', cursor: 'pointer', textAlign: 'center',
+                }}
+              >
+                {tab === 'buy' ? '⬇ Buy' : '⬆ Sell'}
+              </button>
+            )
+          })}
+        </div>
+
+        {/* Loading / Error */}
+        {isLoading && (
+          <div style={{ color: colors.text.muted, fontSize: '0.8rem', textAlign: 'center', padding: spacing.md }}>
+            Loading shop…
+          </div>
+        )}
+        {error && (
+          <div style={{
+            color: colors.danger, fontSize: '0.75rem', padding: '8px 12px',
+            background: 'rgba(255,68,68,0.1)', border: '1px solid rgba(255,68,68,0.3)',
+            borderRadius: '6px',
+          }}>
+            ⚠ {error}
+          </div>
+        )}
+
+        {/* Transaction feedback */}
+        {txnMessage && (
+          <div style={{
+            fontSize: '0.72rem', padding: '6px 12px',
+            background: txnMessage.type === 'success' ? 'rgba(0,255,136,0.08)' : 'rgba(255,68,68,0.08)',
+            border: `1px solid ${txnMessage.type === 'success' ? 'rgba(0,255,136,0.25)' : 'rgba(255,68,68,0.25)'}`,
+            color: txnMessage.type === 'success' ? colors.primary : colors.danger,
+            borderRadius: '6px',
+          }}>
+            {txnMessage.type === 'success' ? '✓' : '✗'} {txnMessage.text}
+          </div>
+        )}
+
+        {/* Item List */}
+        {!isLoading && !error && (
+          <div style={{
+            background: 'rgba(0,0,0,0.4)',
+            border: `1px solid ${colors.border.main}`,
+            borderRadius: '8px', overflow: 'hidden',
+          }}>
+            {/* List header */}
+            <div style={{
+              display: 'grid',
+              gridTemplateColumns: '2fr 58px 68px 86px',
+              padding: '5px 14px',
+              background: 'rgba(0,0,0,0.5)',
+              borderBottom: `1px solid ${colors.border.main}`,
+            }}>
+              {[activeTab === 'buy' ? 'Item' : 'Your Item', 'Type', 'Weight', activeTab === 'buy' ? 'Price' : 'Offer'].map((h, i) => (
+                <div key={h} style={{
+                  color: colors.text.dim, fontSize: '0.58rem',
+                  fontWeight: 'bold', textTransform: 'uppercase', letterSpacing: '1px',
+                  textAlign: i > 0 ? 'right' : 'left',
+                }}>{h}</div>
+              ))}
+            </div>
+
+            {/* Buy tab content */}
+            {activeTab === 'buy' && (
+              <>
+                {/* Buyback section */}
+                {hasBuyback && (
+                  <>
+                    <div style={{
+                      padding: '4px 14px',
+                      background: 'rgba(0,204,255,0.07)',
+                      borderBottom: '1px solid rgba(0,204,255,0.15)',
+                      color: colors.accent, fontSize: '0.58rem',
+                      fontWeight: 'bold', textTransform: 'uppercase', letterSpacing: '1.5px',
+                      display: 'flex', alignItems: 'center', gap: '6px',
+                    }}>
+                      ↩ Buyback Available
+                      <span style={{ color: colors.text.dim, fontWeight: 'normal', letterSpacing: 0 }}>
+                        (until next beat)
+                      </span>
+                    </div>
+                    {shopState.buyback_items.map(item => (
+                      <ItemRow
+                        key={item.id}
+                        item={item}
+                        isSelected={selectedId === item.id}
+                        tab="buy"
+                        onClick={() => handleSelectItem(item.id)}
+                        isMobile={isMobile}
+                      />
+                    ))}
+                  </>
+                )}
+
+                {/* Regular stock */}
+                {hasBuyback && (
+                  <div style={{
+                    padding: '4px 14px',
+                    background: 'rgba(0,0,0,0.2)',
+                    borderBottom: '1px dashed rgba(255,255,255,0.05)',
+                    color: colors.text.dim, fontSize: '0.58rem',
+                    fontWeight: 'bold', textTransform: 'uppercase', letterSpacing: '1.5px',
+                  }}>
+                    {npcName}'s Stock
+                  </div>
+                )}
+                {buyItems.length === 0 && (
+                  <div style={{
+                    color: colors.text.muted, fontSize: '0.8rem',
+                    padding: spacing.lg, textAlign: 'center', fontStyle: 'italic',
+                  }}>
+                    Out of stock.
+                  </div>
+                )}
+                {buyItems.map(item => (
+                  <ItemRow
+                    key={item.id}
+                    item={item}
+                    isSelected={selectedId === item.id}
+                    tab="buy"
+                    onClick={() => handleSelectItem(item.id)}
+                    isMobile={isMobile}
+                  />
+                ))}
+              </>
+            )}
+
+            {/* Sell tab content */}
+            {activeTab === 'sell' && (
+              <>
+                {/* Merchant gold bar */}
+                <div style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                  padding: '6px 14px',
+                  background: 'rgba(255,170,0,0.06)',
+                  borderBottom: `1px solid rgba(255,170,0,0.2)`,
+                  fontSize: '0.7rem',
+                }}>
+                  <span style={{ color: colors.text.muted }}>
+                    {npcName}'s gold:
+                  </span>
+                  <span style={{
+                    color: merchantGold < 50 ? colors.danger : colors.gold,
+                    fontWeight: 'bold',
+                  }}>
+                    {merchantGold} 💰
+                  </span>
+                  <span style={{ color: colors.text.dim, fontSize: '0.6rem' }}>
+                    Max per sale
+                  </span>
+                </div>
+
+                {sellInventory.length === 0 && (
+                  <div style={{
+                    color: colors.text.muted, fontSize: '0.8rem',
+                    padding: spacing.lg, textAlign: 'center', fontStyle: 'italic',
+                  }}>
+                    Nothing to sell.
+                  </div>
+                )}
+                {sellInventory.map(item => (
+                  <ItemRow
+                    key={item.id}
+                    item={item}
+                    isSelected={selectedId === item.id}
+                    tab="sell"
+                    onClick={() => handleSelectItem(item.id)}
+                    isMobile={isMobile}
+                  />
+                ))}
+              </>
+            )}
+
+            {/* Action Row */}
+            {selectedItem && (
+              <div style={{
+                display: 'flex',
+                flexDirection: isMobile ? 'column' : 'row',
+                alignItems: isMobile ? 'stretch' : 'center',
+                justifyContent: 'space-between',
+                padding: '10px 14px',
+                gap: '10px',
+                background: selectedItem.is_buyback
+                  ? 'rgba(0,204,255,0.05)'
+                  : activeTab === 'sell'
+                  ? 'rgba(255,170,0,0.05)'
+                  : 'rgba(0,255,136,0.05)',
+                borderTop: `1px solid ${
+                  selectedItem.is_buyback ? 'rgba(0,204,255,0.2)'
+                  : activeTab === 'sell' ? 'rgba(255,170,0,0.2)'
+                  : 'rgba(0,255,136,0.2)'
+                }`,
+              }}>
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div style={{ fontSize: '0.72rem', color: colors.text.muted }}>
+                    {selectedItem.is_buyback ? 'Buying back:' : activeTab === 'buy' ? 'Selected:' : 'Selling:'}
+                    <span style={{ color: colors.text.main, fontWeight: 'bold', marginLeft: '4px' }}>
+                      {getItemIcon(selectedItem)} {selectedItem.name}
+                    </span>
+                  </div>
+
+                  {/* Qty picker for stackable items (not buyback) */}
+                  {selectedItem.is_stackable && !selectedItem.is_buyback && maxQty > 1 && (
+                    <div style={{ marginTop: '5px', display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+                      <QtyPicker value={quantity} max={maxQty} onChange={setQuantity} isMobile={isMobile} />
+                      <span style={{ fontSize: '0.65rem', color: colors.gold, whiteSpace: 'nowrap' }}>
+                        = {activeTab === 'buy' ? buyTotal : sellTotal} 💰
+                      </span>
+                    </div>
+                  )}
+
+                  {/* Sell breakdown */}
+                  {activeTab === 'sell' && !selectedItem.is_buyback && (
+                    <div style={{ fontSize: '0.6rem', color: colors.text.dim, marginTop: '3px' }}>
+                      Value {selectedItem.value} 💰 · Offer {Math.round((shopState?.sell_modifier || 0.5) * 100)}% = {selectedItem.offer} 💰
+                    </div>
+                  )}
+
+                  {/* Buyback note */}
+                  {selectedItem.is_buyback && (
+                    <div style={{ fontSize: '0.6rem', color: 'rgba(0,204,255,0.7)', marginTop: '3px', display: 'flex', alignItems: 'center', gap: '4px' }}>
+                      ⏱ Expires next game beat
+                    </div>
+                  )}
+
+                  {/* Error reason */}
+                  {buyDisabledReason && (
+                    <div style={{ fontSize: '0.63rem', color: colors.danger, marginTop: '3px', display: 'flex', alignItems: 'center', gap: '4px' }}>
+                      ⚠ {buyDisabledReason}
+                    </div>
+                  )}
+                  {merchantCantAfford && (
+                    <div style={{ fontSize: '0.63rem', color: colors.danger, marginTop: '3px' }}>
+                      ⚠ Merchant has insufficient funds
+                    </div>
+                  )}
+                </div>
+
+                {/* Action button */}
+                {selectedItem.is_buyback ? (
+                  <ActionButton
+                    onClick={handleBuyback}
+                    color={colors.accent}
+                    label={`Buyback · ${selectedItem.price} 💰`}
+                    isMobile={isMobile}
+                  />
+                ) : activeTab === 'buy' ? (
+                  <ActionButton
+                    onClick={handleBuy}
+                    color={colors.primary}
+                    label={quantity > 1 ? `Buy ${quantity} · ${buyTotal} 💰` : `Buy · ${buyTotal} 💰`}
+                    disabled={!!buyDisabledReason}
+                    isMobile={isMobile}
+                  />
+                ) : (
+                  <ActionButton
+                    onClick={handleSell}
+                    color={colors.secondary}
+                    label={quantity > 1 ? `Sell ${quantity} · +${sellTotal} 💰` : `Sell · +${sellTotal} 💰`}
+                    disabled={merchantCantAfford}
+                    isMobile={isMobile}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+      </div>
+    </BaseDialog>
+  )
+}
+
+function ActionButton({ onClick, color, label, disabled, isMobile }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        padding: isMobile ? '12px 20px' : '7px 18px',
+        borderRadius: '5px',
+        fontFamily: 'monospace',
+        fontSize: '0.72rem', fontWeight: 'bold',
+        textTransform: 'uppercase', letterSpacing: '1px',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        whiteSpace: 'nowrap',
+        flexShrink: 0,
+        width: isMobile ? '100%' : 'auto',
+        background: disabled ? 'rgba(255,68,68,0.08)' : `${color}33`,
+        border: `2px solid ${disabled ? 'rgba(255,68,68,0.3)' : color}`,
+        color: disabled ? 'rgba(255,68,68,0.45)' : color,
+        transition: 'all 0.15s',
+      }}
+    >
+      {label}
+    </button>
+  )
+}

--- a/frontend/src/components/ShopDialog.jsx
+++ b/frontend/src/components/ShopDialog.jsx
@@ -42,12 +42,11 @@ function WeightBar({ current, max, pendingDelta, isMobile }) {
           <span style={{ color: colors.text.main, fontWeight: 'bold' }}>{current.toFixed(1)}</span>
           {pendingDelta !== 0 && (
             <>
-              <span style={{ color: colors.text.dim }}>+</span>
               <span style={{
                 color: isSellDelta ? colors.primary : isOverweight ? colors.danger : colors.secondary,
                 fontWeight: 'bold',
               }}>
-                ({isSellDelta ? '−' : '+'}{Math.abs(pendingDelta).toFixed(2)})
+                {isSellDelta ? '(−' : '(+'}{Math.abs(pendingDelta).toFixed(2)})
               </span>
               {!isMobile && (
                 <span style={{ color: colors.text.dim, fontSize: '0.58rem' }}>

--- a/frontend/src/hooks/useShop.js
+++ b/frontend/src/hooks/useShop.js
@@ -1,0 +1,75 @@
+import { useState, useCallback, useEffect } from 'react'
+import { shop as shopApi } from '../api/endpoints'
+
+/**
+ * useShop — manages all shop API interactions for a given merchant NPC.
+ *
+ * Fetches shop state on mount, exposes buy / sell / buyback actions that
+ * re-fetch state after every successful transaction. Callers should also
+ * invoke onRefetch() (from the parent) after success to sync player gold
+ * and inventory in the rest of the UI.
+ *
+ * @param {string} npcId - str(id(npc)) of the target merchant
+ */
+export function useShop(npcId) {
+  const [shopState, setShopState] = useState(null)
+  const [sellInventory, setSellInventory] = useState([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [txnMessage, setTxnMessage] = useState(null)
+
+  const refresh = useCallback(async () => {
+    if (!npcId) return
+    setIsLoading(true)
+    setError(null)
+    try {
+      const res = await shopApi.getState(npcId)
+      const data = res.data
+      if (data.success) {
+        setShopState(data.shop_state)
+        setSellInventory(data.sell_inventory || [])
+      } else {
+        setError(data.error || 'Failed to load shop')
+      }
+    } catch (err) {
+      setError(err.response?.data?.error || err.message || 'Network error')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [npcId])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const _handleTxn = async (apiFn, successKey) => {
+    setTxnMessage(null)
+    try {
+      const res = await apiFn()
+      const data = res.data
+      if (data.success) {
+        setShopState(data.shop_state)
+        setSellInventory(data.sell_inventory || [])
+        setTxnMessage({ type: 'success', text: data.message || 'Done.' })
+      } else {
+        setTxnMessage({ type: 'error', text: data.error || 'Transaction failed' })
+      }
+      return { success: data.success, message: data.message, [successKey]: data[successKey] }
+    } catch (err) {
+      const msg = err.response?.data?.error || err.message || 'Network error'
+      setTxnMessage({ type: 'error', text: msg })
+      return { success: false, message: msg }
+    }
+  }
+
+  const buy = (itemId, quantity) =>
+    _handleTxn(() => shopApi.buy(npcId, itemId, quantity), 'gold_spent')
+
+  const sell = (itemId, quantity) =>
+    _handleTxn(() => shopApi.sell(npcId, itemId, quantity), 'gold_gained')
+
+  const buyback = (itemId) =>
+    _handleTxn(() => shopApi.buyback(npcId, itemId), 'gold_spent')
+
+  return { shopState, sellInventory, isLoading, error, txnMessage, buy, sell, buyback, refresh }
+}

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -247,6 +247,7 @@ def create_app(config_class=None):
         dialogue_context_bp,
         logs_bp,
         feedback_bp,
+        shop_bp,
     )
     from src.api.routes.npc_chat import npc_chat_bp
 
@@ -266,6 +267,7 @@ def create_app(config_class=None):
     app.register_blueprint(npc_chat_bp, url_prefix="/api/npc/chat")
     app.register_blueprint(logs_bp, url_prefix="/api/logs")
     app.register_blueprint(feedback_bp, url_prefix="/api/feedback")
+    app.register_blueprint(shop_bp, url_prefix="/api/shop")
 
     # Register error handlers from dedicated module
     from src.api.handlers.error_handler import register_error_handlers

--- a/src/api/routes/__init__.py
+++ b/src/api/routes/__init__.py
@@ -15,6 +15,7 @@ from .npc_availability import npc_availability_bp
 from .dialogue_context import dialogue_context_bp
 from .logs import logs_bp
 from .feedback import feedback_bp
+from .shop import shop_bp
 
 __all__ = [
     "auth_bp",
@@ -32,4 +33,5 @@ __all__ = [
     "dialogue_context_bp",
     "logs_bp",
     "feedback_bp",
+    "shop_bp",
 ]

--- a/src/api/routes/shop.py
+++ b/src/api/routes/shop.py
@@ -1,0 +1,232 @@
+"""
+Shop routes for the Flask API.
+
+Provides endpoints for:
+- Fetching merchant stock and player sell inventory
+- Buying items from a merchant
+- Selling items to a merchant
+- Buying back recently sold items (before the game beat advances)
+
+All price computation, gold validation, and weight validation happen in
+GameService — the client only sends identifiers and quantity.
+
+URL prefix: /api/shop  (registered in app.py)
+"""
+
+from flask import Blueprint, current_app, jsonify, request
+
+from src.api.services.validators import validate_required_fields
+
+shop_bp = Blueprint("shop", __name__)
+
+
+def get_session_and_player():
+    """Extract and validate session from Authorization header.
+
+    Returns:
+        (session, player, error_response, status_code)
+        On failure, session and player are None; error_response and status_code
+        are set. On success, error_response and status_code are None.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return (
+            None,
+            None,
+            jsonify({"success": False, "error": "Missing authorization"}),
+            401,
+        )
+
+    session_id = auth_header[7:]
+    session_manager = current_app.session_manager
+    session = session_manager.get_session(session_id)
+
+    if not session:
+        return (
+            None,
+            None,
+            jsonify({"success": False, "error": "Invalid or expired session"}),
+            401,
+        )
+
+    player = session_manager.get_player(session_id)
+    if not player:
+        return None, None, jsonify({"success": False, "error": "Player not found"}), 404
+
+    return session, player, None, None
+
+
+@shop_bp.route("/state", methods=["GET"])
+def get_shop_state():
+    """Fetch merchant stock, buyback items, and player's sellable inventory.
+
+    Query params:
+        npc_id (str): str(id(npc)) of the merchant on the current tile.
+
+    Returns:
+        {
+            "success": true,
+            "shop_state": {
+                "npc_id", "npc_name", "shop_name",
+                "buy_modifier", "sell_modifier",
+                "stock": [...],
+                "buyback_items": [...],
+                "merchant_gold", "player_gold",
+                "player_weight_current", "player_weight_max"
+            },
+            "sell_inventory": [...]
+        }
+    """
+    session, player, error, status = get_session_and_player()
+    if error:
+        return error, status
+
+    npc_id = request.args.get("npc_id", "")
+    if not npc_id:
+        return jsonify({"success": False, "error": "Missing npc_id query parameter"}), 400
+
+    try:
+        result = current_app.game_service.get_shop_state(player, npc_id)
+        return jsonify(result), 200 if result.get("success") else 404
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@shop_bp.route("/buy", methods=["POST"])
+def buy_item():
+    """Purchase an item from a merchant.
+
+    Request body:
+        {
+            "npc_id": str,
+            "item_id": str,
+            "quantity": int  (optional, default 1)
+        }
+
+    Returns:
+        {
+            "success": true,
+            "message": str,
+            "gold_spent": int,
+            "shop_state": {...},
+            "sell_inventory": [...]
+        }
+    """
+    session, player, error, status = get_session_and_player()
+    if error:
+        return error, status
+
+    try:
+        data = request.get_json() or {}
+        is_valid, error_msg = validate_required_fields(data, ["npc_id", "item_id"])
+        if not is_valid:
+            return jsonify({"success": False, "error": error_msg}), 400
+
+        quantity = int(data.get("quantity", 1))
+        if quantity < 1:
+            return jsonify({"success": False, "error": "Quantity must be at least 1"}), 400
+
+        result = current_app.game_service.shop_buy(
+            player, data["npc_id"], data["item_id"], quantity
+        )
+
+        if result.get("success"):
+            current_app.session_manager.save_session(session.session_id)
+
+        return jsonify(result), 200 if result.get("success") else 400
+    except (ValueError, TypeError) as e:
+        return jsonify({"success": False, "error": f"Invalid input: {e}"}), 400
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@shop_bp.route("/sell", methods=["POST"])
+def sell_item():
+    """Sell an item from the player's inventory to a merchant.
+
+    Request body:
+        {
+            "npc_id": str,
+            "item_id": str,
+            "quantity": int  (optional, default 1)
+        }
+
+    Returns:
+        {
+            "success": true,
+            "message": str,
+            "gold_gained": int,
+            "shop_state": {...},
+            "sell_inventory": [...]
+        }
+    """
+    session, player, error, status = get_session_and_player()
+    if error:
+        return error, status
+
+    try:
+        data = request.get_json() or {}
+        is_valid, error_msg = validate_required_fields(data, ["npc_id", "item_id"])
+        if not is_valid:
+            return jsonify({"success": False, "error": error_msg}), 400
+
+        quantity = int(data.get("quantity", 1))
+        if quantity < 1:
+            return jsonify({"success": False, "error": "Quantity must be at least 1"}), 400
+
+        result = current_app.game_service.shop_sell(
+            player, data["npc_id"], data["item_id"], quantity
+        )
+
+        if result.get("success"):
+            current_app.session_manager.save_session(session.session_id)
+
+        return jsonify(result), 200 if result.get("success") else 400
+    except (ValueError, TypeError) as e:
+        return jsonify({"success": False, "error": f"Invalid input: {e}"}), 400
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@shop_bp.route("/buyback", methods=["POST"])
+def buyback_item():
+    """Repurchase a recently sold item at the original sell price.
+
+    Buyback offers expire when the game beat (game_tick) advances. The server
+    validates eligibility — clients cannot submit prices.
+
+    Request body:
+        {
+            "npc_id": str,
+            "item_id": str   (the item_id from the buyback_items list)
+        }
+
+    Returns:
+        {
+            "success": true,
+            "message": str,
+            "gold_spent": int,
+            "shop_state": {...},
+            "sell_inventory": [...]
+        }
+    """
+    session, player, error, status = get_session_and_player()
+    if error:
+        return error, status
+
+    try:
+        data = request.get_json() or {}
+        is_valid, error_msg = validate_required_fields(data, ["npc_id", "item_id"])
+        if not is_valid:
+            return jsonify({"success": False, "error": error_msg}), 400
+
+        result = current_app.game_service.shop_buyback(
+            player, data["npc_id"], data["item_id"]
+        )
+
+        if result.get("success"):
+            current_app.session_manager.save_session(session.session_id)
+
+        return jsonify(result), 200 if result.get("success") else 400
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500

--- a/src/api/serializers/shop_serializer.py
+++ b/src/api/serializers/shop_serializer.py
@@ -1,0 +1,160 @@
+"""Serializers for shop/merchant state exposed to the web API."""
+
+from typing import Any, Dict, List
+
+
+def _get_gold(inventory: list) -> int:
+    """Mirror of interface.get_gold without importing the terminal module."""
+    total = 0
+    for item in inventory:
+        if getattr(item, "name", None) == "Gold":
+            total += getattr(item, "amt", 0)
+    return total
+
+
+def _serialize_shop_item(item: Any, price_modifier: float) -> Dict:
+    """Serialize a single merchant stock item with a computed price."""
+    count = 1
+    if hasattr(item, "count"):
+        count = item.count
+    elif hasattr(item, "quantity"):
+        count = item.quantity
+
+    base_value = getattr(item, "value", 0)
+    price = max(1, int(base_value * price_modifier))
+
+    return {
+        "id": str(id(item)),
+        "name": getattr(item, "name", "Unknown"),
+        "type": type(item).__name__,
+        "subtype": getattr(item, "subtype", ""),
+        "description": getattr(item, "description", ""),
+        "value": base_value,
+        "price": price,
+        "weight": getattr(item, "weight", 0.0),
+        "count": count,
+        "is_stackable": count > 1,
+        "power": getattr(item, "power", None),
+        "is_buyback": False,
+    }
+
+
+def _serialize_buyback_item(entry: Dict) -> Dict:
+    """Serialize a buyback ledger entry for display in the buy tab."""
+    return {
+        "id": entry["item_id"],
+        "name": entry["item_name"],
+        "type": entry.get("type", ""),
+        "subtype": entry.get("subtype", ""),
+        "description": entry.get("description", ""),
+        "value": entry.get("value", 0),
+        "price": entry["buyback_price"],
+        "weight": entry["weight"],
+        "count": entry["count"],
+        "is_stackable": entry["count"] > 1,
+        "power": entry.get("power"),
+        "is_buyback": True,
+    }
+
+
+class ShopSerializer:
+    """Serialize merchant shop state for the web API."""
+
+    @staticmethod
+    def serialize_state(
+        merchant: Any,
+        player: Any,
+        current_game_tick: int,
+    ) -> Dict:
+        """Return the full shop state for GET /api/shop/state.
+
+        Flushes stale buyback entries (beat_acquired < current_game_tick) as a
+        side effect so callers don't have to do it separately.
+
+        Args:
+            merchant: Merchant NPC instance (has .shop, .inventory, ._buyback_ledger).
+            player: Player instance (has .inventory, .weight_current, .weight_tolerance).
+            current_game_tick: player.universe.game_tick value.
+
+        Returns:
+            JSON-safe dict with stock, buyback_items, player state, merchant gold.
+        """
+        shop = getattr(merchant, "shop", None)
+        buy_mod = getattr(shop, "buy_modifier", 1.0) if shop else 1.0
+        sell_mod = getattr(shop, "sell_modifier", 0.5) if shop else 0.5
+        shop_name = getattr(shop, "title", None) or f"{merchant.name}'s Shop"
+
+        # Flush stale buyback entries in-place
+        ledger: List[Dict] = getattr(merchant, "_buyback_ledger", [])
+        active_ledger = [e for e in ledger if e["beat_acquired"] >= current_game_tick]
+        merchant._buyback_ledger = active_ledger
+
+        # Serialize regular stock (exclude Gold items)
+        merchant_inv = getattr(merchant, "inventory", [])
+        buyback_ids = {e["item_id"] for e in active_ledger}
+        stock = [
+            _serialize_shop_item(item, buy_mod)
+            for item in merchant_inv
+            if getattr(item, "name", None) != "Gold"
+            and str(id(item)) not in buyback_ids
+        ]
+
+        # Serialize buyback items
+        buyback_items = [_serialize_buyback_item(e) for e in active_ledger]
+
+        player_inv = getattr(player, "inventory", [])
+        player.refresh_weight()
+
+        return {
+            "npc_id": str(id(merchant)),
+            "npc_name": getattr(merchant, "name", "Merchant"),
+            "shop_name": shop_name,
+            "buy_modifier": buy_mod,
+            "sell_modifier": sell_mod,
+            "stock": stock,
+            "buyback_items": buyback_items,
+            "merchant_gold": _get_gold(merchant_inv),
+            "player_gold": _get_gold(player_inv),
+            "player_weight_current": getattr(player, "weight_current", 0.0),
+            "player_weight_max": getattr(player, "weight_tolerance", 100.0),
+        }
+
+    @staticmethod
+    def serialize_player_sellable(player: Any, sell_modifier: float) -> List[Dict]:
+        """Return the player's inventory formatted for the sell tab.
+
+        Excludes Gold items and equipped items (can't sell what you're wearing).
+
+        Args:
+            player: Player instance.
+            sell_modifier: Price multiplier for selling (e.g. 0.5).
+
+        Returns:
+            List of item dicts with offer price computed.
+        """
+        result = []
+        player_inv = getattr(player, "inventory", [])
+        for item in player_inv:
+            if getattr(item, "name", None) == "Gold":
+                continue
+            if getattr(item, "is_equipped", False) or getattr(item, "isequipped", False):
+                continue
+            base_value = getattr(item, "value", 0)
+            if not base_value:
+                continue
+            offer = max(1, int(base_value * sell_modifier))
+            count = getattr(item, "count", getattr(item, "quantity", 1))
+            result.append({
+                "id": str(id(item)),
+                "name": getattr(item, "name", "Unknown"),
+                "type": type(item).__name__,
+                "subtype": getattr(item, "subtype", ""),
+                "description": getattr(item, "description", ""),
+                "value": base_value,
+                "offer": offer,
+                "weight": getattr(item, "weight", 0.0),
+                "count": count,
+                "is_stackable": count > 1,
+                "power": getattr(item, "power", None),
+            })
+        return result

--- a/src/api/serializers/shop_serializer.py
+++ b/src/api/serializers/shop_serializer.py
@@ -61,6 +61,18 @@ class ShopSerializer:
     """Serialize merchant shop state for the web API."""
 
     @staticmethod
+    def flush_stale_buyback(merchant: Any, current_game_tick: int) -> None:
+        """Remove buyback ledger entries that were acquired before the current game tick.
+
+        Separated from serialize_state so callers can flush before performing
+        ledger lookups (e.g. shop_buyback) without coupling flush to serialization.
+        """
+        ledger: List[Dict] = getattr(merchant, "_buyback_ledger", [])
+        merchant._buyback_ledger = [
+            e for e in ledger if e["beat_acquired"] >= current_game_tick
+        ]
+
+    @staticmethod
     def serialize_state(
         merchant: Any,
         player: Any,
@@ -68,8 +80,8 @@ class ShopSerializer:
     ) -> Dict:
         """Return the full shop state for GET /api/shop/state.
 
-        Flushes stale buyback entries (beat_acquired < current_game_tick) as a
-        side effect so callers don't have to do it separately.
+        Does NOT flush the buyback ledger — callers are responsible for calling
+        flush_stale_buyback(merchant, tick) before serialize_state if needed.
 
         Args:
             merchant: Merchant NPC instance (has .shop, .inventory, ._buyback_ledger).
@@ -84,14 +96,10 @@ class ShopSerializer:
         sell_mod = getattr(shop, "sell_modifier", 0.5) if shop else 0.5
         shop_name = getattr(shop, "title", None) or f"{merchant.name}'s Shop"
 
-        # Flush stale buyback entries in-place
-        ledger: List[Dict] = getattr(merchant, "_buyback_ledger", [])
-        active_ledger = [e for e in ledger if e["beat_acquired"] >= current_game_tick]
-        merchant._buyback_ledger = active_ledger
-
         # Serialize regular stock (exclude Gold items)
         merchant_inv = getattr(merchant, "inventory", [])
-        buyback_ids = {e["item_id"] for e in active_ledger}
+        ledger: List[Dict] = getattr(merchant, "_buyback_ledger", [])
+        buyback_ids = {e["item_id"] for e in ledger}
         stock = [
             _serialize_shop_item(item, buy_mod)
             for item in merchant_inv
@@ -100,7 +108,7 @@ class ShopSerializer:
         ]
 
         # Serialize buyback items
-        buyback_items = [_serialize_buyback_item(e) for e in active_ledger]
+        buyback_items = [_serialize_buyback_item(e) for e in ledger]
 
         player_inv = getattr(player, "inventory", [])
         player.refresh_weight()

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -4832,6 +4832,7 @@ class GameService:
             merchant.update_goods()
 
         current_tick = self._game_tick(player)
+        ShopSerializer.flush_stale_buyback(merchant, current_tick)
         shop_state = ShopSerializer.serialize_state(merchant, player, current_tick)
         sell_inventory = ShopSerializer.serialize_player_sellable(
             player, shop_state["sell_modifier"]
@@ -4909,6 +4910,7 @@ class GameService:
         transfer_item(merchant, player, target_item, quantity)
 
         current_tick = self._game_tick(player)
+        ShopSerializer.flush_stale_buyback(merchant, current_tick)
         shop_state = ShopSerializer.serialize_state(merchant, player, current_tick)
         sell_inventory = ShopSerializer.serialize_player_sellable(
             player, shop_state["sell_modifier"]
@@ -4995,28 +4997,25 @@ class GameService:
         transfer_gold(merchant.inventory, player.inventory, total_offer)
         transfer_item(player, merchant, target_item, quantity)
 
-        # The item is now in merchant.inventory — record its new id for buyback.
-        # transfer_item() moves the same Python object for non-stackables (id
-        # unchanged) but creates a new object for partial stack splits (new id).
-        # We prefer a new-id match (split case) and fall back to the original id
-        # (moved-object case) so the ledger always references the correct object.
-        transferred_item = None
-        for item in getattr(merchant, "inventory", []):
-            if (
-                getattr(item, "name", None) == item_name
-                and str(id(item)) != item_id  # could be same object; use it if so
-            ) or str(id(item)) == item_id:
-                if getattr(item, "name", None) == item_name:
-                    transferred_item = item
-                    break
-
-        new_item_id = str(id(transferred_item)) if transferred_item else item_id
+        # For full-stack sells, transfer_item moves the same Python object so its
+        # id is unchanged and still present in merchant.inventory. For partial-stack
+        # splits, a new object is created and appended, but stack_inv_items may
+        # immediately merge it into an existing same-name item. In that case the
+        # original id is gone — fall back to the first name-matching merchant item.
+        if any(str(id(i)) == item_id for i in getattr(merchant, "inventory", [])):
+            buyback_item_id = item_id
+        else:
+            buyback_item_id = next(
+                (str(id(i)) for i in getattr(merchant, "inventory", [])
+                 if getattr(i, "name", None) == item_name),
+                item_id,
+            )
 
         if not hasattr(merchant, "_buyback_ledger"):
             merchant._buyback_ledger = []
 
         merchant._buyback_ledger.append({
-            "item_id": new_item_id,
+            "item_id": buyback_item_id,
             "item_name": item_name,
             "buyback_price": unit_offer,
             "weight": item_weight,
@@ -5030,6 +5029,7 @@ class GameService:
         })
 
         current_tick = self._game_tick(player)
+        ShopSerializer.flush_stale_buyback(merchant, current_tick)
         shop_state = ShopSerializer.serialize_state(merchant, player, current_tick)
         sell_inventory = ShopSerializer.serialize_player_sellable(
             player, shop_state["sell_modifier"]
@@ -5070,12 +5070,9 @@ class GameService:
         if merchant.shop is None:
             merchant.initialize_shop()
 
-        # Flush stale entries first
+        # Flush stale entries before ledger lookup
         current_tick = self._game_tick(player)
-        ledger = getattr(merchant, "_buyback_ledger", [])
-        merchant._buyback_ledger = [
-            e for e in ledger if e["beat_acquired"] >= current_tick
-        ]
+        ShopSerializer.flush_stale_buyback(merchant, current_tick)
 
         # Find the ledger entry
         entry = None

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -4788,3 +4788,352 @@ class GameService:
 
         player.combat_drops = []
         return {"success": True, "collected": collected, "skipped": skipped}
+
+    # ── Shop ──────────────────────────────────────────────────────────────────
+
+    def _find_merchant(self, player: Any, npc_id: str):
+        """Return the merchant NPC on the player's current tile, or None."""
+        tile = player.universe.get_tile(player.location_x, player.location_y)
+        for npc in getattr(tile, "npcs_here", []):
+            if str(id(npc)) == npc_id and hasattr(npc, "shop"):
+                return npc
+        return None
+
+    def get_shop_state(self, player: Any, npc_id: str) -> Dict[str, Any]:
+        """Return the full shop state for a merchant NPC.
+
+        Also serializes the player's sellable inventory so the frontend has
+        everything it needs in one request.
+
+        Args:
+            player: The Player instance.
+            npc_id: str(id(npc)) of the target merchant.
+
+        Returns:
+            Dict with success, shop_state, and sell_inventory.
+        """
+        from src.api.serializers.shop_serializer import ShopSerializer
+
+        merchant = self._find_merchant(player, npc_id)
+        if merchant is None:
+            return {"success": False, "error": "Merchant not found at this location"}
+
+        if merchant.shop is None:
+            merchant.initialize_shop()
+
+        current_tick = self._game_tick(player)
+        shop_state = ShopSerializer.serialize_state(merchant, player, current_tick)
+        sell_inventory = ShopSerializer.serialize_player_sellable(
+            player, shop_state["sell_modifier"]
+        )
+
+        return {
+            "success": True,
+            "shop_state": shop_state,
+            "sell_inventory": sell_inventory,
+        }
+
+    def shop_buy(
+        self, player: Any, npc_id: str, item_id: str, quantity: int
+    ) -> Dict[str, Any]:
+        """Purchase an item from a merchant.
+
+        All price computation and validation happens server-side. The client
+        only sends identifiers and quantity.
+
+        Args:
+            player: The Player instance.
+            npc_id: str(id(npc)) of the merchant.
+            item_id: str(id(item)) of the item in merchant inventory.
+            quantity: Number of units to purchase (≥ 1).
+
+        Returns:
+            Dict with success, updated shop_state, sell_inventory, and message.
+        """
+        from src.interface import transfer_gold, transfer_item
+        from src.api.serializers.shop_serializer import ShopSerializer
+
+        merchant = self._find_merchant(player, npc_id)
+        if merchant is None:
+            return {"success": False, "error": "Merchant not found at this location"}
+
+        if merchant.shop is None:
+            merchant.initialize_shop()
+
+        buy_mod = getattr(merchant.shop, "buy_modifier", 1.0)
+
+        # Locate item in merchant inventory
+        target_item = None
+        for item in getattr(merchant, "inventory", []):
+            if getattr(item, "name", None) != "Gold" and str(id(item)) == item_id:
+                target_item = item
+                break
+
+        if target_item is None:
+            return {"success": False, "error": "Item not found in merchant inventory"}
+
+        # Clamp and validate quantity
+        quantity = max(1, int(quantity))
+        if hasattr(target_item, "count") and quantity > target_item.count:
+            quantity = target_item.count
+
+        unit_price = max(1, int(getattr(target_item, "value", 0) * buy_mod))
+        total_price = unit_price * quantity
+
+        player_gold = get_gold(player.inventory)
+        if player_gold < total_price:
+            needed = total_price - player_gold
+            return {
+                "success": False,
+                "error": f"Not enough gold — need {needed} more",
+            }
+
+        # Weight check
+        player.refresh_weight()
+        item_weight = getattr(target_item, "weight", 0.0)
+        if player.weight_current + item_weight * quantity > player.weight_tolerance:
+            return {"success": False, "error": "Exceeds carry limit"}
+
+        # Execute transfer
+        transfer_gold(player.inventory, merchant.inventory, total_price)
+        transfer_item(merchant, player, target_item, quantity)
+
+        current_tick = self._game_tick(player)
+        shop_state = ShopSerializer.serialize_state(merchant, player, current_tick)
+        sell_inventory = ShopSerializer.serialize_player_sellable(
+            player, shop_state["sell_modifier"]
+        )
+
+        return {
+            "success": True,
+            "message": f"Purchased {quantity}× {target_item.name} for {total_price} gold.",
+            "gold_spent": total_price,
+            "shop_state": shop_state,
+            "sell_inventory": sell_inventory,
+        }
+
+    def shop_sell(
+        self, player: Any, npc_id: str, item_id: str, quantity: int
+    ) -> Dict[str, Any]:
+        """Sell an item from the player's inventory to a merchant.
+
+        After a successful sale the item is added to the merchant's buyback
+        ledger at the exact price paid, tied to the current game_tick so the
+        frontend can offer instant repurchase until the beat advances.
+
+        Args:
+            player: The Player instance.
+            npc_id: str(id(npc)) of the merchant.
+            item_id: str(id(item)) of the item in player inventory.
+            quantity: Number of units to sell (≥ 1).
+
+        Returns:
+            Dict with success, updated shop_state, sell_inventory, and message.
+        """
+        from src.interface import transfer_gold, transfer_item
+        from src.api.serializers.shop_serializer import ShopSerializer
+
+        merchant = self._find_merchant(player, npc_id)
+        if merchant is None:
+            return {"success": False, "error": "Merchant not found at this location"}
+
+        if merchant.shop is None:
+            merchant.initialize_shop()
+
+        sell_mod = getattr(merchant.shop, "sell_modifier", 0.5)
+
+        # Locate item in player inventory
+        target_item = None
+        for item in getattr(player, "inventory", []):
+            if getattr(item, "name", None) != "Gold" and str(id(item)) == item_id:
+                target_item = item
+                break
+
+        if target_item is None:
+            return {"success": False, "error": "Item not found in inventory"}
+
+        if getattr(target_item, "is_equipped", False) or getattr(
+            target_item, "isequipped", False
+        ):
+            return {"success": False, "error": "Cannot sell equipped items"}
+
+        base_value = getattr(target_item, "value", 0)
+        if not base_value:
+            return {"success": False, "error": "This item has no sell value"}
+
+        # Clamp and validate quantity
+        quantity = max(1, int(quantity))
+        if hasattr(target_item, "count") and quantity > target_item.count:
+            quantity = target_item.count
+
+        unit_offer = max(1, int(base_value * sell_mod))
+        total_offer = unit_offer * quantity
+
+        merchant_gold = get_gold(merchant.inventory)
+        if merchant_gold < total_offer:
+            return {"success": False, "error": "Merchant has insufficient funds"}
+
+        # Capture pre-transfer metadata for the buyback ledger
+        item_name = getattr(target_item, "name", "Unknown")
+        item_weight = getattr(target_item, "weight", 0.0)
+        item_type = type(target_item).__name__
+        item_subtype = getattr(target_item, "subtype", "")
+        item_description = getattr(target_item, "description", "")
+        item_power = getattr(target_item, "power", None)
+
+        # Execute transfer
+        transfer_gold(merchant.inventory, player.inventory, total_offer)
+        transfer_item(player, merchant, target_item, quantity)
+
+        # The item is now in merchant.inventory — record its new id for buyback.
+        # transfer_item() moves the same Python object for non-stackables (id
+        # unchanged) but creates a new object for partial stack splits (new id).
+        # We prefer a new-id match (split case) and fall back to the original id
+        # (moved-object case) so the ledger always references the correct object.
+        transferred_item = None
+        for item in getattr(merchant, "inventory", []):
+            if (
+                getattr(item, "name", None) == item_name
+                and str(id(item)) != item_id  # could be same object; use it if so
+            ) or str(id(item)) == item_id:
+                if getattr(item, "name", None) == item_name:
+                    transferred_item = item
+                    break
+
+        new_item_id = str(id(transferred_item)) if transferred_item else item_id
+
+        if not hasattr(merchant, "_buyback_ledger"):
+            merchant._buyback_ledger = []
+
+        merchant._buyback_ledger.append({
+            "item_id": new_item_id,
+            "item_name": item_name,
+            "buyback_price": unit_offer,
+            "weight": item_weight,
+            "count": quantity,
+            "type": item_type,
+            "subtype": item_subtype,
+            "description": item_description,
+            "value": base_value,
+            "power": item_power,
+            "beat_acquired": self._game_tick(player),
+        })
+
+        current_tick = self._game_tick(player)
+        shop_state = ShopSerializer.serialize_state(merchant, player, current_tick)
+        sell_inventory = ShopSerializer.serialize_player_sellable(
+            player, shop_state["sell_modifier"]
+        )
+
+        return {
+            "success": True,
+            "message": f"Sold {quantity}× {item_name} for {total_offer} gold.",
+            "gold_gained": total_offer,
+            "shop_state": shop_state,
+            "sell_inventory": sell_inventory,
+        }
+
+    def shop_buyback(
+        self, player: Any, npc_id: str, item_id: str
+    ) -> Dict[str, Any]:
+        """Repurchase a recently sold item from the merchant's buyback ledger.
+
+        The buyback price equals what the merchant paid — no markup. The ledger
+        entry is removed on success regardless of whether the game tick has
+        advanced (the frontend is responsible for only showing active entries).
+
+        Args:
+            player: The Player instance.
+            npc_id: str(id(npc)) of the merchant.
+            item_id: The item_id from the buyback ledger entry.
+
+        Returns:
+            Dict with success, updated shop_state, sell_inventory, and message.
+        """
+        from src.interface import transfer_gold, transfer_item
+        from src.api.serializers.shop_serializer import ShopSerializer
+
+        merchant = self._find_merchant(player, npc_id)
+        if merchant is None:
+            return {"success": False, "error": "Merchant not found at this location"}
+
+        if merchant.shop is None:
+            merchant.initialize_shop()
+
+        # Flush stale entries first
+        current_tick = self._game_tick(player)
+        ledger = getattr(merchant, "_buyback_ledger", [])
+        merchant._buyback_ledger = [
+            e for e in ledger if e["beat_acquired"] >= current_tick
+        ]
+
+        # Find the ledger entry
+        entry = None
+        for e in merchant._buyback_ledger:
+            if e["item_id"] == item_id:
+                entry = e
+                break
+
+        if entry is None:
+            return {
+                "success": False,
+                "error": "Buyback offer has expired or was not found",
+            }
+
+        total_price = entry["buyback_price"] * entry["count"]
+
+        player_gold = get_gold(player.inventory)
+        if player_gold < total_price:
+            needed = total_price - player_gold
+            return {
+                "success": False,
+                "error": f"Not enough gold — need {needed} more",
+            }
+
+        # Weight check
+        player.refresh_weight()
+        added_weight = entry["weight"] * entry["count"]
+        if player.weight_current + added_weight > player.weight_tolerance:
+            return {"success": False, "error": "Exceeds carry limit"}
+
+        # Find the actual item object in merchant inventory
+        target_item = None
+        for item in getattr(merchant, "inventory", []):
+            if str(id(item)) == item_id:
+                target_item = item
+                break
+
+        if target_item is None:
+            # Item may have been re-stacked; search by name as fallback
+            item_name = entry["item_name"]
+            for item in getattr(merchant, "inventory", []):
+                if getattr(item, "name", None) == item_name:
+                    target_item = item
+                    break
+
+        if target_item is None:
+            merchant._buyback_ledger.remove(entry)
+            return {"success": False, "error": "Buyback item no longer in merchant stock"}
+
+        # Execute transfer
+        transfer_gold(player.inventory, merchant.inventory, total_price)
+        transfer_item(merchant, player, target_item, entry["count"])
+
+        # Remove ledger entry
+        merchant._buyback_ledger.remove(entry)
+
+        shop_state = ShopSerializer.serialize_state(merchant, player, current_tick)
+        sell_inventory = ShopSerializer.serialize_player_sellable(
+            player, shop_state["sell_modifier"]
+        )
+
+        return {
+            "success": True,
+            "message": (
+                f"Bought back {entry['count']}× {entry['item_name']} "
+                f"for {total_price} gold."
+            ),
+            "gold_spent": total_price,
+            "shop_state": shop_state,
+            "sell_inventory": sell_inventory,
+        }

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -4821,6 +4821,16 @@ class GameService:
         if merchant.shop is None:
             merchant.initialize_shop()
 
+        # Stock the merchant on first API access — update_goods() is normally
+        # triggered by game_tick events (every 1000 ticks) but the API skips
+        # the terminal game loop entirely.
+        non_gold = [
+            item for item in getattr(merchant, "inventory", [])
+            if getattr(item, "name", None) != "Gold"
+        ]
+        if not non_gold and hasattr(merchant, "update_goods"):
+            merchant.update_goods()
+
         current_tick = self._game_tick(player)
         shop_state = ShopSerializer.serialize_state(merchant, player, current_tick)
         sell_inventory = ShopSerializer.serialize_player_sellable(

--- a/src/npc/_merchants.py
+++ b/src/npc/_merchants.py
@@ -221,6 +221,19 @@ class JamboHealsU(Merchant):
             intelligence=14,
         )
 
+    def initialize_shop(self):
+        """Override to set the canonical shop name used by both terminal and web API."""
+        if self.inventory is None:
+            self.inventory = []
+        try:
+            from interface import ShopInterface as Shop
+        except Exception:
+            Shop = None
+        if Shop:
+            self.shop = Shop(merchant=self, player=None, shop_name="Jambo Heals U")
+        else:
+            self.shop = None
+
     def talk(self, player):  # pragma: no cover - simple flavor
         print(
             "Jambo chuckles: 'Feeling a bit under the weather, friend? Well no worry; Jambo Heals U! "

--- a/src/npc/_shop.py
+++ b/src/npc/_shop.py
@@ -272,7 +272,7 @@ class MerchantShopMixin:
         for room in (
             rooms_source.values() if hasattr(rooms_source, "values") else rooms_source
         ):
-            if isinstance(room, str):
+            if isinstance(room, (str, dict)):
                 continue
             for obj in getattr(room, "objects_here", getattr(room, "objects", [])):
                 if hasattr(obj, "inventory") and hasattr(obj, "merchant"):

--- a/src/resources/maps/shop-testing.json
+++ b/src/resources/maps/shop-testing.json
@@ -1,0 +1,22 @@
+{
+    "metadata": {
+        "bgm": "dream_space"
+    },
+    "(0, 0)": {
+        "id": "tile_0_0",
+        "title": "Market Stall",
+        "description": "A small market stall sheltered by a colourful awning. The sharp, clean smell of tinctures and herbs hangs in the warm air. Rows of small glass vials catch the light from a lantern hung at the entrance.",
+        "exits": [],
+        "block_exit": [],
+        "events": [],
+        "items": [],
+        "objects": [],
+        "npcs": [
+            {
+                "__class__": "JamboHealsU",
+                "__module__": "npc",
+                "props": {}
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

Implements a complete shop system for the web API and React frontend, enabling players to buy items from merchants, sell items back, and repurchase recently sold items. Includes a full-featured modal dialog with weight tracking, quantity selection, and real-time price computation.

## Key Changes

**Backend API:**
- Added `/api/shop/state` endpoint to fetch merchant stock, buyback items, and player's sellable inventory
- Added `/api/shop/buy` endpoint for purchasing items with server-side validation (gold, weight, quantity)
- Added `/api/shop/sell` endpoint for selling items to merchants with automatic buyback ledger creation
- Added `/api/shop/buyback` endpoint to repurchase recently sold items before game tick advances
- Implemented `ShopSerializer` to serialize merchant state and player inventory for API responses
- Extended `GameService` with shop transaction methods (`get_shop_state`, `shop_buy`, `shop_sell`, `shop_buyback`)
- Added merchant `initialize_shop()` method to set canonical shop names used by both terminal and web API

**Frontend UI:**
- Created `ShopDialog` React component with tabbed interface (Buy/Sell tabs)
- Implemented `WeightBar` sub-component showing current weight, pending delta, and overweight warnings
- Implemented `ItemRow` sub-component for displaying merchant stock and player inventory with selection states
- Implemented `QtyPicker` sub-component for quantity selection with +/− buttons and direct input
- Added `useShop` hook to manage all shop API interactions and state synchronization
- Integrated shop dialog into `LeftPanel` and `InteractPanel` for NPC interaction flow
- Added shop endpoints to API client (`shop.getState`, `shop.buy`, `shop.sell`, `shop.buyback`)

**Testing & Documentation:**
- Created `shop-testing.ini` config for isolated shop testing with pre-configured player state
- Created `shop-testing.json` map with Jambo merchant NPC
- Added comprehensive acceptance test plan (`shop-acceptance-test-plan.md`) with 20+ test cases covering happy paths, error conditions, and edge cases
- Created detailed UI mockup (`jambo-shop-dialog-mockup.html`) showing all dialog states and interactions

**Design:**
- Retro terminal aesthetic with neon green/cyan/orange color scheme matching game theme
- Responsive design with mobile touch target support (44px minimum)
- Real-time weight validation with visual feedback (green → orange → red)
- Buyback items displayed with distinct styling and "↩ BUYBACK" badge
- Equipped items filtered from sell inventory (cannot be sold)
- All price computation and validation happens server-side; client sends only identifiers and quantity

## Notable Implementation Details

- Weight bar shows both current weight and pending delta with color-coded warnings
- Buyback ledger persists across game ticks until explicitly repurchased or game beat advances
- Merchant gold pool is separate from player gold; transactions update both
- Quantity picker prevents invalid inputs (min 1, max available stock)
- All API responses include updated shop state for immediate UI refresh
- Equipped items are automatically filtered from sell inventory on the backend

https://claude.ai/code/session_01MeZtN23ZZCqPipgVbPgd65