### PR TITLE
refactor(story): simplify quest choice input & auto-generate door keywords

### DIFF
--- a/src/objects.py
+++ b/src/objects.py
@@ -820,6 +820,11 @@ class Passageway(Object):
         self.keywords.append("enter")
         self.action_aliases.extend(["go", "leave", "exit"])
         self.keywords.extend(self.action_aliases)
+        _name_words = name.lower().replace("'s", "").replace("'", "").split()
+        for _word in _name_words:
+            if len(_word) > 3 and _word.isalpha() and not hasattr(self, _word):
+                setattr(self, _word, self.enter)
+                self.keywords.append(_word)
         self.events_before = events_before if events_before is not None else []
         self.events_after = events_after if events_after is not None else []
         self.teleport_map = teleport_map if teleport_map is not None else ""

--- a/src/resources/maps/grondia.json
+++ b/src/resources/maps/grondia.json
@@ -951,7 +951,9 @@
             "enter",
             "go",
             "leave",
-            "exit"
+            "exit",
+            "tent",
+            "jambo"
           ],
           "events": [],
           "tile": null,

--- a/src/story/ch02.py
+++ b/src/story/ch02.py
@@ -114,7 +114,7 @@ class Ch02GuideToCitadel(
             name=name, player=player, tile=tile, repeat=repeat, params=params
         )
 
-    def check_combat_conditions(self):
+    def check_conditions(self):
         if len(self.player.combat_list) == 0:
             self.pass_conditions_to_process()
 
@@ -329,9 +329,9 @@ class Ch02GuideToCitadel(
             time.sleep(1)
             print(colored("[a]", "magenta") + ' "Tell me more."')
             print(colored("[b]", "magenta") + ' "I\'ll take a look at it."')
-            _quest_choice = ""
-            while _quest_choice not in ["a", "b"]:
-                _quest_choice = input("Choice: ").strip().lower()
+            _quest_choice = input("Choice: ").strip().lower()
+            if _quest_choice not in ["a", "b"]:
+                _quest_choice = "a"
 
             if _quest_choice == "a":
                 time.sleep(1)


### PR DESCRIPTION
## Summary
This PR improves user experience and code maintainability by simplifying quest choice input handling and automatically generating keyword aliases for door/entrance objects based on their names.

## Key Changes

- **Quest choice input simplification** (`src/story/ch02.py`):
  - Renamed `check_combat_conditions()` → `check_conditions()` for clarity
  - Replaced while-loop validation with immediate input capture + fallback logic
  - Invalid choices now default to "a" instead of re-prompting, reducing friction in dialogue flow

- **Dynamic door keyword generation** (`src/objects.py`):
  - Added automatic keyword extraction from door/entrance names (e.g., "Jambo's Tent" → adds "jambo" and "tent" as keywords)
  - Filters words by length (>3 chars), alphabetic content, and avoids overwriting existing attributes
  - Reduces manual keyword maintenance in map definitions

- **Map data update** (`src/resources/maps/grondia.json`):
  - Updated Jambo's Tent keywords to reflect auto-generated aliases ("tent", "jambo")

## Implementation Details

The keyword generation logic:
1. Normalizes the door name (lowercase, removes apostrophes)
2. Splits into words and filters by length and character type
3. Dynamically sets each word as a method alias pointing to `self.enter`
4. Adds the word to the object's keyword list for command matching

This reduces boilerplate in map JSON while maintaining backward compatibility with manually-defined keywords.

https://claude.ai/code/session_01UTs3YoggrjGM7ty9uAcCTv