### PR TITLE
Add pause/resume control for Tactical Advisor suggestions

### DIFF
--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -80,6 +80,7 @@ export const combat = {
     return apiClient.post('/combat/move', payload)
   },
   collectLoot: (itemNames) => apiClient.post('/combat/collect-loot', { item_names: itemNames }),
+  pauseSuggestions: (paused) => apiClient.post('/combat/suggestions/pause', { paused }),
 }
 
 // Inventory endpoints

--- a/frontend/src/components/LeftPanel.jsx
+++ b/frontend/src/components/LeftPanel.jsx
@@ -31,7 +31,7 @@ const BETA_MODE = import.meta.env.VITE_BETA_MODE === 'true'
  */
 const KEEP_TAB_MOVES = new Set(['Check'])
 
-function LeftPanel({ player, location, mode, combat, isEventDialogActive = false, isMobile, onMove, onRefetch, onEventsTriggered, onInteractionComplete, onInteractionTypingChange, onInteractionClose, onCombatAction, onLogProgress, onLogProcessingChange, onDisplayedLogCountChange, onTargetHover, onMoveSubmitted }) {
+function LeftPanel({ player, location, mode, combat, isEventDialogActive = false, isMobile, onMove, onRefetch, onEventsTriggered, onInteractionComplete, onInteractionTypingChange, onInteractionClose, onCombatAction, onLogProgress, onLogProcessingChange, onDisplayedLogCountChange, onTargetHover, onMoveSubmitted, onAdvisorPause, onAdvisorRequestSuggestions }) {
   const notifyMoveSubmitted = () => { if (onMoveSubmitted) onMoveSubmitted() }
 
   const [showInventory, setShowInventory] = useState(false)
@@ -747,6 +747,8 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
             }
             isPlayerTurn={isMyTurn}
             onTargetHover={onTargetHover}
+            onPause={onAdvisorPause}
+            onRequestSuggestions={onAdvisorRequestSuggestions}
             onSuggestClick={(s) => {
               if (s.move_name === 'repeat_last') {
                 // Use explicit tracking fields from backend

--- a/frontend/src/components/SuggestedMovesPanel.jsx
+++ b/frontend/src/components/SuggestedMovesPanel.jsx
@@ -1,8 +1,13 @@
 import { useState, useEffect } from 'react'
 import { colors } from '../styles/theme'
 
+const STORAGE_KEY = 'hov_tactical_advisor_collapsed'
+
 export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoading = false, lastOutcome = "", lastMoveViable = false, onSuggestClick, isPlayerTurn = false, onTargetHover, isMobile = false }) {
     const [isVisible, setIsVisible] = useState(false)
+    const [isCollapsed, setIsCollapsed] = useState(() => {
+        try { return localStorage.getItem(STORAGE_KEY) === 'true' } catch { return false }
+    })
     const [hoveredSuggestionName, setHoveredSuggestionName] = useState(null)
     const [hoveredRepeatBtn, setHoveredRepeatBtn] = useState(false)
     const [mobileExpanded, setMobileExpanded] = useState(false)
@@ -16,6 +21,10 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
             setMobileExpanded(false)
         }
     }, [isPlayerTurn])
+
+    useEffect(() => {
+        try { localStorage.setItem(STORAGE_KEY, String(isCollapsed)) } catch {}
+    }, [isCollapsed])
 
     if (!isPlayerTurn) return null
 
@@ -89,16 +98,17 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
         }}>
             {/* Header */}
             <div
