### PR TITLE
Round protection and armor values in serializers and UI

### DIFF
--- a/frontend/src/components/InventoryDialog.jsx
+++ b/frontend/src/components/InventoryDialog.jsx
@@ -401,7 +401,7 @@ function ItemCard({ item, onClick, isShop }) {
       <div style={{ fontSize: '10px', color: colors.text.muted, display: 'flex', justifyContent: 'space-between' }}>
         <span>{item.subtype || item.maintype}</span>
         {item.damage && <span style={{ color: colors.danger }}>{getItemIcon(item)}{Math.round(item.damage)}</span>}
-        {item.protection && <span style={{ color: colors.text.highlight }}>🛡️{item.protection}</span>}
+        {item.protection && <span style={{ color: colors.text.highlight }}>🛡️{Math.round(item.protection)}</span>}
       </div>
 
       <div style={{

--- a/frontend/src/components/StatsPanel.jsx
+++ b/frontend/src/components/StatsPanel.jsx
@@ -33,7 +33,7 @@ export default function StatsPanel({ player, onClose }) {
   const coreStats = [
     { label: 'HP', val: `${player.hp}/${player.max_hp}`, color: colors.danger, icon: '❤️' },
     { label: 'Fatigue', val: `${player.fatigue}/${player.max_fatigue}`, color: colors.gold, icon: '🔋' },
-    { label: 'Protection', val: player.protection || 0, color: colors.info, icon: '🛡️' },
+    { label: 'Protection', val: Math.round(player.protection || 0), color: colors.info, icon: '🛡️' },
     { label: 'Level', val: player.level || 1, color: '#cc88ff', icon: '⭐' },
     { label: 'Attack', val: `${player.attack_damage_min}-${player.attack_damage_max}`, color: colors.secondary, icon: '⚔️' },
     { label: 'Accuracy', val: `${player.hit_accuracy}%`, color: colors.primary, icon: '🎯' },

--- a/src/api/serializers/inventory.py
+++ b/src/api/serializers/inventory.py
@@ -99,7 +99,7 @@ class InventoryItemSerializer:
             "Gloves",
             "Accessory",
         ] or maintype in ["Armor", "Boots", "Helm", "Gloves", "Accessory"]:
-            item_data["protection"] = getattr(item, "protection", 0)
+            item_data["protection"] = round(getattr(item, "protection", 0))
 
         # Add composable effects array for usable (consumable) items
         if item_data["can_use"]:
@@ -178,7 +178,7 @@ class EquipmentSlotSerializer:
             "equipped": True,
             "item_name": getattr(item, "name", "Unknown"),
             "item_type": item.__class__.__name__,
-            "armor": getattr(item, "armor", 0),
+            "armor": round(getattr(item, "armor", 0)),
             "damage": round(getattr(item, "damage", 0)),
             "weight": getattr(item, "weight", 0.0),
             "value": getattr(item, "value", 0),
@@ -308,7 +308,7 @@ class ItemDetailSerializer:
             "can_use": hasattr(item, "use"),
             "can_drop": True,  # Most items can be dropped
             "stats": {
-                "armor": getattr(item, "armor", 0),
+                "armor": round(getattr(item, "armor", 0)),
                 "damage": round(getattr(item, "damage", 0)),
                 "magic_attack": getattr(item, "magic_attack", 0),
                 "magic_defense": getattr(item, "magic_defense", 0),

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2499,7 +2499,7 @@ class GameService:
         stats["weight"] = weight
         stats["max_weight"] = max_weight
         stats["gold"] = get_gold(getattr(player, "inventory", []))
-        stats["protection"] = getattr(player, "protection", 0)
+        stats["protection"] = round(getattr(player, "protection", 0))
 
         # Calculate combat stats
         weapon = getattr(player, "eq_weapon", None)

--- a/src/story/ch02.py
+++ b/src/story/ch02.py
@@ -1071,4 +1071,3 @@ class AfterKingSlimeReturn(Event):
         self.completed = True
         self.player.universe.story["votha_krr_response_given"] = "1"
         self.tile.remove_event(self.name)
-


### PR DESCRIPTION
## Summary
Ensures protection and armor stat values are consistently rounded to integers across the API serializers and frontend components. This prevents floating-point values from being displayed in the UI and maintains data consistency.

## Changes
- **Backend serializers** (`src/api/serializers/inventory.py`):
  - Round `protection` value in item serialization (line 102)
  - Round `armor` value in equipped item serialization (line 181)
  - Round `armor` value in item stats serialization (line 311)

- **Game service** (`src/api/services/game_service.py`):
  - Round `protection` value in player stats response (line 2502)

- **Frontend components**:
  - Round `protection` display in ItemCard component (`InventoryDialog.jsx`, line 404)
  - Round `protection` display in StatsPanel component (`StatsPanel.jsx`, line 36)

## Implementation Details
All rounding uses `round()` (Python) and `Math.round()` (JavaScript) to convert floating-point values to integers. This aligns with existing patterns in the codebase where `damage` values are already rounded in the same serializers.

https://claude.ai/code/session_01NeTrpHqRiPKg38SZXAPnTL