### PR TITLE
fix(frontend): prevent mode flicker to exploration before victory/defeat dialog

### DIFF
--- a/frontend/src/hooks/useCombatCoordinator.js
+++ b/frontend/src/hooks/useCombatCoordinator.js
@@ -39,6 +39,9 @@ export function useCombatCoordinator({
     const [lastEndStateId, setLastEndStateId] = useState(
         () => sessionStorage.getItem('hov_last_end_state_id')
     )
+    // True from when the end-state timer is scheduled until the dialog fires.
+    // Lets GamePage keep mode='combat' during the delay without relying on lastEndStateId.
+    const [endStatePending, setEndStatePending] = useState(false)
 
     // Combat log processing state
     const [isCombatLogProcessing, setIsCombatLogProcessing] = useState(false)
@@ -67,10 +70,12 @@ export function useCombatCoordinator({
                 // Mark handled immediately so re-renders don't schedule a second timer
                 setLastEndStateId(maybeEnd.id)
                 sessionStorage.setItem('hov_last_end_state_id', maybeEnd.id)
+                setEndStatePending(true)
 
                 const isVictory = maybeEnd.status === 'victory'
                 endStateTimerRef.current = setTimeout(() => {
                     endStateTimerRef.current = null
+                    setEndStatePending(false)
                     if (isVictory) {
                         setShowVictoryDialog(true)
                         // Play fanfare as a one-shot sting (non-looping)
@@ -173,6 +178,7 @@ export function useCombatCoordinator({
         showLootDialog,
         endState,
         lastEndStateId,
+        endStatePending,
         isCombatLogProcessing,
         currentLogIndex,
         hoveredTargetId,

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -66,6 +66,7 @@ export default function GamePage() {
     showLootDialog,
     endState,
     lastEndStateId,
+    endStatePending,
     isCombatLogProcessing,
     currentLogIndex,
     hoveredTargetId,
@@ -337,10 +338,12 @@ export default function GamePage() {
       if (maybeEnd && (maybeEnd.status === 'victory' || maybeEnd.status === 'defeat')) {
         setEndState(maybeEnd)
 
-        // Keep mode locked to 'combat' while the dialog is open or pending.
-        // Once closed, lastEndStateId catches up and we switch back to exploration.
-        const isDialogActive = showVictoryDialog || showDefeatDialog || maybeEnd.id !== lastEndStateId;
-        
+        // Keep mode locked to 'combat' while the dialog is pending (timer running)
+        // or while the dialog is open. endStatePending bridges the gap between when
+        // lastEndStateId is updated (immediately, to prevent duplicate timers) and
+        // when showVictoryDialog/showDefeatDialog becomes true (after the delay).
+        const isDialogActive = showVictoryDialog || showDefeatDialog || endStatePending;
+
         if (isDialogActive) {
           setMode('combat')
         } else {
@@ -355,7 +358,7 @@ export default function GamePage() {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inCombat, combat, eventQueue, currentEvent, lastEndStateId, showVictoryDialog, showDefeatDialog])
+  }, [inCombat, combat, eventQueue, currentEvent, endStatePending, showVictoryDialog, showDefeatDialog])
 
   /**
    * Manage SFX when modes change


### PR DESCRIPTION
## Summary

- After defeating the last enemy, the screen was briefly dumping to exploration mode before the victory screen appeared ~5 seconds later, then snapping back to combat mode and replaying battle animations and SFX with the victory overlay.
- Root cause: `useCombatCoordinator` updated `lastEndStateId` immediately (to prevent duplicate timers), but `GamePage`'s mode-lock condition used `maybeEnd.id !== lastEndStateId` to detect a pending dialog — which evaluated to `false` right away, dropping mode to `'exploration'` for the full 5-second delay.
- Fix: adds an `endStatePending` boolean in `useCombatCoordinator` that is `true` from when the delay timer is scheduled until it fires, and uses it in `GamePage`'s `isDialogActive` check in place of the unreliable `lastEndStateId` comparison.

## Test plan

- [ ] Defeat the last enemy in combat — battlefield should remain visible for the full ~5 seconds before the victory screen appears; no flash to the world map in between
- [ ] Verify battle SFX/animations do not replay when the victory screen appears
- [ ] Dismiss the victory screen — should transition cleanly to exploration mode
- [ ] Defeat path (player dies): same check — no flash to world map before defeat dialog appears
- [ ] Frontend tests pass: `cd frontend && npm test -- --run` (1238 tests, all green)

https://claude.ai/code/session_013PWTZVqb7UpRQmnH3Cp1Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_013PWTZVqb7UpRQmnH3Cp1Wa)_