### PR TITLE
fix(moves): prompt for direction in prep() for headless contexts

### DIFF
--- a/src/moves/_movement.py
+++ b/src/moves/_movement.py
@@ -1061,8 +1061,19 @@ class Turn(Move):
         return best_direction
 
     def prep(self, user):
-        """Prep stage - prompt for direction and announce the turn."""
-        self._prompt_direction_selection()
+        """Prep stage - prompt for direction if not already selected and announce the turn."""
+        # Only prompt if direction hasn't been selected yet.
+        # In terminal mode, direction is selected at combat.py:530-535 before cast().
+        # In API mode, direction is set by combat_adapter.py:801 before advance().
+        if not self.target_direction:
+            try:
+                self._prompt_direction_selection()
+            except EOFError:
+                # Headless context (API/testing): no stdin available.
+                # Default to North if direction wasn't pre-selected.
+                self.target_direction = positions.Direction.N
+                cprint(f"{user.name} defaults to facing North.", "yellow")
+
         if self.target_direction:
             cprint(f"{user.name} begins to turn...", "cyan")
 

--- a/src/moves/_movement.py
+++ b/src/moves/_movement.py
@@ -1061,7 +1061,8 @@ class Turn(Move):
         return best_direction
 
     def prep(self, user):
-        """Prep stage - announce the turn."""
+        """Prep stage - prompt for direction and announce the turn."""
+        self._prompt_direction_selection()
         if self.target_direction:
             cprint(f"{user.name} begins to turn...", "cyan")
 


### PR DESCRIPTION
## Summary
Add direction selection prompt to the `prep()` stage of directional moves to handle headless/API contexts where direction is not pre-selected before `cast()` is called.

## Key Changes
- **Enhanced `prep()` docstring** to clarify that it now prompts for direction if not already selected
- **Added direction selection logic** in `prep()` that:
  - Checks if `target_direction` is already set (terminal mode pre-selects at combat.py:530-535; API mode pre-selects at combat_adapter.py:801)
  - Calls `_prompt_direction_selection()` if direction is missing
  - Catches `EOFError` for headless contexts (API/testing with no stdin) and defaults to North with a yellow status message
- **Maintains backward compatibility** with existing terminal and API flows that pre-select direction

## Implementation Details
The change ensures directional moves work correctly in all execution contexts:
- **Terminal mode**: Direction pre-selected before `cast()` → `prep()` skips prompt
- **API mode**: Direction pre-selected before `advance()` → `prep()` skips prompt  
- **Headless/testing**: No pre-selection → `prep()` prompts or defaults to North gracefully

This prevents `AttributeError` when directional moves reach `prep()` without a direction set, improving robustness for edge cases and testing scenarios.

https://claude.ai/code/session_01PHXprEcS8KENVTeqxZ5fN9