### PR TITLE
fix(BattlefieldGrid): use ref instead of state for snap position

### DIFF
--- a/frontend/src/components/BattlefieldGrid.jsx
+++ b/frontend/src/components/BattlefieldGrid.jsx
@@ -1078,9 +1078,10 @@ function BattlefieldGrid({
   if (isFullMode) {
     leftX = 0;
     topY = resolvedMapSize - 1;
-  } else if (snapState) {
-    leftX = snapState.leftX;
-    topY  = snapState.topY;
+  } else if (snapCellRef.current) {
+    // Use the ref directly (always current) instead of state (which may lag during RAF)
+    leftX = snapCellRef.current.leftX;
+    topY  = snapCellRef.current.topY;
   } else {
     // Pre-snapState fallback — Jean always centered, no edge-clamping
     leftX = playerPos.x - HALF_VIEW;


### PR DESCRIPTION
## Summary
Replace `snapState` with `snapCellRef.current` when retrieving snap cell position to avoid stale state during RAF (requestAnimationFrame) cycles.

## Key Changes
- Changed condition from `snapState` to `snapCellRef.current` to check if snap position is available
- Updated position retrieval to use `snapCellRef.current.leftX` and `snapCellRef.current.topY` instead of state values
- Added clarifying comment explaining that refs provide current values without RAF lag

## Implementation Details
This fix addresses a timing issue where `snapState` could lag behind the actual snap cell position during animation frame updates. By using the ref directly, we ensure the viewport always uses the most current snap position without waiting for state updates to propagate through React's render cycle.

https://claude.ai/code/session_01XgNwbh9PPtVbEhNhkpAjZ1