### PR TITLE
refactor(frontend): move equipped status outside grid layout

### DIFF
--- a/frontend/src/components/ItemDetailDialog.jsx
+++ b/frontend/src/components/ItemDetailDialog.jsx
@@ -376,23 +376,22 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
             </div>
           )}
 
-          {/* Equipped Status */}
-          {item.is_equipped && (
-            <div style={{
-              backgroundColor: 'rgba(0, 50, 0, 0.6)',
-              padding: '6px',
-              textAlign: 'center',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              gridColumn: '1 / -1',
-            }}>
-              <div style={{ color: '#00ff88', fontWeight: 'bold', fontSize: '14px' }}>
-                ✓ Equipped
-              </div>
-            </div>
-          )}
         </div>
+
+        {/* Equipped Status — outside the grid to avoid auto-fit column count distortion */}
+        {item.is_equipped && (
+          <div style={{
+            backgroundColor: 'rgba(0, 50, 0, 0.6)',
+            border: '1px solid #664400',
+            borderRadius: '3px',
+            padding: '6px',
+            textAlign: 'center',
+          }}>
+            <div style={{ color: '#00ff88', fontWeight: 'bold', fontSize: '14px' }}>
+              ✓ Equipped
+            </div>
+          </div>
+        )}
 
         {/* Merchandise Callout */}
         {item.is_merchandise && (


### PR DESCRIPTION
## Summary
Moved the "Equipped Status" indicator outside the CSS Grid container in `ItemDetailDialog` to prevent layout distortion caused by the `auto-fit` grid column count.

## Key Changes
- Relocated the equipped status `<div>` from inside the grid (with `gridColumn: '1 / -1'`) to a sibling element after the grid closes
- Added visual styling to the relocated element:
  - `border: '1px solid #664400'` for consistency with other callouts
  - `borderRadius: '3px'` for polish
  - Removed grid-specific layout properties (`display: 'flex'`, `flexDirection`, `justifyContent`)
- Updated inline comment to clarify the reason for the structural change

## Implementation Details
The equipped status was previously using `gridColumn: '1 / -1'` to span all columns, but this can interfere with the grid's `auto-fit` behavior and cause unexpected column count changes. By moving it outside the grid entirely, the layout remains stable while maintaining visual prominence through border and background styling.

https://claude.ai/code/session_01NJegbZepnwwcdQhU2E7NyQ