### PR TITLE
Skip SFX and delays when recovering from page reload during combat

### DIFF
--- a/frontend/src/components/LeftPanel.jsx
+++ b/frontend/src/components/LeftPanel.jsx
@@ -94,6 +94,18 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
     )
   }, [combat?.log, displayedLog])
 
+  // Detect page reload during combat: all logs pending on first batch (no logs displayed yet)
+  const isPageReloadRecovery = useRef(false)
+  useEffect(() => {
+    // If we have pending logs but haven't displayed ANY yet, it's a reload recovery
+    if (displayedLog.length === 0 && pendingLogEntries.length > 0) {
+      isPageReloadRecovery.current = true
+    } else if (displayedLog.length > 0) {
+      // Once we've displayed any logs normally, no longer in reload recovery
+      isPageReloadRecovery.current = false
+    }
+  }, [displayedLog.length, pendingLogEntries.length])
+
   // Determine if we are effectively busy
   const isBusyProcessing = isProcessingLog || pendingLogEntries.length > 0
 
@@ -144,6 +156,7 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
       const delayPerLine = 400 // ms per line
       let currentIndex = 0
       const currentPending = pendingLogEntries // capture for closure
+      const skipDelays = isPageReloadRecovery.current
 
       // Function to process one line at a time
       const processNextLine = () => {
@@ -152,6 +165,7 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
         if (currentIndex >= currentPending.length) {
           // All lines processed
           setIsProcessingLog(false)
+          isPageReloadRecovery.current = false
           return
         }
 
@@ -179,8 +193,8 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
           onLogProgress(beatIndex)
         }
 
-        // Play SFX (skip for animation-only entries)
-        if (!isAnimationEntry) {
+        // Play SFX (skip for animation-only entries, and skip all SFX during reload recovery)
+        if (!isAnimationEntry && !skipDelays) {
           if (msg.includes('attacks')) playSFX('attack_swipe')
           else if (msg.includes('hit') || msg.includes('damage')) playSFX('attack_hit')
           else if (msg.includes('miss')) playSFX('attack_miss')
@@ -207,18 +221,25 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
 
         currentIndex++
 
-        // For animation entries, hold the log reveal for the animation's
-        // duration so the next (outcome) line doesn't appear before the
-        // player sees the swing/impact. Fall back to 0 when we don't know
-        // the animation type.
-        const animDuration = isAnimationEntry
-          ? getAnimationDuration(entry.animation?.type)
-          : 0
-        const nextDelay = isAnimationEntry
-          ? animDuration
-          : (msg.includes('victory') ? 2000 : delayPerLine)
-        if (isMounted) {
-          timeoutId = setTimeout(processNextLine, nextDelay)
+        // For page reloads, display all logs instantly without delays
+        if (skipDelays) {
+          if (isMounted) {
+            timeoutId = setTimeout(processNextLine, 0)
+          }
+        } else {
+          // For animation entries, hold the log reveal for the animation's
+          // duration so the next (outcome) line doesn't appear before the
+          // player sees the swing/impact. Fall back to 0 when we don't know
+          // the animation type.
+          const animDuration = isAnimationEntry
+            ? getAnimationDuration(entry.animation?.type)
+            : 0
+          const nextDelay = isAnimationEntry
+            ? animDuration
+            : (msg.includes('victory') ? 2000 : delayPerLine)
+          if (isMounted) {
+            timeoutId = setTimeout(processNextLine, nextDelay)
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
When a player reloads the page during active combat, the frontend now detects this scenario and displays all pending combat logs instantly without sound effects or animation delays. This prevents the jarring experience of hearing rapid-fire SFX and watching logs appear in slow motion after a reload.

## Key Changes
- **Page reload detection**: Added `isPageReloadRecovery` ref that tracks whether we're in the initial batch of logs after a reload (no logs displayed yet, but pending logs exist)
- **Skip SFX during recovery**: Sound effects are suppressed when `skipDelays` is true, preventing audio spam
- **Instant log display**: All pending logs are processed with zero delay (0ms timeout) during reload recovery, allowing the player to quickly catch up to the current combat state
- **Recovery flag reset**: The flag is cleared once normal log processing resumes or all pending logs are processed

## Implementation Details
- Uses a `useRef` to persist the reload recovery state across renders without triggering re-renders
- Captures `skipDelays` in the closure of `processNextLine` to maintain consistent behavior throughout the batch
- Preserves normal animation timing and SFX for logs displayed after the initial recovery batch
- Resets the recovery flag both when processing completes and when normal logs start appearing, ensuring the feature only applies to the immediate post-reload scenario

https://claude.ai/code/session_014usxq7Un754j1WyiatbdQU