### PR TITLE
feat(combat): Add distance input support for Tactical Positioning

### DIFF
--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -763,6 +763,18 @@ class ApiCombatAdapter:
 
         pending_move.target = target
 
+        # Check if move needs distance input (e.g., Tactical Positioning)
+        if hasattr(pending_move, "needs_distance_input") and pending_move.needs_distance_input:
+            self.input_type = "number_input"
+            self.available_options = {
+                "prompt": "Enter the desired distance (0-100):",
+                "min": pending_move.mvrange[0] if hasattr(pending_move, "mvrange") else 0,
+                "max": pending_move.mvrange[1] if hasattr(pending_move, "mvrange") else 100,
+                "default": 10,
+            }
+            # Keep pending_move_index so we can access the move later
+            return self.get_combat_state()
+
         # Clear pending move index
         self.pending_move_index = None
 
@@ -832,6 +844,10 @@ class ApiCombatAdapter:
         # Set the duration on the move (for Wait move)
         if hasattr(pending_move, "duration"):
             pending_move.duration = value
+
+        # Set the distance on the move (for Tactical Positioning)
+        if hasattr(pending_move, "distance"):
+            pending_move.distance = value
 
         # Clear pending move index
         self.pending_move_index = None

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -766,6 +766,7 @@ class ApiCombatAdapter:
         # Check if move needs distance input (e.g., Tactical Positioning)
         if hasattr(pending_move, "needs_distance_input") and pending_move.needs_distance_input:
             self.input_type = "number_input"
+            self.awaiting_input = True
             self.available_options = {
                 "prompt": "Enter the desired distance (0-100):",
                 "min": pending_move.mvrange[0] if hasattr(pending_move, "mvrange") else 0,
@@ -821,6 +822,10 @@ class ApiCombatAdapter:
         """Handle player entering a numeric value."""
         if self.input_type != "number_input":
             return {"error": "Not expecting number input"}
+
+        # Ensure value is an integer
+        if not isinstance(value, int) or isinstance(value, bool):
+            return {"error": "Invalid numeric value"}
 
         # Reconstruct pending move
         if self.pending_move_index is None:

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2173,6 +2173,9 @@ class GameService:
                         "target_id": target_id,
                     }
                     result = adapter.process_command(target_command)
+                    # Note: If the move needs additional input after targeting (e.g., distance),
+                    # result will now contain that input_type (e.g., 'number_input') and will be
+                    # returned to the client for further input.
 
             return result
 

--- a/src/moves/_movement.py
+++ b/src/moves/_movement.py
@@ -749,6 +749,7 @@ class TacticalPositioning(Move):
         self.distance = 0
         self.target_dist_final = None
         self.fatigue_per_beat = 1
+        self.needs_distance_input = True
         self.evaluate()
 
     def viable(self):


### PR DESCRIPTION
## Summary
Extends the combat adapter to support moves that require additional numeric input after target selection. Implements distance input flow for the Tactical Positioning move, allowing players to specify desired distance (0-100) after selecting a target.

## Key Changes
- **combat_adapter.py**: 
  - Added check in `_handle_target_selection()` to detect moves with `needs_distance_input` flag
  - When distance input is needed, set `input_type = "number_input"` and return combat state with distance prompt (min/max from move's `mvrange`)
  - Keep `pending_move_index` set so the move can be accessed when distance input is received
  - Added validation in `_handle_number_selection()` to ensure value is a valid integer (not bool)
  - Added logic to set `distance` attribute on pending move when number input is processed

- **_movement.py**:
  - Added `needs_distance_input = True` flag to `TacticalPositioning` class to signal that this move requires distance input after targeting

- **game_service.py**:
  - Added clarifying comment explaining that moves requiring additional input (e.g., distance) will return `input_type` in the result for client-side handling

## Implementation Details
- The distance input flow follows the existing pattern: target selection → input request → number input processing
- Distance constraints are derived from the move's `mvrange` attribute (fallback: 0-100)
- Default distance is set to 10 if not specified
- The `pending_move_index` is preserved during distance input to maintain move context
- Input validation prevents boolean values from being accepted as numeric input

https://claude.ai/code/session_013Ytb2KTPDhr1DnnbWrf4on