### PR TITLE
refactor(story): convert Ch02CitadelMeeting to multi-stage event with API support

### DIFF
--- a/src/story/ch02.py
+++ b/src/story/ch02.py
@@ -118,357 +118,384 @@ class Ch02GuideToCitadel(
         if len(self.player.combat_list) == 0:
             self.pass_conditions_to_process()
 
-    def process(self):
-        if not self.player.skip_dialog:
-            print(
-                "Gorran turns. His great head swings toward the passage that leads into the city.\n"
-                "He makes a sound — short, low, the kind that doesn't require translation — and moves.\n"
-                "Not wanting to disappoint his new friend, Jean follows him through the passageway.\n\n"
-            )
-            time.sleep(0.5)
-            # Describe the surroundings as they walk. Include descriptions of the Arcology through which they pass.
-            # There will be several Grondites milling about with their daily concerns.
-            # Gorran can only communicate in grunts and gestures, so Jean must rely on his own observations.
-            print(
-                "The passageway opens into a large cavern, the walls of which are covered in strange, glowing \n"
-                "symbols. The air is thick with the smell of damp earth and moss. \n"
-                "Gorran leads Jean through the cavern, "
-                "pointing out various features of the Grondite settlement as they go."
-            )
-            time.sleep(2)
-            print(
-                "From the ceiling at various intervals hang clusters of red crystals, casting a steady glow on the \n"
-                "streets below. Gorran stops in front of a large, stone archway. \n"
-                "The archway is covered in the same glowing symbols as the walls of the cavern. \n"
-                "Gorran gestures for Jean to follow him through the archway."
-            )
-            await_input()
-            print(
-                "As Jean steps through the archway, he is struck by the sheer size of the cavern beyond. \n"
-                "The ceiling is so high that it is lost in darkness, \nand the walls are so far away that "
-                "they seem to be a part of the very rock itself. "
-                "The floor is covered in a thick layer of moss, \nand the air is filled with the sound of dripping water "
-                "and the heavy bustle of the city's stony inhabitants."
-            )
-            time.sleep(2)
-            print(
-                "After walking at length, Gorran stops in front of a large, stone building. "
-            )
-            print(
-                "The Citadel rises before them, an immense structure carved directly from the cavern's living stone. \n"
-                "Its walls are etched with intricate, ancient depictions of Grondia's history. \n"
-                "Massive pillars support the vaulted entrance, and the air hums with a quiet energy. \n"
-                "Jean feels a sense of both wonder and trepidation as he gazes up at the fortress, \n"
-                "realizing that this place has stood for countless generations, \n"
-                "guarding secrets as old as the earth itself."
-            )
-            await_input()
-            print(
-                "Gorran turns to Jean, his expression serious. He gestures towards the Citadel, \n"
-                "indicating that this is where they must go next. \n"
-                "Jean nods, understanding that this is a place of great importance to the Grondites, \n"
-                "and perhaps to his own journey as well."
-            )
-            time.sleep(4)
-            print(
-                "Gorran leads Jean into the Citadel, where they are greeted by a group of Grondites. \n"
-                "They are dressed in simple, yet sturdy clothing, and they regard Jean with curiosity. \n"
-                "Gorran addresses the Grondites in their peculiar language of grunts and groans, \n"
-                "apparently explaining that he is a friend and ally - or, at the very least, not an enemy."
-            )
-            time.sleep(4)
-            print(
-                "The Grondites nod in understanding, and one of them steps forward to address Jean. \n"
-                "He speaks in a deep, rumbling voice, gesturing towards the interior of the Citadel. \n"
-                "Gorran nods his great head and sets off into the depths of the Citadel, \n"
-                "motioning for Jean to follow. "
-            )
-            await_input()
-            print(
-                "As they walk through the Citadel, Jean is struck by the sheer scale of the place. \n"
-                "The halls are vast and echo with the sound of their footsteps. "
-                "The walls are adorned with intricate carvings and murals, \ndepicting scenes from Grondia's history "
-                "much like the ones on the walls outside. \n"
-                "Jean's first thought is not of the carvings. It is of the air — steady, slow-moving, \n"
-                "cool at his feet and perceptibly warmer at his shoulders. Convection, working the way \n"
-                "it's supposed to, on a scale he has never encountered. He wants to find where it rises. \n"
-                "Then Gorran makes a sound and Jean remembers to look at the walls."
-            )
-            time.sleep(4)
-            print(
-                "Gorran leads Jean to a large chamber at the heart of the Citadel where a group of Grondite elders \n"
-                "are gathered. They are seated on stone thrones, their faces lined with age and wisdom. \n"
-                "Gorran speaks to them in their language, and they regard Jean with a mixture of curiosity and respect. \n"
-                "One of the elders stands and approaches Jean. Much to Jean's surprise, the elder extends a \n"
-                "burly, unyielding hand in greeting. Taking it, Jean has the sensation of grasping a \n"
-                "piece of the mountain itself. The elder's grip is firm, but not painful, \n"
-                "and Jean feels a sense of connection to this ancient being."
-            )
-            await_input()
-            print(
-                "Even more astonishingly, the elder speaks in a deep, rumbling voice, which Jean is able to understand."
-            )
-            time.sleep(1)
-            dialogue(
-                "Elder",
-                "You are a friend of Gorran. You are welcome here.",
-                "green",
-            )
-            time.sleep(1)
-            print(
-                "Jean nods, grateful for the warm welcome. He can feel the weight of the elder's gaze upon him, \n"
-                "and he knows that he is in the presence of someone who has seen much in their long life. \n"
-                "The elder gestures for Jean to sit on a nearby stool, also made from stone. Jean does so, \n"
-                "feeling awkward and out of place on the hard, cold seat."
-            )
-            time.sleep(5)
-            print(
-                "Gorran comes over and stands beside Jean, his massive frame casting a shadow over the elder.\n"
-                "The elder looks up at Gorran and speaks in a low, rumbling voice. \n"
-                "Gorran rumbles briefly in reply, then turns and strides out of the chamber.\n"
-                "The elder turns back to Jean, his expression serious."
-            )
-            time.sleep(5)
-            print(
-                "Now having gotten a chance to look at the elder, Jean can see that he is a bit smaller in form \n"
-                "than Gorran, though still quite large by human standards. Rather than the craggy, harsh exterior \n"
-                "of other Golemites, this elder has a smooth, almost polished appearance. It's clear that many \n"
-                "years of erosion have worn away the rough edges of his form, much like stones in a riverbed. \n"
-                "His eyes are deep-set and wise, and they seem to hold a depth of knowledge that speaks of \n"
-                "centuries of experience. He opens his mouth to speak."
-            )
-            await_input()
-            dialogue(
-                "Elder",
-                "Welcome, little one. I am Elder Votha Krr. Within this city, I serve "
-                "on its council of leaders — though some among us are more foolish than "
-                "others in how much weight they give that title.",
-                "green",
-            )
-            time.sleep(2)
-            print(
-                "With that, a rolling rumble of laughter erupts from the elder's mouth like the aftershocks of an "
-                "earthquake. "
-            )
-            time.sleep(2)
-            dialogue(
-                "Votha Krr",
-                "Ah, but let's not waste time talking about me. Tell me who you are and, "
-                "especially, why you are here. Or, perhaps more especially, where you are going.",
-                "green",
-            )
-            time.sleep(2)
-            print(
-                "Jean pauses for a long moment, unsure of how to answer. If he's honest with himself, he doesn't \n"
-                "really know how to answer any of those questions. He furrows his brow, troubled by this sudden \n"
-                "consternation. He takes a deep breath, trying to gather his thoughts."
-            )
-            time.sleep(3)
-            dialogue("Jean", "I am Jean. Jean Claire.", "cyan")
-            time.sleep(1)
-            print("He stops there. Votha Krr waits, unhurried as erosion.")
-            time.sleep(2)
-            dialogue(
-                "Jean",
-                "As for the rest — I can fight. I'm good with my hands. "
-                "I can figure out what's broken and fix it. "
-                "That's... that's what I do.",
-                "cyan",
-            )
-            time.sleep(2)
-            print(
-                "Votha Krr does not nod. He regards Jean with those deep-set eyes — "
-                "patient, unhurried, the way a canyon regards a river."
-            )
-            time.sleep(3)
-            dialogue(
-                "Votha Krr",
-                "You know who you are in your hands. That is not a small thing. "
-                "Many who arrive in this world know far less.",
-                "green",
-            )
-            time.sleep(1)
-            print("He tilts his great head, just slightly.")
-            time.sleep(1)
-            dialogue(
-                "Votha Krr",
-                "But I notice you did not answer where you are going.",
-                "green",
-            )
-            time.sleep(2)
-            print("Jean opens his mouth. Closes it. The chamber is very quiet.")
-            time.sleep(2)
-            dialogue("Jean", "No. I didn't.", "cyan")
-            time.sleep(2)
-            print(
-                "Something passes across Votha Krr's expression — not pity, not recognition. "
-                "Something older than both."
-            )
-            time.sleep(2)
-            dialogue(
-                "Votha Krr",
-                "Then perhaps that is a question for the road.",
-                "green",
-            )
-            time.sleep(2)
-            print(
-                "He settles back in his throne, the stone of him indistinguishable from the stone beneath him."
-            )
-            time.sleep(1)
-            dialogue(
-                "Votha Krr",
-                "Since you are a man who knows what to do with his hands — "
-                "and since you find yourself without a direction — allow me to offer you one. "
-                "Our sacred Grondelith Mineral Pools to the southwest have been infested by slimes. "
-                "They consume the minerals our people depend on, and their corruption is lethal to our kind. "
-                "We cannot clear them ourselves.",
-                "green",
-            )
-            time.sleep(1.5)
-            print("He watches Jean's face. Jean isn't showing much.")
-            time.sleep(1)
-            print(colored("[a]", "magenta") + ' "Tell me more."')
-            print(colored("[b]", "magenta") + ' "I\'ll take a look at it."')
-            _quest_choice = input("Choice: ").strip().lower()
-            if _quest_choice not in ["a", "b"]:
-                _quest_choice = "a"
+    def process(self, user_input=None):
+        import io
+        import sys
 
-            if _quest_choice == "a":
-                time.sleep(1)
-                print("Votha Krr's expression darkens, and he continues.")
-                time.sleep(1)
-                dialogue(
-                    "Votha Krr",
-                    "The pools have become infested by a colony of slimes. "
-                    "These slimes are not only consuming the minerals, but are also corrupting the pools "
-                    "themselves, rendering them toxic to our people. We have tried to eradicate the slimes "
-                    "ourselves, but the corruption infects our kind like a disease — it is much too "
-                    "dangerous for me to send my people. I fear that if we do not act soon, the pools "
-                    "will be lost to us and our people will begin to starve.",
-                    "green",
+        if not hasattr(self, "_stage"):
+            self._stage = 1
+
+        in_api_mode = isinstance(sys.stdout, io.StringIO)
+
+        if self._stage == 1:
+            if not self.player.skip_dialog:
+                print(
+                    "Gorran turns. His great head swings toward the passage that leads into the city.\n"
+                    "He makes a sound — short, low, the kind that doesn't require translation — and moves.\n"
+                    "Not wanting to disappoint his new friend, Jean follows him through the passageway.\n\n"
+                )
+                time.sleep(0.5)
+                print(
+                    "The passageway opens into a large cavern, the walls of which are covered in strange, glowing \n"
+                    "symbols. The air is thick with the smell of damp earth and moss. \n"
+                    "Gorran leads Jean through the cavern, "
+                    "pointing out various features of the Grondite settlement as they go."
                 )
                 time.sleep(2)
-                dialogue(
-                    "Jean",
-                    "And you think me, being a creature of flesh, would not be affected by "
-                    "the corruption?",
-                    "cyan",
+                print(
+                    "From the ceiling at various intervals hang clusters of red crystals, casting a steady glow on the \n"
+                    "streets below. Gorran stops in front of a large, stone archway. \n"
+                    "The archway is covered in the same glowing symbols as the walls of the cavern. \n"
+                    "Gorran gestures for Jean to follow him through the archway."
+                )
+                await_input()
+                print(
+                    "As Jean steps through the archway, he is struck by the sheer size of the cavern beyond. \n"
+                    "The ceiling is so high that it is lost in darkness, \nand the walls are so far away that "
+                    "they seem to be a part of the very rock itself. "
+                    "The floor is covered in a thick layer of moss, \nand the air is filled with the sound of dripping water "
+                    "and the heavy bustle of the city's stony inhabitants."
+                )
+                time.sleep(2)
+                print(
+                    "After walking at length, Gorran stops in front of a large, stone building. "
+                )
+                print(
+                    "The Citadel rises before them, an immense structure carved directly from the cavern's living stone. \n"
+                    "Its walls are etched with intricate, ancient depictions of Grondia's history. \n"
+                    "Massive pillars support the vaulted entrance, and the air hums with a quiet energy. \n"
+                    "Jean feels a sense of both wonder and trepidation as he gazes up at the fortress, \n"
+                    "realizing that this place has stood for countless generations, \n"
+                    "guarding secrets as old as the earth itself."
+                )
+                await_input()
+                print(
+                    "Gorran turns to Jean, his expression serious. He gestures towards the Citadel, \n"
+                    "indicating that this is where they must go next. \n"
+                    "Jean nods, understanding that this is a place of great importance to the Grondites, \n"
+                    "and perhaps to his own journey as well."
+                )
+                time.sleep(4)
+                print(
+                    "Gorran leads Jean into the Citadel, where they are greeted by a group of Grondites. \n"
+                    "They are dressed in simple, yet sturdy clothing, and they regard Jean with curiosity. \n"
+                    "Gorran addresses the Grondites in their peculiar language of grunts and groans, \n"
+                    "apparently explaining that he is a friend and ally - or, at the very least, not an enemy."
+                )
+                time.sleep(4)
+                print(
+                    "The Grondites nod in understanding, and one of them steps forward to address Jean. \n"
+                    "He speaks in a deep, rumbling voice, gesturing towards the interior of the Citadel. \n"
+                    "Gorran nods his great head and sets off into the depths of the Citadel, \n"
+                    "motioning for Jean to follow. "
+                )
+                await_input()
+                print(
+                    "As they walk through the Citadel, Jean is struck by the sheer scale of the place. \n"
+                    "The halls are vast and echo with the sound of their footsteps. "
+                    "The walls are adorned with intricate carvings and murals, \ndepicting scenes from Grondia's history "
+                    "much like the ones on the walls outside. \n"
+                    "Jean's first thought is not of the carvings. It is of the air — steady, slow-moving, \n"
+                    "cool at his feet and perceptibly warmer at his shoulders. Convection, working the way \n"
+                    "it's supposed to, on a scale he has never encountered. He wants to find where it rises. \n"
+                    "Then Gorran makes a sound and Jean remembers to look at the walls."
+                )
+                time.sleep(4)
+                print(
+                    "Gorran leads Jean to a large chamber at the heart of the Citadel where a group of Grondite elders \n"
+                    "are gathered. They are seated on stone thrones, their faces lined with age and wisdom. \n"
+                    "Gorran speaks to them in their language, and they regard Jean with a mixture of curiosity and respect. \n"
+                    "One of the elders stands and approaches Jean. Much to Jean's surprise, the elder extends a \n"
+                    "burly, unyielding hand in greeting. Taking it, Jean has the sensation of grasping a \n"
+                    "piece of the mountain itself. The elder's grip is firm, but not painful, \n"
+                    "and Jean feels a sense of connection to this ancient being."
+                )
+                await_input()
+                print(
+                    "Even more astonishingly, the elder speaks in a deep, rumbling voice, which Jean is able to understand."
                 )
                 time.sleep(1)
                 dialogue(
-                    "Votha Krr",
-                    "Ah, well, your kind is not immune to the corruption, "
-                    "but it does not affect you in the same way it does us. You see, our bodies are made of "
-                    "the very minerals that the slimes consume, and so we are much more vulnerable to their "
-                    "corruption. However, your flesh is not stone and mineral, so while you may be "
-                    "harmed if you are not careful, you would not turn to dust and crumble "
-                    "as we surely would.",
-                    "green",
-                )
-                dialogue(
-                    "Jean",
-                    'Wait, "my kind?" There are others here like me?',
-                    "cyan",
-                )
-                dialogue(
-                    "Votha Krr",
-                    "Oh yes, indeed! We have traded, formed treaties, and even in times of war, "
-                    "allied with fleshlings like yourself. I believe you call yourselves... ahhhh... humans.",
+                    "Elder",
+                    "You are a friend of Gorran. You are welcome here.",
                     "green",
                 )
                 time.sleep(1)
                 print(
-                    "The last word rumbled from Votha like a landslide, reverberating into Jean's chest."
+                    "Jean nods, grateful for the warm welcome. He can feel the weight of the elder's gaze upon him, \n"
+                    "and he knows that he is in the presence of someone who has seen much in their long life. \n"
+                    "The elder gestures for Jean to sit on a nearby stool, also made from stone. Jean does so, \n"
+                    "feeling awkward and out of place on the hard, cold seat."
+                )
+                time.sleep(5)
+                print(
+                    "Gorran comes over and stands beside Jean, his massive frame casting a shadow over the elder.\n"
+                    "The elder looks up at Gorran and speaks in a low, rumbling voice. \n"
+                    "Gorran rumbles briefly in reply, then turns and strides out of the chamber.\n"
+                    "The elder turns back to Jean, his expression serious."
+                )
+                time.sleep(5)
+                print(
+                    "Now having gotten a chance to look at the elder, Jean can see that he is a bit smaller in form \n"
+                    "than Gorran, though still quite large by human standards. Rather than the craggy, harsh exterior \n"
+                    "of other Golemites, this elder has a smooth, almost polished appearance. It's clear that many \n"
+                    "years of erosion have worn away the rough edges of his form, much like stones in a riverbed. \n"
+                    "His eyes are deep-set and wise, and they seem to hold a depth of knowledge that speaks of \n"
+                    "centuries of experience. He opens his mouth to speak."
+                )
+                await_input()
+                dialogue(
+                    "Elder",
+                    "Welcome, little one. I am Elder Votha Krr. Within this city, I serve "
+                    "on its council of leaders — though some among us are more foolish than "
+                    "others in how much weight they give that title.",
+                    "green",
                 )
                 time.sleep(2)
                 print(
-                    "Jean is quiet, but his mind is already moving — tracing the shape of the problem. "
-                    "An infestation with a center. Corrupted channels. A source."
+                    "With that, a rolling rumble of laughter erupts from the elder's mouth like the aftershocks of an "
+                    "earthquake. "
                 )
+                time.sleep(2)
+                dialogue(
+                    "Votha Krr",
+                    "Ah, but let's not waste time talking about me. Tell me who you are and, "
+                    "especially, why you are here. Or, perhaps more especially, where you are going.",
+                    "green",
+                )
+                time.sleep(2)
+                print(
+                    "Jean pauses for a long moment, unsure of how to answer. If he's honest with himself, he doesn't \n"
+                    "really know how to answer any of those questions. He furrows his brow, troubled by this sudden \n"
+                    "consternation. He takes a deep breath, trying to gather his thoughts."
+                )
+                time.sleep(3)
+                dialogue("Jean", "I am Jean. Jean Claire.", "cyan")
+                time.sleep(1)
+                print("He stops there. Votha Krr waits, unhurried as erosion.")
                 time.sleep(2)
                 dialogue(
                     "Jean",
-                    "Is it centralized? Or spread through the whole system?",
+                    "As for the rest — I can fight. I'm good with my hands. "
+                    "I can figure out what's broken and fix it. "
+                    "That's... that's what I do.",
                     "cyan",
+                )
+                time.sleep(2)
+                print(
+                    "Votha Krr does not nod. He regards Jean with those deep-set eyes — "
+                    "patient, unhurried, the way a canyon regards a river."
+                )
+                time.sleep(3)
+                dialogue(
+                    "Votha Krr",
+                    "You know who you are in your hands. That is not a small thing. "
+                    "Many who arrive in this world know far less.",
+                    "green",
+                )
+                time.sleep(1)
+                print("He tilts his great head, just slightly.")
+                time.sleep(1)
+                dialogue(
+                    "Votha Krr",
+                    "But I notice you did not answer where you are going.",
+                    "green",
+                )
+                time.sleep(2)
+                print("Jean opens his mouth. Closes it. The chamber is very quiet.")
+                time.sleep(2)
+                dialogue("Jean", "No. I didn't.", "cyan")
+                time.sleep(2)
+                print(
+                    "Something passes across Votha Krr's expression — not pity, not recognition. "
+                    "Something older than both."
+                )
+                time.sleep(2)
+                dialogue(
+                    "Votha Krr",
+                    "Then perhaps that is a question for the road.",
+                    "green",
+                )
+                time.sleep(2)
+                print(
+                    "He settles back in his throne, the stone of him indistinguishable from the stone beneath him."
                 )
                 time.sleep(1)
                 dialogue(
                     "Votha Krr",
-                    "There is a heart to it. One great slime at the center of the corruption — "
-                    "the others follow where it leads. Remove the heart, and the rest will dissipate.",
+                    "Since you are a man who knows what to do with his hands — "
+                    "and since you find yourself without a direction — allow me to offer you one. "
+                    "Our sacred Grondelith Mineral Pools to the southwest have been infested by slimes. "
+                    "They consume the minerals our people depend on, and their corruption is lethal to our kind. "
+                    "We cannot clear them ourselves.",
+                    "green",
+                )
+                time.sleep(1.5)
+                print("He watches Jean's face. Jean isn't showing much.")
+                time.sleep(1)
+
+            if in_api_mode:
+                self.needs_input = True
+                self.input_type = "choice"
+                self.description = ""
+                self.input_prompt = ""
+                self.input_options = [
+                    {"value": "a", "label": '"Tell me more."'},
+                    {"value": "b", "label": '"I\'ll take a look at it."'},
+                ]
+                self._stage = 2
+                return
+
+            # Terminal path: ask directly
+            if not self.player.skip_dialog:
+                print(colored("[a]", "magenta") + ' "Tell me more."')
+                print(colored("[b]", "magenta") + ' "I\'ll take a look at it."')
+                user_input = input("Choice: ").strip().lower()
+            if user_input not in ["a", "b"]:
+                user_input = "a"
+            self._stage = 2
+
+        if self._stage == 2:
+            _quest_choice = user_input if user_input in ["a", "b"] else "a"
+
+            if not self.player.skip_dialog:
+                if _quest_choice == "a":
+                    time.sleep(1)
+                    print("Votha Krr's expression darkens, and he continues.")
+                    time.sleep(1)
+                    dialogue(
+                        "Votha Krr",
+                        "The pools have become infested by a colony of slimes. "
+                        "These slimes are not only consuming the minerals, but are also corrupting the pools "
+                        "themselves, rendering them toxic to our people. We have tried to eradicate the slimes "
+                        "ourselves, but the corruption infects our kind like a disease — it is much too "
+                        "dangerous for me to send my people. I fear that if we do not act soon, the pools "
+                        "will be lost to us and our people will begin to starve.",
+                        "green",
+                    )
+                    time.sleep(2)
+                    dialogue(
+                        "Jean",
+                        "And you think me, being a creature of flesh, would not be affected by "
+                        "the corruption?",
+                        "cyan",
+                    )
+                    time.sleep(1)
+                    dialogue(
+                        "Votha Krr",
+                        "Ah, well, your kind is not immune to the corruption, "
+                        "but it does not affect you in the same way it does us. You see, our bodies are made of "
+                        "the very minerals that the slimes consume, and so we are much more vulnerable to their "
+                        "corruption. However, your flesh is not stone and mineral, so while you may be "
+                        "harmed if you are not careful, you would not turn to dust and crumble "
+                        "as we surely would.",
+                        "green",
+                    )
+                    dialogue(
+                        "Jean",
+                        'Wait, "my kind?" There are others here like me?',
+                        "cyan",
+                    )
+                    dialogue(
+                        "Votha Krr",
+                        "Oh yes, indeed! We have traded, formed treaties, and even in times of war, "
+                        "allied with fleshlings like yourself. I believe you call yourselves... ahhhh... humans.",
+                        "green",
+                    )
+                    time.sleep(1)
+                    print(
+                        "The last word rumbled from Votha like a landslide, reverberating into Jean's chest."
+                    )
+                    time.sleep(2)
+                    print(
+                        "Jean is quiet, but his mind is already moving — tracing the shape of the problem. "
+                        "An infestation with a center. Corrupted channels. A source."
+                    )
+                    time.sleep(2)
+                    dialogue(
+                        "Jean",
+                        "Is it centralized? Or spread through the whole system?",
+                        "cyan",
+                    )
+                    time.sleep(1)
+                    dialogue(
+                        "Votha Krr",
+                        "There is a heart to it. One great slime at the center of the corruption — "
+                        "the others follow where it leads. Remove the heart, and the rest will dissipate.",
+                        "green",
+                    )
+                    time.sleep(1)
+                    print(
+                        "Jean nods slowly. He's had that kind of job before. Somewhere, in some life, he's gone "
+                        "after the source and let the symptoms take care of themselves."
+                    )
+                    time.sleep(1)
+                    print("He doesn't ask himself why he's so sure of that.")
+                    time.sleep(2)
+                    dialogue("Jean", "Alright. I'll take a look at it.", "cyan")
+                    time.sleep(1)
+                    dialogue(
+                        "Votha Krr",
+                        "Thank you, Jean. The pools are to the southwest. "
+                        "Take these supplies — the corruption will harm you if you are not careful.",
+                        "green",
+                    )
+                    time.sleep(1)
+                else:
+                    dialogue("Jean", "I'll take a look at it.", "cyan")
+                    time.sleep(1)
+                    dialogue(
+                        "Votha Krr",
+                        "Thank you, Jean. The pools are southwest of the city. "
+                        "The corruption will not destroy your kind as it does ours, "
+                        "but it will hurt you if you are careless. Take these supplies.",
+                        "green",
+                    )
+                    time.sleep(1)
+
+            if not self.player.skip_dialog:
+                print(
+                    "Votha Krr waves a hand, and a Grondite attendant steps forward, carrying a small bundle of supplies. "
+                )
+                print("The attendant hands the bundle to Jean, who takes it gratefully.")
+            # Add 5 Antidotes and 2 Restoratives to the player's inventory
+            loot = [items.Antidote(5), items.Restorative(2)]
+            self.player.add_items_to_inventory(loot)
+            if not self.player.skip_dialog:
+                await_input()
+
+            if not self.player.skip_dialog:
+                print(
+                    "With that, Votha Krr slowly got to his feet, his massive form towering over Jean.\n"
+                )
+                dialogue(
+                    "Votha Krr",
+                    "May the earth guide your steps, Jean. "
+                    "You are a guest of our city. The merchants of the Eastern Gate "
+                    "will have what you need for the road. "
+                    "Return to me when you have dealt with the slimes.",
                     "green",
                 )
                 time.sleep(1)
                 print(
-                    "Jean nods slowly. He's had that kind of job before. Somewhere, in some life, he's gone "
-                    "after the source and let the symptoms take care of themselves."
+                    "He pauses. Those deep-set eyes hold Jean's for a moment longer than necessary."
                 )
-                time.sleep(1)
-                print("He doesn't ask himself why he's so sure of that.")
-                time.sleep(2)
-                dialogue("Jean", "Alright. I'll take a look at it.", "cyan")
                 time.sleep(1)
                 dialogue(
                     "Votha Krr",
-                    "Thank you, Jean. The pools are to the southwest. "
-                    "Take these supplies — the corruption will harm you if you are not careful.",
+                    "And when you return — perhaps we will speak again "
+                    "of where you are going.",
                     "green",
                 )
                 time.sleep(1)
-            else:
-                dialogue("Jean", "I'll take a look at it.", "cyan")
-                time.sleep(1)
-                dialogue(
-                    "Votha Krr",
-                    "Thank you, Jean. The pools are southwest of the city. "
-                    "The corruption will not destroy your kind as it does ours, "
-                    "but it will hurt you if you are careless. Take these supplies.",
-                    "green",
+                print(
+                    "He says it the same way he said it the first time. Like a door left open."
                 )
-                time.sleep(1)
-        if not self.player.skip_dialog:
-            print(
-                "Votha Krr waves a hand, and a Grondite attendant steps forward, carrying a small bundle of supplies. "
-            )
-            print("The attendant hands the bundle to Jean, who takes it gratefully.")
-        # Add 5 Antidotes and 2 Restoratives to the player's inventory
-        loot = [items.Antidote(5), items.Restorative(2)]
-        self.player.add_items_to_inventory(loot)
-        if not self.player.skip_dialog:
-            await_input()
 
-        if not self.player.skip_dialog:
-            print(
-                "With that, Votha Krr slowly got to his feet, his massive form towering over Jean.\n"
-            )
-            dialogue(
-                "Votha Krr",
-                "May the earth guide your steps, Jean. "
-                "You are a guest of our city. The merchants of the Eastern Gate "
-                "will have what you need for the road. "
-                "Return to me when you have dealt with the slimes.",
-                "green",
-            )
-            time.sleep(1)
-            print(
-                "He pauses. Those deep-set eyes hold Jean's for a moment longer than necessary."
-            )
-            time.sleep(1)
-            dialogue(
-                "Votha Krr",
-                "And when you return — perhaps we will speak again "
-                "of where you are going.",
-                "green",
-            )
-            time.sleep(1)
-            print(
-                "He says it the same way he said it the first time. Like a door left open."
-            )
-
-        # At the end of the sequence, don't forget to teleport to the Citadel tile.
-
-        #  Remove this event from the tile
-        self.tile.remove_event(self.name)
+            # Remove this event from the tile
+            self.tile.remove_event(self.name)
+            self.needs_input = False
+            self.completed = True
 
 
 class Ch02ArenaEntrance(Event):

--- a/src/story/effects.py
+++ b/src/story/effects.py
@@ -349,7 +349,16 @@ class StMichael(Shrine):
         )
         # Declare input requirements for API mode
         self.input_type = "choice"
-        self.input_prompt = "Selection:"
+        self.input_prompt = "TELL ME THE INSTRUMENT OF JUSTICE THOU DESIREST."
+        self.description = (
+            "This, particularly, is a shrine to Saint Michael the Archangel. "
+            "There is a small statue depicting St Michael spearing a vicious dragon. "
+            "An inscription on the shrine reads:\n\n"
+            "Sáncte Míchael Archángele, defénde nos in proélio...\n\n"
+            "Suddenly, Jean has the feeling of intense heat all around him. "
+            "He hears a voice echoing inside his head.\n\n"
+            "CHILD, THY FAITH PRESERVES THEE. TELL ME THE INSTRUMENT OF JUSTICE THOU DESIREST."
+        )
         # Generate weapon choices at init time
         self._generate_weapon_choices()
 
@@ -391,42 +400,32 @@ class StMichael(Shrine):
         return self.input_options
 
     def process(self, user_input=None):
-        print("This, particularly, is a shrine to Saint Michael the Archangel.")
-        print("There is a small statue depicting St Michael spearing a vicious dragon.")
-        print("""An inscription on the shrine reads,
+        if user_input is None:
+            # Terminal path: print prose + choices and collect input directly
+            print("This, particularly, is a shrine to Saint Michael the Archangel.")
+            print("There is a small statue depicting St Michael spearing a vicious dragon.")
+            print("""An inscription on the shrine reads,
 
         Sáncte Míchael Archángele, defénde nos in proélio, cóntra nequítiam et insídias diáboli ésto præsídium.
         Ímperet ílli Déus, súpplices deprecámur: tuque, prínceps milítiæ cæléstis, Sátanam aliósque spíritus malígnos,
         qui ad perditiónem animárum pervagántur in múndo, divína virtúte, in inférnum detrúde. Ámen.
 
         """)
-        print(
-            "Suddenly, Jean has the feeling of intense heat all around him. "
-            "He hears a voice echoing inside his head."
-        )
-        time.sleep(2)
-        cprint(
-            """CHILD, THY FAITH PRESERVES THEE. TELL ME THE INSTRUMENT OF JUSTICE THOU DESIREST.""",
-            "red",
-        )
-
-        for i, choice in enumerate(self.available_choices):
-            print("{}: {}".format(i, choice[0]))
-
-        if user_input is None:
+            print(
+                "Suddenly, Jean has the feeling of intense heat all around him. "
+                "He hears a voice echoing inside his head."
+            )
+            time.sleep(2)
+            cprint(
+                """CHILD, THY FAITH PRESERVES THEE. TELL ME THE INSTRUMENT OF JUSTICE THOU DESIREST.""",
+                "red",
+            )
+            for i, choice in enumerate(self.available_choices):
+                print("{}: {}".format(i, choice[0]))
             self.needs_input = True
             return
 
         selection = user_input
-        if selection is None:
-            # Fallback for terminal mode, but skip await_input if in API mode (user_input provided)
-            # Actually, just remove the blocking await_input as well
-            # functions.await_input()
-            try:
-                selection = input(colored("Selection: ", "cyan"))
-            except (EOFError, OSError, ValueError):
-                # Default to first option if no input available
-                selection = "0"
 
         if functions.is_input_integer(selection):
             selection = int(selection)


### PR DESCRIPTION
## Summary

Refactored the `Ch02CitadelMeeting` event in `src/story/ch02.py` to support both terminal and API modes by converting it from a single-stage blocking process into a multi-stage event handler. This enables the web API to pause at user input points and resume with provided input, rather than blocking on `input()` calls.

## Key Changes

### `src/story/ch02.py` — Ch02CitadelMeeting.process()
- **Multi-stage architecture**: Introduced `self._stage` state machine (stages 1–2) to track progress through the narrative
- **API mode detection**: Added check for `io.StringIO` stdout to distinguish API vs. terminal execution
- **Input handling**: 
  - Stage 1 displays initial dialogue and quest choice prompt; in API mode, sets `self.needs_input = True` and returns
  - Stage 2 processes the user's choice (a/b) and continues with conditional dialogue
- **Deferred input**: Terminal mode still calls `input()` directly; API mode returns early and resumes via `user_input` parameter
- **Completion tracking**: Set `self.completed = True` after quest acceptance and item grant

### `src/story/effects.py` — ShrineOfStMichael.process()
- **Moved prose to init**: Moved descriptive text and input prompt to `__init__` as `self.description` and `self.input_prompt` for API serialization
- **Simplified process()**: Removed redundant input collection logic; now only prints prose in terminal mode (when `user_input is None`)
- **Cleaner input flow**: Removed try/except fallback for `input()` — API always provides `user_input`

## Implementation Details

- Both events now follow the pattern: detect API mode → set `needs_input` flag and return early → resume on next call with `user_input`
- Terminal mode behavior unchanged: prints all text and blocks on `input()` as before
- Inventory grant (Antidotes, Restoratives) happens in stage 2 regardless of mode
- Event removal from tile deferred until completion to allow multi-call resumption

https://claude.ai/code/session_01SRPsd2tejkUURfmP6J7V4x