### PR TITLE
Preserve API event ID in multi-stage event serialization

### DIFF
--- a/src/api/serializers/event_serializer.py
+++ b/src/api/serializers/event_serializer.py
@@ -264,6 +264,10 @@ class EventSerializer:
         """
         event_data = EventSerializer.serialize(event)
 
+        # Preserve API event ID if set (critical for multi-stage events)
+        if hasattr(event, "api_event_id") and event.api_event_id:
+            event_data["event_id"] = event.api_event_id
+
         # Check if event requires input
         needs_input = EventSerializer._detect_input_requirement(event)
         event_data["needs_input"] = needs_input


### PR DESCRIPTION
## Summary
Fixes event serialization to preserve the `api_event_id` field when present on an event object. This ensures that multi-stage events maintain their unique API identifier throughout the serialization pipeline, preventing ID mismatches in event tracking and response handling.

## Changes
- **`src/api/serializers/event_serializer.py`**: Added logic to `serialize_with_input()` to check for and preserve `api_event_id` if set on the event object before input requirement detection. This ensures the API event ID is not lost during serialization and is included in the final event data payload.

## Implementation Details
The fix is minimal and non-breaking:
- Checks for the presence of `api_event_id` attribute using `hasattr()` before attempting to access it
- Only overwrites `event_data["event_id"]` if the attribute exists and is truthy
- Placed early in the serialization flow (after base serialization, before input detection) to ensure the ID is preserved in all downstream processing
- Critical for multi-stage events where the API event ID must be maintained across serialization boundaries

https://claude.ai/code/session_017DLhGVJoUszkT1GjPNrpU7