-                onClick={isMobile ? () => setMobileExpanded(false) : undefined}
+                onClick={isMobile ? () => setMobileExpanded(false) : () => setIsCollapsed(prev => !prev)}
                 style={{
                     padding: '12px',
                     backgroundColor: `${colors.primary}22`,
-                    borderBottom: `1px solid ${colors.primary}44`,
+                    borderBottom: isCollapsed && !isMobile ? 'none' : `1px solid ${colors.primary}44`,
                     display: 'flex',
                     alignItems: 'center',
                     gap: '8px',
-                    cursor: isMobile ? 'pointer' : 'default',
-                    touchAction: isMobile ? 'manipulation' : undefined,
+                    cursor: 'pointer',
+                    touchAction: 'manipulation',
+                    userSelect: 'none',
                 }}
             >
                 <div style={{
@@ -112,13 +122,13 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
                 <span style={{ color: colors.primary, fontWeight: 'bold', fontSize: '14px', letterSpacing: '1px', flex: 1 }}>
                     TACTICAL ADVISOR
                 </span>
-                {isMobile && (
-                    <span style={{ color: colors.primary, fontSize: '12px', opacity: 0.7 }}>▲</span>
-                )}
+                <span style={{ color: colors.primary, fontSize: '12px', opacity: 0.7 }}>
+                    {isMobile ? '▲' : (isCollapsed ? '▼' : '▲')}
+                </span>
             </div>
 
-            {/* Outcome Section & Repeat Action */}
-            {lastOutcome && (
+            {/* Body — hidden when collapsed on desktop */}
+            {(!isCollapsed || isMobile) && lastOutcome && (
                 <div style={{
                     padding: '10px 12px',
                     fontSize: '11px',
@@ -162,8 +172,8 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
                 </div>
             )}
 
-            {/* Suggestions List */}
-            <div style={{
+            {/* Suggestions List + Footer — hidden when collapsed on desktop */}
+            {(!isCollapsed || isMobile) && <div style={{
                 padding: '12px',
                 overflowY: 'auto',
                 display: 'flex',
@@ -268,9 +278,9 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
                         </div>
                     )})
                 )}
-            </div>
+            </div>}
 
-            <div style={{
+            {(!isCollapsed || isMobile) && <div style={{
                 padding: '10px',
                 textAlign: 'center',
                 fontSize: '9px',
@@ -278,7 +288,7 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
                 borderTop: '1px solid rgba(0, 255, 136, 0.1)'
             }}>
                 NEURAL TACTICAL ENGINE ACTIVE
-            </div>
+            </div>}
         </div>
     )
 }

--- a/frontend/src/components/SuggestedMovesPanel.jsx
+++ b/frontend/src/components/SuggestedMovesPanel.jsx
@@ -3,7 +3,7 @@ import { colors } from '../styles/theme'
 
 const STORAGE_KEY = 'hov_tactical_advisor_collapsed'
 
-export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoading = false, lastOutcome = "", lastMoveViable = false, onSuggestClick, isPlayerTurn = false, onTargetHover, isMobile = false }) {
+export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoading = false, lastOutcome = "", lastMoveViable = false, onSuggestClick, isPlayerTurn = false, onTargetHover, isMobile = false, onPause, onRequestSuggestions }) {
     const [isVisible, setIsVisible] = useState(false)
     const [isCollapsed, setIsCollapsed] = useState(() => {
         try { return localStorage.getItem(STORAGE_KEY) === 'true' } catch { return false }
@@ -14,17 +14,28 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
 
     useEffect(() => {
         if (isPlayerTurn) {
+            // Sync paused state with backend at the start of each player turn
+            onPause?.(isCollapsed)
             const timer = setTimeout(() => setIsVisible(true), 500)
             return () => clearTimeout(timer)
         } else {
             setIsVisible(false)
             setMobileExpanded(false)
         }
-    }, [isPlayerTurn])
+    }, [isPlayerTurn]) // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         try { localStorage.setItem(STORAGE_KEY, String(isCollapsed)) } catch {}
     }, [isCollapsed])
+
+    const handleDesktopToggle = async () => {
+        const newCollapsed = !isCollapsed
+        setIsCollapsed(newCollapsed)
+        try { await onPause?.(newCollapsed) } catch {}
+        if (!newCollapsed && isPlayerTurn) {
+            onRequestSuggestions?.()
+        }
+    }
 
     if (!isPlayerTurn) return null
 
@@ -98,7 +109,7 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
         }}>
             {/* Header */}
             <div
