### PR TITLE
Fix phantom combat on load by resetting transient combat state

### DIFF
--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1172,12 +1172,15 @@ class ApiCombatAdapter:
             result["beat_states"] = beat_states
 
             # Clear enemies after the state snapshot so the defeat payload shows who killed
-            # the player rather than an empty battlefield. Preserve living allies (e.g. Gorran)
-            # so the party roster survives defeat — mirrors _handle_victory and _initialize_combat.
+            # the player rather than an empty battlefield. Preserve only living allies
+            # (e.g. Gorran) so dead allies don't haunt subsequent rooms via recall_friends.
             self.player.combat_list = []
             existing_allies = [
-                a for a in self.player.combat_list_allies if a is not self.player
+                a for a in self.player.combat_list_allies
+                if a is not self.player and a.is_alive()
             ]
+            for ally in existing_allies:
+                ally.in_combat = False
             self.player.combat_list_allies = [self.player] + existing_allies
 
             return result
@@ -1863,12 +1866,18 @@ class ApiCombatAdapter:
                 npc.aggro = False
                 npc.in_combat = False
 
-        # Clear enemies; preserve living allies (e.g. Gorran) so the party roster
-        # survives the fight. Invariant: combat_list_allies[0] is always the player.
+        # Clear enemies; preserve only living allies so the party roster survives the
+        # fight without dead NPCs haunting recall_friends or the next combat's grid sizing.
+        # Also clear in_combat on surviving allies — the tile-reset loop above only touches
+        # non-friend NPCs, leaving friend=True allies with in_combat=True after every fight.
+        # Invariant: combat_list_allies[0] is always the player.
         self.player.combat_list = []
         existing_allies = [
-            a for a in self.player.combat_list_allies if a is not self.player
+            a for a in self.player.combat_list_allies
+            if a is not self.player and a.is_alive()
         ]
+        for ally in existing_allies:
+            ally.in_combat = False
         self.player.combat_list_allies = [self.player] + existing_allies
 
     def _get_available_moves(self) -> List[Dict[str, Any]]:

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1150,10 +1150,6 @@ class ApiCombatAdapter:
                 self.player.combat_beat, "You have been defeated!", "system"
             )
 
-            # Clear combat lists so any subsequent autosave doesn't preserve stale enemies
-            self.player.combat_list = []
-            self.player.combat_list_allies = [self.player]
-
             # Set end-of-combat summary for defeat so frontend can show a game-over dialog
             try:
                 import uuid
@@ -1174,6 +1170,16 @@ class ApiCombatAdapter:
 
             result = self.get_combat_state()
             result["beat_states"] = beat_states
+
+            # Clear enemies after the state snapshot so the defeat payload shows who killed
+            # the player rather than an empty battlefield. Preserve living allies (e.g. Gorran)
+            # so the party roster survives defeat — mirrors _handle_victory and _initialize_combat.
+            self.player.combat_list = []
+            existing_allies = [
+                a for a in self.player.combat_list_allies if a is not self.player
+            ]
+            self.player.combat_list_allies = [self.player] + existing_allies
+
             return result
 
         # Evaluate all combat events one final time when enemies are defeated
@@ -1857,10 +1863,13 @@ class ApiCombatAdapter:
                 npc.aggro = False
                 npc.in_combat = False
 
-        # Clear the player's own combat lists so a stale adapter cannot resume.
-        # Invariant: combat_list_allies[0] is always the player (mirrors _initialize_combat).
+        # Clear enemies; preserve living allies (e.g. Gorran) so the party roster
+        # survives the fight. Invariant: combat_list_allies[0] is always the player.
         self.player.combat_list = []
-        self.player.combat_list_allies = [self.player]
+        existing_allies = [
+            a for a in self.player.combat_list_allies if a is not self.player
+        ]
+        self.player.combat_list_allies = [self.player] + existing_allies
 
     def _get_available_moves(self) -> List[Dict[str, Any]]:
         """Get list of all moves for the player with availability status."""

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1150,6 +1150,10 @@ class ApiCombatAdapter:
                 self.player.combat_beat, "You have been defeated!", "system"
             )
 
+            # Clear combat lists so any subsequent autosave doesn't preserve stale enemies
+            self.player.combat_list = []
+            self.player.combat_list_allies = [self.player]
+
             # Set end-of-combat summary for defeat so frontend can show a game-over dialog
             try:
                 import uuid

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2886,11 +2886,14 @@ class GameService:
                 # phantom combat with no enemies.
                 player.in_combat = False
                 player.combat_list = []
-                # Preserve living allies (e.g. Gorran) — same pattern as _initialize_combat.
+                # Preserve only living allies — dead allies must not be re-injected into
+                # rooms via recall_friends or re-enrolled in the next combat.
                 existing_allies = [
                     a for a in getattr(player, "combat_list_allies", [])
-                    if a is not player
+                    if a is not player and a.is_alive()
                 ]
