### PR TITLE
Add inventory stacking after item acquisition events

### DIFF
--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -1204,6 +1204,9 @@ class GameService:
             if hasattr(tile, "items_here") and item in tile.items_here:
                 tile.items_here.remove(item)
 
+        if items_to_remove and hasattr(player, "stack_inv_items"):
+            player.stack_inv_items()
+
         # Check Objects
         if hasattr(tile, "objects_here"):
             for obj in tile.objects_here:
@@ -3786,6 +3789,8 @@ class GameService:
         for item in final_rewards["items"]:
             if len(inventory) < getattr(player, "max_inventory", 20):
                 inventory.append(item)
+        if final_rewards["items"] and hasattr(player, "stack_inv_items"):
+            player.stack_inv_items()
 
         # Award reputation (simplified - just track)
         if not hasattr(player, "reputation"):
@@ -4954,6 +4959,12 @@ class GameService:
                 skipped.append({"name": name, "reason": "not_found"})
 
         player.combat_drops = []
+
+        if collected and hasattr(player, "stack_inv_items"):
+            player.stack_inv_items()
+        if hasattr(player, "refresh_weight"):
+            player.refresh_weight()
+
         return {"success": True, "collected": collected, "skipped": skipped}
 
     # ── Shop ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Add calls to `player.stack_inv_items()` after item acquisition in three key game service methods to ensure inventory items are properly consolidated after loot collection, quest rewards, and combat drops.

## Changes
- **search()**: Call `stack_inv_items()` after removing items from tiles during search
- **complete_quest()**: Call `stack_inv_items()` after adding quest reward items to inventory
- **collect_combat_loot()**: Call `stack_inv_items()` after collecting combat drops, and also call `refresh_weight()` to update player encumbrance

## Implementation Details
All three changes follow the same pattern:
1. Check if items were actually added/collected (guard condition)
2. Verify the player has the `stack_inv_items()` method before calling (defensive check)
3. Call the method to consolidate stackable items in inventory

The `collect_combat_loot()` method additionally calls `refresh_weight()` to ensure the player's carrying capacity is recalculated after loot collection, maintaining consistency with the game's weight/encumbrance system.

https://claude.ai/code/session_01JdxDNLxeXAiPu6N6ZjPpeo