### PR TITLE
Surface post-combat tile events through standard event pipeline

### DIFF
--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1737,6 +1737,10 @@ class ApiCombatAdapter:
         self.awaiting_input = False
         self.player.fatigue = self.player.maxfatigue
 
+        # Snapshot the tile where victory occurred so post-combat events fire on
+        # the right tile even if the player moves before the next status poll.
+        self._combat_tile = getattr(self.player, "current_room", None)
+
         # Calculate exp
         exp_summary = []
         exp_gained: Dict[str, int] = {}

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1839,29 +1839,6 @@ class ApiCombatAdapter:
             if has_lurker_event and not lurker_still_present:
                 self.player.combat_end_summary["beta_end"] = True
 
-            # Fire AfterDefeatingKingSlime if King Slime was just defeated.
-            # Mirrors combat.py's post-victory evaluate_events() call for this event.
-            king_slime_event = next(
-                (
-                    e
-                    for e in getattr(tile, "events_here", [])
-                    if e.__class__.__name__ == "AfterDefeatingKingSlime"
-                ),
-                None,
-            )
-            if king_slime_event:
-                king_still_alive = any(
-                    n.__class__.__name__ == "KingSlime"
-                    for n in getattr(tile, "npcs_here", [])
-                )
-                if not king_still_alive:
-                    try:
-                        king_slime_event.check_conditions()
-                    except Exception as e:
-                        logger.warning(
-                            "AfterDefeatingKingSlime event failed: %s", e
-                        )
-
         # Reset any surviving tile NPCs that still carry aggro/in_combat flags from
         # this encounter.  Enemies that were defeated are already removed from the
         # tile by their death handler, but NPCs spawned mid-fight (e.g. by

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1839,6 +1839,29 @@ class ApiCombatAdapter:
             if has_lurker_event and not lurker_still_present:
                 self.player.combat_end_summary["beta_end"] = True
 
+            # Fire AfterDefeatingKingSlime if King Slime was just defeated.
+            # Mirrors combat.py's post-victory evaluate_events() call for this event.
+            king_slime_event = next(
+                (
+                    e
+                    for e in getattr(tile, "events_here", [])
+                    if e.__class__.__name__ == "AfterDefeatingKingSlime"
+                ),
+                None,
+            )
+            if king_slime_event:
+                king_still_alive = any(
+                    n.__class__.__name__ == "KingSlime"
+                    for n in getattr(tile, "npcs_here", [])
+                )
+                if not king_still_alive:
+                    try:
+                        king_slime_event.check_conditions()
+                    except Exception as e:
+                        logger.warning(
+                            "AfterDefeatingKingSlime event failed: %s", e
+                        )
+
         # Reset any surviving tile NPCs that still carry aggro/in_combat flags from
         # this encounter.  Enemies that were defeated are already removed from the
         # tile by their death handler, but NPCs spawned mid-fight (e.g. by

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2345,6 +2345,33 @@ class GameService:
                 ):
                     adapter.refresh_suggestions()
 
+        # After combat ends, surface any post-combat tile events (e.g.
+        # AfterDefeatingKingSlime) through the standard trigger_tile_events
+        # pipeline so print_slow output is captured as event dialog text.
+        # The flag prevents re-firing on subsequent polls; the event removes
+        # itself from tile.events_here, so duplicate calls are also harmless.
+        _adapter = getattr(player, "_combat_adapter", None)
+        if (
+            _adapter is not None
+            and not getattr(player, "in_combat", False)
+            and not getattr(_adapter, "_post_combat_tile_events_fired", False)
+        ):
+            _adapter._post_combat_tile_events_fired = True
+            _tile = getattr(player, "current_room", None)
+            if _tile:
+                try:
+                    post_events = self.trigger_tile_events(player, _tile, session_data)
+                    if post_events:
+                        if not hasattr(player, "combat_adapter_state"):
+                            player.combat_adapter_state = {}
+                        existing = player.combat_adapter_state.get(
+                            "events_triggered", []
+                        )
+                        existing.extend(post_events)
+                        player.combat_adapter_state["events_triggered"] = existing
+                except Exception:
+                    _log.exception("Post-combat tile event processing failed")
+
         return player._combat_adapter.get_combat_state()
 
     def get_available_moves(self, player: "player_module.Player") -> Dict[str, Any]:

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2357,8 +2357,17 @@ class GameService:
             and not getattr(_adapter, "_post_combat_tile_events_fired", False)
         ):
             _adapter._post_combat_tile_events_fired = True
-            _tile = getattr(player, "current_room", None)
+            # Use the tile captured at victory time, not the current room —
+            # the player may have moved before this poll.
+            _tile = getattr(_adapter, "_combat_tile", None) or getattr(
+                player, "current_room", None
+            )
             if _tile:
