### PR TITLE
fix(story): implement Citadel teleport at end of ch02 sequence

### DIFF
--- a/src/story/ch02.py
+++ b/src/story/ch02.py
@@ -1071,4 +1071,3 @@ class AfterKingSlimeReturn(Event):
         self.completed = True
         self.player.universe.story["votha_krr_response_given"] = "1"
         self.tile.remove_event(self.name)
-

--- a/src/story/ch02.py
+++ b/src/story/ch02.py
@@ -465,7 +465,7 @@ class Ch02GuideToCitadel(
                 "He says it the same way he said it the first time. Like a door left open."
             )
 
-        # At the end of the sequence, don't forget to teleport to the Citadel tile.
+        self.player.teleport("grondia", (10, 5))
 
         #  Remove this event from the tile
         self.tile.remove_event(self.name)


### PR DESCRIPTION
## Summary
Replaces a TODO comment with the actual implementation to teleport the player to the Citadel tile at the end of the chapter 2 event sequence.

## Changes
- **Implemented player teleport**: Replaced the comment `"At the end of the sequence, don't forget to teleport to the Citadel tile."` with the actual teleport call: `self.player.teleport("grondia", (10, 5))`
- This ensures the player is moved to the Citadel location (Grondia region, coordinates 10, 5) after the ch02 narrative sequence completes

## Implementation Details
The teleport is called immediately before removing the event from the tile, ensuring proper cleanup order and that the player is positioned correctly for the next game phase.

https://claude.ai/code/session_018aDGUduzb849XbdmBX5t2B