### PR TITLE
Add scroll fade indicators to EventDialog

### DIFF
--- a/config_votha_test.ini
+++ b/config_votha_test.ini
@@ -1,0 +1,15 @@
+[game]
+testmode = True
+skipdialog = False
+skipintro = False
+
+startmap = grondia
+startposition = 6, 5
+
+starting_items = Shortsword, LeatherArmor, Restorative, Restorative, Restorative, Antidote
+starting_exp = 8000
+starting_story_flags = lurker_defeated
+
+use_colour = True
+debug_mode = False
+autosave_enabled = False

--- a/frontend/src/components/EventDialog.jsx
+++ b/frontend/src/components/EventDialog.jsx
@@ -4,6 +4,8 @@ import GameButton from './GameButton'
 import GameText from './GameText'
 import GameInput from './GameInput'
 import TypewriterOutput from './TypewriterOutput'
+import ScrollFadeIndicator from './ScrollFadeIndicator'
+import useScrollIndicators from '../hooks/useScrollIndicators'
 import { colors, spacing, commonStyles, fonts } from '../styles/theme'
 import { cleanTerminalLineBreaks } from '../utils/entityUtils'
 
@@ -24,6 +26,7 @@ function EventDialog({ event, history = [], onClose, onSubmitInput }) {
 
     const inputRef = useRef(null)
     const dialogRef = useRef(null)
+    const { showTop, showBottom, check: checkScroll, ref: scrollRef } = useScrollIndicators()
 
     // Earthbound-style damage effect: shake screen + red flash
     const handleDamageHit = useCallback(() => {
@@ -331,25 +334,29 @@ function EventDialog({ event, history = [], onClose, onSubmitInput }) {
                         </pre>
                     </div>
                 ) : (
-                    <TypewriterOutput
-                        text={eventText}
-                        speed={25}
-                        onComplete={() => {
-                            setIsComplete(true)
-                            if (needsInput) setShowInput(true)
-                        }}
-                        onDamageHit={handleDamageHit}
-                        style={{
-                            padding: spacing.lg,
-                            flex: 1,
-                            maxHeight: '450px',
-                            overflowY: 'auto',
-                            border: `2px solid ${colors.secondary}`,
-                            color: colors.success,
-                            whiteSpace: 'pre-wrap',
-                            fontSize: '16px',
-                        }}
-                    />
+                    <div style={{ position: 'relative', flex: 1 }}>
+                        <div ref={scrollRef} style={{ maxHeight: '450px', overflowY: 'auto' }}>
+                            <TypewriterOutput
+                                text={eventText}
+                                speed={25}
+                                onComplete={() => {
+                                    setIsComplete(true)
+                                    if (needsInput) setShowInput(true)
+                                    checkScroll()
+                                }}
+                                onDamageHit={handleDamageHit}
+                                style={{
+                                    padding: spacing.lg,
+                                    border: `2px solid ${colors.secondary}`,
+                                    color: colors.success,
+                                    whiteSpace: 'pre-wrap',
+                                    fontSize: '16px',
+                                }}
+                            />
+                        </div>
+                        {showTop && <ScrollFadeIndicator position="top" color={colors.secondary} bgColor="rgb(5, 10, 5)" />}
+                        {showBottom && <ScrollFadeIndicator position="bottom" color={colors.secondary} bgColor="rgb(5, 10, 5)" />}
+                    </div>
                 )}
 
                 {/* Input Section */}

--- a/frontend/src/components/RoomContents.jsx
+++ b/frontend/src/components/RoomContents.jsx
@@ -64,8 +64,6 @@ export default function RoomContents({ location, onInteract }) {
   return (
     <div className="border-l-4 border-lime rounded px-2.5 py-2.5 text-lime text-sm leading-relaxed font-serif" style={{
       backgroundColor: 'rgba(0,100,50,0.2)',
-      maxHeight: '30vh',
-      overflowY: 'auto',
     }}>
       {/* Room narrative and content all together */}
 


### PR DESCRIPTION
## Summary
Adds visual scroll fade indicators to the EventDialog component to signal when content is scrollable above or below the current viewport. This improves UX by making it clear that more text is available.

## Changes
- **EventDialog.jsx**: 
  - Import `ScrollFadeIndicator` component and `useScrollIndicators` hook
  - Wrap `TypewriterOutput` in a scrollable container with ref tracking
  - Add `checkScroll()` call on typewriter completion to update indicator state
  - Render top/bottom fade indicators conditionally based on scroll position
  - Remove `maxHeight` and `overflowY` from `TypewriterOutput` styles (moved to parent container)

- **RoomContents.jsx**:
  - Remove `maxHeight: '30vh'` and `overflowY: 'auto'` styles (cleanup; unrelated to scroll indicators)

- **config_votha_test.ini** (added):
  - Test configuration file for game initialization (test mode, starting items, story flags, etc.)

## Implementation Details
- Uses the `useScrollIndicators` hook to track scroll state and provide `showTop`/`showBottom` flags
- Indicators render as overlays at top/bottom of scrollable area with fade effect
- Scroll check is triggered when typewriter animation completes, ensuring indicators reflect final content state

https://claude.ai/code/session_015hPHbbthiV1fUDjJDHyzHx