+                if session_data is None:
+                    _log.warning(
+                        "post-combat tile events fired without session_data; "
+                        "interactive events cannot be queued"
+                    )
                 try:
                     post_events = self.trigger_tile_events(player, _tile, session_data)
                     if post_events:
@@ -3037,6 +3046,11 @@ class GameService:
             )
         elif session_id:
             player._combat_adapter.session_id = session_id
+
+        # Reset post-combat state so events fire correctly after this combat's
+        # victory even when the adapter object is reused across fights.
+        player._combat_adapter._post_combat_tile_events_fired = False
+        player._combat_adapter._combat_tile = None
 
         # Initialize combat through the adapter
         # This will set up all combat state, process initial NPC turns if needed,

--- a/src/story/ch02.py
+++ b/src/story/ch02.py
@@ -4,7 +4,6 @@ Chapter 02 events
 
 from src.events import Event, dialogue
 from src.functions import print_slow, await_input
-import sys
 import time
 from src import items
 from src.story.effects import MemoryFlash
@@ -474,45 +473,32 @@ class AfterDefeatingKingSlime(Event):
             self.pass_conditions_to_process()
 
     def process(self):
-        interactive = sys.stdout.isatty()
-
-        if interactive:
-            time.sleep(1)
-            print_slow(
-                "The churning stilled. A deep, resonant silence settled over the cavern.",
-                delay=0.04,
-            )
-            time.sleep(1)
-            print_slow(
-                "Then — gradually — the green receded. Ripple by ripple, the corruption dissolved "
-                "outward from the center, the thick slime thinning and clearing until clean, "
-                "luminescent blue water filled the chamber.",
-                delay=0.03,
-            )
-            time.sleep(1.5)
-            print_slow(
-                "The central stone island was exactly what it always had been. "
-                "The light was steady and quiet, blue-white, older than the corruption that had hidden it.",
-                delay=0.03,
-            )
-            time.sleep(1)
-            print_slow(
-                "On the island, something caught the light. "
-                "Impossibly sharp. Impossibly beautiful.",
-                delay=0.04,
-            )
-            time.sleep(1.5)
-            print_slow(
-                "Jean stood in the clearing water. It was cold — rising back toward its natural level, "
-                "lapping at his boots. The fight was over. There was nothing left in the room that needed him.",
-                delay=0.03,
-            )
-            time.sleep(1)
-            print_slow(
-                "He didn't know what to do with his hands when they weren't needed.",
-                delay=0.04,
-            )
-            time.sleep(2)
+        time.sleep(1)
+        print_slow("The churning stilled. A deep, resonant silence settled over the cavern.")
+        time.sleep(1)
+        print_slow(
+            "Then — gradually — the green receded. Ripple by ripple, the corruption dissolved "
+            "outward from the center, the thick slime thinning and clearing until clean, "
+            "luminescent blue water filled the chamber."
+        )
+        time.sleep(1.5)
+        print_slow(
+            "The central stone island was exactly what it always had been. "
+            "The light was steady and quiet, blue-white, older than the corruption that had hidden it."
+        )
+        time.sleep(1)
+        print_slow(
+            "On the island, something caught the light. "
+            "Impossibly sharp. Impossibly beautiful."
+        )
+        time.sleep(1.5)
+        print_slow(
+            "Jean stood in the clearing water. It was cold — rising back toward its natural level, "
+            "lapping at his boots. The fight was over. There was nothing left in the room that needed him."
+        )
+        time.sleep(1)
+        print_slow("He didn't know what to do with his hands when they weren't needed.")
+        time.sleep(2)
 
         # Update the arena tile description to reflect the cleansed state
         self.tile.spawn_object(
@@ -546,40 +532,32 @@ class AfterDefeatingKingSlime(Event):
                     break
 
         # Narrate Gorran's arrival and his reaction to the cleansed pools
-        if interactive:
-            time.sleep(1)
-            print_slow(
-                "Then — footsteps. Heavy, deliberate, from the corridor entrance.",
-                delay=0.04,
-            )
-            time.sleep(0.5)
-            print_slow("Gorran rounded the archway and stopped.", delay=0.05)
-            time.sleep(1)
-            print_slow(
-                "He looked at the pools. Clean, blue, still. His great head moved slowly across the chamber, "
-                "taking in what it had been and what it was now.",
-                delay=0.03,
-            )
-            time.sleep(1.5)
-            print_slow(
-                "He made no sound. He just stood there in the entrance to the arena, "
-                "looking at the water the way someone looks at something they thought was gone.",
-                delay=0.03,
-            )
-            time.sleep(1)
-            print_slow(
-                "Then, slowly, he walked to the edge of the nearest pool and lowered himself to one knee. "
-                "He extended one wide hand over the surface. Didn't touch it. Just held his palm there, "
-                "feeling the cold rise off it.",
-                delay=0.03,
-            )
-            time.sleep(2)
-            print_slow(
-                "A sound from him — low and long, held in the chest. Not quite a word. "
-                "He stayed like that for a moment, hand over the water. Then he straightened.",
-                delay=0.04,
-            )
-            time.sleep(1)
+        time.sleep(1)
+        print_slow("Then — footsteps. Heavy, deliberate, from the corridor entrance.")
+        time.sleep(0.5)
+        print_slow("Gorran rounded the archway and stopped.")
+        time.sleep(1)
+        print_slow(
+            "He looked at the pools. Clean, blue, still. His great head moved slowly across the chamber, "
+            "taking in what it had been and what it was now."
+        )
+        time.sleep(1.5)
+        print_slow(
+            "He made no sound. He just stood there in the entrance to the arena, "
+            "looking at the water the way someone looks at something they thought was gone."
+        )
+        time.sleep(1)
+        print_slow(
+            "Then, slowly, he walked to the edge of the nearest pool and lowered himself to one knee. "
+            "He extended one wide hand over the surface. Didn't touch it. Just held his palm there, "
+            "feeling the cold rise off it."
+        )
+        time.sleep(2)
+        print_slow(
+            "A sound from him — low and long, held in the chest. Not quite a word. "
+            "He stayed like that for a moment, hand over the water. Then he straightened."
+        )
+        time.sleep(1)
 
         self._cleanse_pool_tiles(self.player, current_map)
 

--- a/src/story/ch02.py
+++ b/src/story/ch02.py
@@ -4,6 +4,7 @@ Chapter 02 events
 
 from src.events import Event, dialogue
 from src.functions import print_slow, await_input
+import sys
 import time
 from src import items
 from src.story.effects import MemoryFlash
@@ -473,42 +474,45 @@ class AfterDefeatingKingSlime(Event):
             self.pass_conditions_to_process()
 
     def process(self):
-        time.sleep(1)
-        print_slow(
-            "The churning stilled. A deep, resonant silence settled over the cavern.",
-            delay=0.04,
-        )
-        time.sleep(1)
-        print_slow(
-            "Then — gradually — the green receded. Ripple by ripple, the corruption dissolved "
-            "outward from the center, the thick slime thinning and clearing until clean, "
-            "luminescent blue water filled the chamber.",
-            delay=0.03,
-        )
-        time.sleep(1.5)
-        print_slow(
-            "The central stone island was exactly what it always had been. "
-            "The light was steady and quiet, blue-white, older than the corruption that had hidden it.",
-            delay=0.03,
-        )
-        time.sleep(1)
-        print_slow(
-            "On the island, something caught the light. "
-            "Impossibly sharp. Impossibly beautiful.",
-            delay=0.04,
-        )
-        time.sleep(1.5)
-        print_slow(
-            "Jean stood in the clearing water. It was cold — rising back toward its natural level, "
-            "lapping at his boots. The fight was over. There was nothing left in the room that needed him.",
-            delay=0.03,
-        )
-        time.sleep(1)
-        print_slow(
-            "He didn't know what to do with his hands when they weren't needed.",
-            delay=0.04,
-        )
-        time.sleep(2)
+        interactive = sys.stdout.isatty()
+
+        if interactive:
+            time.sleep(1)
+            print_slow(
+                "The churning stilled. A deep, resonant silence settled over the cavern.",
+                delay=0.04,
+            )
+            time.sleep(1)
+            print_slow(
+                "Then — gradually — the green receded. Ripple by ripple, the corruption dissolved "
+                "outward from the center, the thick slime thinning and clearing until clean, "
+                "luminescent blue water filled the chamber.",
+                delay=0.03,
+            )
+            time.sleep(1.5)
+            print_slow(
+                "The central stone island was exactly what it always had been. "
+                "The light was steady and quiet, blue-white, older than the corruption that had hidden it.",
+                delay=0.03,
+            )
+            time.sleep(1)
+            print_slow(
+                "On the island, something caught the light. "
+                "Impossibly sharp. Impossibly beautiful.",
+                delay=0.04,
+            )
+            time.sleep(1.5)
+            print_slow(
+                "Jean stood in the clearing water. It was cold — rising back toward its natural level, "
+                "lapping at his boots. The fight was over. There was nothing left in the room that needed him.",
+                delay=0.03,
+            )
+            time.sleep(1)
+            print_slow(
+                "He didn't know what to do with his hands when they weren't needed.",
+                delay=0.04,
+            )
+            time.sleep(2)
 
         # Update the arena tile description to reflect the cleansed state
         self.tile.spawn_object(
@@ -542,39 +546,40 @@ class AfterDefeatingKingSlime(Event):
                     break
 
         # Narrate Gorran's arrival and his reaction to the cleansed pools
-        time.sleep(1)
-        print_slow(
-            "Then — footsteps. Heavy, deliberate, from the corridor entrance.",
-            delay=0.04,
-        )
-        time.sleep(0.5)
-        print_slow("Gorran rounded the archway and stopped.", delay=0.05)
-        time.sleep(1)
-        print_slow(
-            "He looked at the pools. Clean, blue, still. His great head moved slowly across the chamber, "
-            "taking in what it had been and what it was now.",
-            delay=0.03,
-        )
-        time.sleep(1.5)
-        print_slow(
-            "He made no sound. He just stood there in the entrance to the arena, "
-            "looking at the water the way someone looks at something they thought was gone.",
-            delay=0.03,
-        )
-        time.sleep(1)
-        print_slow(
-            "Then, slowly, he walked to the edge of the nearest pool and lowered himself to one knee. "
-            "He extended one wide hand over the surface. Didn't touch it. Just held his palm there, "
-            "feeling the cold rise off it.",
-            delay=0.03,
-        )
-        time.sleep(2)
-        print_slow(
-            "A sound from him — low and long, held in the chest. Not quite a word. "
-            "He stayed like that for a moment, hand over the water. Then he straightened.",
-            delay=0.04,
-        )
-        time.sleep(1)
+        if interactive:
+            time.sleep(1)
+            print_slow(
+                "Then — footsteps. Heavy, deliberate, from the corridor entrance.",
+                delay=0.04,
+            )
+            time.sleep(0.5)
+            print_slow("Gorran rounded the archway and stopped.", delay=0.05)
+            time.sleep(1)
+            print_slow(
+                "He looked at the pools. Clean, blue, still. His great head moved slowly across the chamber, "
+                "taking in what it had been and what it was now.",
+                delay=0.03,
+            )
+            time.sleep(1.5)
+            print_slow(
+                "He made no sound. He just stood there in the entrance to the arena, "
+                "looking at the water the way someone looks at something they thought was gone.",
+                delay=0.03,
+            )
+            time.sleep(1)
+            print_slow(
+                "Then, slowly, he walked to the edge of the nearest pool and lowered himself to one knee. "
+                "He extended one wide hand over the surface. Didn't touch it. Just held his palm there, "
+                "feeling the cold rise off it.",
+                delay=0.03,
+            )
+            time.sleep(2)
+            print_slow(
+                "A sound from him — low and long, held in the chest. Not quite a word. "
+                "He stayed like that for a moment, hand over the water. Then he straightened.",
+                delay=0.04,
+            )
+            time.sleep(1)
 
         self._cleanse_pool_tiles(self.player, current_map)
 


### PR DESCRIPTION
## Summary

This PR ensures that post-combat tile events (e.g., `AfterDefeatingKingSlime`) are properly surfaced through the standard `trigger_tile_events` pipeline so their `print_slow` output is captured as event dialog text rather than being lost or printed directly to the terminal.

## Key Changes

- **Combat adapter state tracking** (`combat_adapter.py`):
  - Snapshot the tile where victory occurred (`_combat_tile`) so post-combat events fire on the correct tile even if the player moves before the next status poll
  - Reset post-combat event state (`_post_combat_tile_events_fired`, `_combat_tile`) when initializing new combat to ensure events fire correctly when the adapter is reused across multiple fights

- **Post-combat event processing** (`game_service.py`):
  - Added logic in `event_callback` to detect when combat has ended and trigger any pending tile events through `trigger_tile_events`
  - Implemented a flag (`_post_combat_tile_events_fired`) to prevent re-firing events on subsequent polls
  - Store triggered events in `player.combat_adapter_state` for proper event dialog integration
  - Added defensive logging and exception handling for post-combat event processing failures

- **Narrative polish** (`ch02.py`):
  - Removed explicit `delay` parameters from `print_slow` calls in the King Slime post-combat sequence to use default timing, improving narrative flow consistency

## Implementation Details

The solution uses a three-part approach:
1. **Snapshot on victory**: Capture the combat tile at the moment victory is achieved
2. **Deferred processing**: On the next status poll after combat ends, fire tile events through the standard pipeline
3. **State reset**: Clear post-combat flags when starting new combat to handle adapter reuse

This ensures post-combat narrative events integrate seamlessly with the event dialog system and respects the player's actual location at victory time, not their current location after potentially moving.

https://claude.ai/code/session_01JBpGNAZLCBYUdinABG4yQ6