-                onClick={isMobile ? () => setMobileExpanded(false) : () => setIsCollapsed(prev => !prev)}
+                onClick={isMobile ? () => setMobileExpanded(false) : handleDesktopToggle}
                 style={{
                     padding: '12px',
                     backgroundColor: `${colors.primary}22`,

--- a/frontend/src/components/SuggestedMovesPanel.jsx
+++ b/frontend/src/components/SuggestedMovesPanel.jsx
@@ -10,7 +10,6 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
     })
     const [hoveredSuggestionName, setHoveredSuggestionName] = useState(null)
     const [hoveredRepeatBtn, setHoveredRepeatBtn] = useState(false)
-    const [mobileExpanded, setMobileExpanded] = useState(false)
 
     useEffect(() => {
         if (isPlayerTurn) {
@@ -20,7 +19,6 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
             return () => clearTimeout(timer)
         } else {
             setIsVisible(false)
-            setMobileExpanded(false)
         }
     }, [isPlayerTurn]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -28,7 +26,7 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
         try { localStorage.setItem(STORAGE_KEY, String(isCollapsed)) } catch {}
     }, [isCollapsed])
 
-    const handleDesktopToggle = async () => {
+    const handleToggle = async () => {
         const newCollapsed = !isCollapsed
         setIsCollapsed(newCollapsed)
         try { await onPause?.(newCollapsed) } catch {}
@@ -39,11 +37,11 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
 
     if (!isPlayerTurn) return null
 
-    // Mobile collapsed view — just a compact tap-to-expand header
-    if (isMobile && !mobileExpanded) {
+    // Mobile collapsed view — compact tap-to-expand strip
+    if (isMobile && isCollapsed) {
         return (
             <div
-                onClick={() => setMobileExpanded(true)}
+                onClick={handleToggle}
                 style={{
                     width: '100%',
                     backgroundColor: 'rgba(10, 15, 10, 0.9)',
@@ -109,11 +107,11 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
         }}>
             {/* Header */}
             <div
-                onClick={isMobile ? () => setMobileExpanded(false) : handleDesktopToggle}
+                onClick={handleToggle}
                 style={{
                     padding: '12px',
                     backgroundColor: `${colors.primary}22`,
-                    borderBottom: isCollapsed && !isMobile ? 'none' : `1px solid ${colors.primary}44`,
+                    borderBottom: isCollapsed ? 'none' : `1px solid ${colors.primary}44`,
                     display: 'flex',
                     alignItems: 'center',
                     gap: '8px',
@@ -138,8 +136,8 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
                 </span>
             </div>
 
-            {/* Body — hidden when collapsed on desktop */}
-            {(!isCollapsed || isMobile) && lastOutcome && (
+            {/* Body — hidden when collapsed */}
+            {!isCollapsed && lastOutcome && (
                 <div style={{
                     padding: '10px 12px',
                     fontSize: '11px',
@@ -183,8 +181,8 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
                 </div>
             )}
 
-            {/* Suggestions List + Footer — hidden when collapsed on desktop */}
-            {(!isCollapsed || isMobile) && <div style={{
+            {/* Suggestions List + Footer — hidden when collapsed */}
+            {!isCollapsed && <div style={{
                 padding: '12px',
                 overflowY: 'auto',
                 display: 'flex',
@@ -291,7 +289,7 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
                 )}
             </div>}
 
-            {(!isCollapsed || isMobile) && <div style={{
+            {!isCollapsed && <div style={{
                 padding: '10px',
                 textAlign: 'center',
                 fontSize: '9px',

--- a/frontend/src/components/SuggestedMovesPanel.jsx
+++ b/frontend/src/components/SuggestedMovesPanel.jsx
@@ -13,8 +13,9 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
 
     useEffect(() => {
         if (isPlayerTurn) {
-            // Sync paused state with backend at the start of each player turn
-            onPause?.(isCollapsed)
+            // Sync paused state with backend at the start of each player turn.
+            // Can't await in useEffect; chain .catch so the rejection is handled.
+            onPause?.(isCollapsed)?.catch(() => {})
             const timer = setTimeout(() => setIsVisible(true), 500)
             return () => clearTimeout(timer)
         } else {
@@ -29,8 +30,9 @@ export default function SuggestedMovesPanel({ suggestions = [], suggestionsLoadi
     const handleToggle = async () => {
         const newCollapsed = !isCollapsed
         setIsCollapsed(newCollapsed)
-        try { await onPause?.(newCollapsed) } catch {}
-        if (!newCollapsed && isPlayerTurn) {
+        let pauseOk = false
+        try { await onPause?.(newCollapsed); pauseOk = true } catch {}
+        if (pauseOk && !newCollapsed && isPlayerTurn) {
             onRequestSuggestions?.()
         }
     }

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import apiEndpoints from '../api/endpoints'
 import { useAuthContext } from '../context/AuthContext'
 
@@ -123,8 +123,11 @@ export const useCombat = () => {
   const [combat, setCombat] = useState(null)
   const [loading, setLoading] = useState(false)
   const [inCombat, setInCombat] = useState(false)
+  const fetchInFlight = useRef(false)
 
   const fetchCombatStatus = useCallback(async () => {
+    if (fetchInFlight.current) return
+    fetchInFlight.current = true
     try {
       setLoading(true)
       const response = await apiEndpoints.combat.getStatus()
@@ -137,6 +140,7 @@ export const useCombat = () => {
       console.error('Combat status error:', err)
     } finally {
       setLoading(false)
+      fetchInFlight.current = false
     }
   }, [])
 

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { usePlayer, useWorld, useCombat, useExploration, useAutosave } from '../hooks/useApi'
 import { useEventManager } from '../hooks/useEventManager'
 import { useCombatCoordinator } from '../hooks/useCombatCoordinator'
@@ -412,6 +412,14 @@ export default function GamePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location])
 
+  const handleAdvisorPause = useCallback(async (paused) => {
+    try { await combatApi.pauseSuggestions(paused) } catch {}
+  }, [])
+
+  const handleAdvisorRequestSuggestions = useCallback(() => {
+    fetchCombatStatus()
+  }, [fetchCombatStatus])
+
   // Loading state
   if ((playerLoading && !player) || (worldLoading && !location)) {
     return (
@@ -577,6 +585,8 @@ export default function GamePage() {
           onDisplayedLogCountChange={setDisplayedLogCount}
           onTargetHover={setHoveredTargetId}
           onMoveSubmitted={isMobile ? () => setActiveMobileTab('map') : undefined}
+          onAdvisorPause={handleAdvisorPause}
+          onAdvisorRequestSuggestions={handleAdvisorRequestSuggestions}
         />
       </div>
 

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1559,6 +1559,9 @@ class ApiCombatAdapter:
 
         logger = logging.getLogger(__name__)
 
+        if getattr(self.player, "suggestions_paused", False):
+            return
+
         # Set loading state
         self.player.suggestions_loading = True
         self.player.suggested_moves = []  # Clear previous suggestions while loading

--- a/src/api/routes/combat.py
+++ b/src/api/routes/combat.py
@@ -227,6 +227,28 @@ def get_combat_status():
         )
 
 
+@combat_bp.route("/suggestions/pause", methods=["POST"])
+def toggle_suggestions_pause():
+    """Pause or resume Tactical Advisor suggestion generation for this session."""
+    try:
+        session_manager, session, player, error = get_session_and_player(request)
+        if error:
+            return error
+
+        data = request.get_json() or {}
+        paused = bool(data.get("paused", False))
+        player.suggestions_paused = paused
+        if not paused:
+            # Clear stale data so the next status poll triggers a fresh fetch
+            player.suggested_moves = []
+            player.suggestions_loading = False
+        return jsonify({"success": True, "paused": paused}), 200
+
+    except Exception:
+        logger.exception("Unhandled error in toggle_suggestions_pause")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
+
+
 @combat_bp.route("/log", methods=["GET"])
 def get_combat_log():
     """Get full combat log.

--- a/src/player/__init__.py
+++ b/src/player/__init__.py
@@ -339,6 +339,8 @@ maintenant et à l'heure de notre mort. Amen.""",
         """
         state = self.__dict__.copy()
         state.pop("_combat_adapter", None)
+        # Transient API-layer suggestion state — regenerated each session, not part of the save
+        state.pop("suggestions_paused", None)
         return state
 
     def get_hp_pcnt(self):


### PR DESCRIPTION
## Summary
Adds the ability to pause and resume the Tactical Advisor suggestion generation during combat. Players can now collapse the panel to pause suggestions, and the paused state persists across player turns via localStorage. When resumed, fresh suggestions are fetched.

## Key Changes

**Frontend (`SuggestedMovesPanel.jsx`)**
- Replaced `mobileExpanded` state with `isCollapsed` state that persists to localStorage
- Added `handleToggle()` callback that:
  - Updates collapsed state
  - Calls `onPause()` to sync with backend
  - Requests fresh suggestions via `onRequestSuggestions()` when unpausing during player's turn
- Made collapse/expand toggle work on both mobile and desktop (header now always clickable)
- Conditionally render body sections (outcome, suggestions, footer) only when not collapsed
- Updated collapse indicator to show `▼` (collapsed) or `▲` (expanded) on desktop

**Backend (`src/api/routes/combat.py`)**
- Added `POST /combat/suggestions/pause` endpoint to toggle `player.suggestions_paused` flag
- Clears stale suggestion data when resuming to force fresh fetch on next status poll

**Game Logic (`src/api/combat_adapter.py`)**
- Added early return in `refresh_suggestions()` if `suggestions_paused` is True
- Prevents suggestion generation while paused

**Player State (`src/player/__init__.py`)**
- Added `suggestions_paused` to `__getstate__()` exclusion list (transient API-layer state, not persisted to save file)

**API Integration (`frontend/src/api/endpoints.js`)**
- Added `pauseSuggestions(paused)` endpoint wrapper

**Game Page (`frontend/src/pages/GamePage.jsx`)**
- Added `handleAdvisorPause()` and `handleAdvisorRequestSuggestions()` callbacks
- Passed callbacks to `LeftPanel` → `SuggestedMovesPanel`

**Left Panel (`frontend/src/components/LeftPanel.jsx`)**
- Threaded `onAdvisorPause` and `onAdvisorRequestSuggestions` props to `SuggestedMovesPanel`

**Fetch Deduplication (`frontend/src/hooks/useApi.js`)**
- Added `fetchInFlight` ref to `useCombat()` to prevent concurrent combat status requests
- Improves stability when multiple components request suggestions simultaneously

## Implementation Details

- **Persistence**: Collapsed state stored in localStorage under key `hov_tactical_advisor_collapsed`; survives page reloads
- **Sync on Turn Start**: `useEffect` calls `onPause()` at the start of each player turn to ensure backend state matches frontend
- **Fresh Data on Resume**: When unpausing, suggestions list is cleared server-side so next status poll triggers regeneration
- **Mobile/Desktop Parity**: Both platforms now use the same collapse mechanism; mobile no longer has separate `mobileExpanded` logic
- **Error Handling**: Pause/resume calls use `.catch(() => {})` to gracefully handle failures without breaking UI

https://claude.ai/code/session_019JKvxNmj7iXgFPAHB2VG14