+                for ally in existing_allies:
+                    ally.in_combat = False
                 player.combat_list_allies = [player] + existing_allies
                 player.current_move = None
                 # Strip non-persistent status effects that should have been cleared at
@@ -3016,9 +3019,10 @@ class GameService:
 
         # Set combat lists on player (required by adapter)
         player.combat_list = enemies
-        # Preserve existing party members (e.g. Gorran already recruited) — only player is reset
+        # Preserve existing living party members — dead allies must not be re-enrolled.
         existing_allies = [
-            a for a in getattr(player, "combat_list_allies", []) if a is not player
+            a for a in getattr(player, "combat_list_allies", [])
+            if a is not player and a.is_alive()
         ]
         player.combat_list_allies = [player] + existing_allies
         player.in_combat = True

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2886,10 +2886,23 @@ class GameService:
                 # phantom combat with no enemies.
                 player.in_combat = False
                 player.combat_list = []
-                player.combat_list_allies = [player]
+                # Preserve living allies (e.g. Gorran) — same pattern as _initialize_combat.
+                existing_allies = [
+                    a for a in getattr(player, "combat_list_allies", [])
+                    if a is not player
+                ]
+                player.combat_list_allies = [player] + existing_allies
                 player.current_move = None
+                # Strip non-persistent status effects that should have been cleared at
+                # combat end (mirrors combat.py line 624 which the API adapter never runs).
+                player.states = [
+                    s for s in getattr(player, "states", [])
+                    if getattr(s, "persistent", True)
+                ]
                 if hasattr(player, "_combat_adapter"):
                     del player._combat_adapter
+                if hasattr(player, "combat_adapter_state"):
+                    del player.combat_adapter_state
                 if hasattr(player, "_combat_deferred_enemies"):
                     del player._combat_deferred_enemies
                 if hasattr(player, "combat_end_summary"):

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2880,6 +2880,21 @@ class GameService:
                     if start_tile:
                         player.current_room = start_tile
 
+                # Reset transient combat state so the player never loads mid-fight.
+                # Saves captured during combat (e.g. autosave every 20 ticks) or after
+                # a defeat whose cleanup was interrupted would otherwise resume into a
+                # phantom combat with no enemies.
+                player.in_combat = False
+                player.combat_list = []
+                player.combat_list_allies = [player]
+                player.current_move = None
+                if hasattr(player, "_combat_adapter"):
+                    del player._combat_adapter
+                if hasattr(player, "_combat_deferred_enemies"):
+                    del player._combat_deferred_enemies
+                if hasattr(player, "combat_end_summary"):
+                    del player.combat_end_summary
+
             return player
         except Exception as e:
             print(f"Error loading save {save_id}: {e}")


### PR DESCRIPTION
## Summary

Fixes a critical bug where players could load into a "phantom combat" state—mid-fight with no enemies present—if a save was captured during combat (e.g., autosave every 20 ticks) or after a defeat whose cleanup was interrupted. The fix resets all transient combat state on load and ensures dead allies are never re-injected into rooms or re-enrolled in subsequent combats.

## Key Changes

- **game_service.py (`load_game`)**: Added comprehensive combat state reset on load:
  - Clear `in_combat` flag and enemy list
  - Preserve only living allies (filter out dead NPCs)
  - Reset `current_move` and strip non-persistent status effects
  - Clean up combat adapter artifacts (`_combat_adapter`, `combat_adapter_state`, `_combat_deferred_enemies`, `combat_end_summary`)

- **game_service.py (`_initialize_combat`)**: Updated ally filtering to exclude dead allies:
  - Changed from `if a is not player` to `if a is not player and a.is_alive()`
  - Prevents dead party members (e.g., fallen Gorran) from being re-enrolled in new fights

- **combat_adapter.py (`_execute_move_inner`)**: Clear enemies after defeat state snapshot:
  - Ensures defeat payload shows the killing blow before wiping the battlefield
  - Preserve only living allies to prevent dead NPCs from haunting subsequent rooms via `recall_friends`

- **combat_adapter.py (`end_combat`)**: Updated ally preservation logic:
  - Changed from `[self.player]` to `[self.player] + existing_allies` to keep living party members
  - Explicitly clear `in_combat` on surviving allies (tile-reset loop only touches non-friend NPCs)
  - Prevents stale adapter from resuming and dead allies from corrupting party roster

## Implementation Details

- All changes maintain the invariant that `combat_list_allies[0]` is always the player
- Dead ally filtering uses `a.is_alive()` check consistently across all three locations
- Comments clarify why each reset is necessary (mirrors combat.py line 624 cleanup that API adapter never runs)
- No breaking changes to public APIs; all modifications are internal state management

https://claude.ai/code/session_01PBMj1qTCUeZ8xdKWJrVnyh