### PR TITLE
fix(frontend): eliminate post-combat mode flicker and gate victory timer on animations

### DIFF
--- a/frontend/src/components/Battlefield.jsx
+++ b/frontend/src/components/Battlefield.jsx
@@ -23,7 +23,7 @@ function anyEnemyOffScreen(state) {
   return false;
 }
 
-export default function Battlefield({ combat, currentLogIndex, displayedLogCount, hoveredTargetId }) {
+export default function Battlefield({ combat, currentLogIndex, displayedLogCount, hoveredTargetId, onAnimatingChange }) {
   const [selectedTab, setSelectedTab] = useState('overview')
   const [zoom, setZoom] = useState(1)
   // Transient banner shown once per "enemy goes off-screen" transition, auto-
@@ -180,6 +180,7 @@ export default function Battlefield({ combat, currentLogIndex, displayedLogCount
           displayedLogCount={displayedLogCount}
           hoveredTargetId={hoveredTargetId}
           mapSize={combat?.map_size}
+          onAnimatingChange={onAnimatingChange}
         />
 
         {selectedTab === 'overview' && showOffScreenBanner && (

--- a/frontend/src/components/BattlefieldGrid.jsx
+++ b/frontend/src/components/BattlefieldGrid.jsx
@@ -703,9 +703,20 @@ function BattlefieldGrid({
 
   // Notify parent when animation busy-state changes so end-of-combat timing
   // can wait for the death animation to finish before starting the grace timer.
+  // prevAnimatingRef skips the callback when the boolean hasn't changed (e.g.
+  // phase transitions within a single animation — all fire activeAnimation!=null
+  // so the value stays true throughout). This avoids unnecessary GamePage
+  // re-renders on every phase. Cleanup resets to false on unmount so GamePage
+  // never gets stuck with isBattlefieldAnimating=true.
+  const prevAnimatingRef = useRef(false);
   useEffect(() => {
-    if (onAnimatingChange) {
-      onAnimatingChange(activeAnimation !== null || animationQueue.length > 0)
+    const isAnimating = activeAnimation !== null || animationQueue.length > 0;
+    if (onAnimatingChange && isAnimating !== prevAnimatingRef.current) {
+      prevAnimatingRef.current = isAnimating;
+      onAnimatingChange(isAnimating)
+    }
+    return () => {
+      if (onAnimatingChange) onAnimatingChange(false)
     }
   }, [activeAnimation, animationQueue, onAnimatingChange]);
 

--- a/frontend/src/components/BattlefieldGrid.jsx
+++ b/frontend/src/components/BattlefieldGrid.jsx
@@ -685,6 +685,7 @@ function BattlefieldGrid({
   displayedLogCount = 0,
   hoveredTargetId = null,
   mapSize = null,
+  onAnimatingChange = null,
 }) {
   const [activeAnimation, setActiveAnimation] = useState(null);
   const [animationPhase, setAnimationPhase] = useState(null);
@@ -699,6 +700,14 @@ function BattlefieldGrid({
   const [selectedEntity, setSelectedEntity] = useState(null);
 
   const { playSFX } = useAudio();
+
+  // Notify parent when animation busy-state changes so end-of-combat timing
+  // can wait for the death animation to finish before starting the grace timer.
+  useEffect(() => {
+    if (onAnimatingChange) {
+      onAnimatingChange(activeAnimation !== null || animationQueue.length > 0)
+    }
+  }, [activeAnimation, animationQueue, onAnimatingChange]);
 
   // Smooth camera — zoomed mode only. All mutable values live in refs so the
   // RAF loop never needs to be recreated and only drives a React re-render

--- a/frontend/src/components/BattlefieldGrid.test.jsx
+++ b/frontend/src/components/BattlefieldGrid.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import BattlefieldGrid from './BattlefieldGrid';
 
@@ -148,5 +148,103 @@ describe('BattlefieldGrid', () => {
         const jeanInPanel = screen.queryAllByText('Jean');
         // Panel renders name inside a distinct section — after Escape there should be at most the marker label
         expect(jeanInPanel.length).toBeLessThanOrEqual(1);
+    });
+
+    describe('onAnimatingChange callback', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        const combatWithAnimation = {
+            ...mockCombat,
+            log: [
+                {
+                    animation: {
+                        type: 'attack',
+                        source_id: 'player',
+                        target_id: 'enemy_goblin',
+                        outcome: 'hit'
+                    }
+                }
+            ]
+        };
+
+        it('calls onAnimatingChange(true) when an animation is queued', () => {
+            const onAnimatingChange = vi.fn();
+            render(
+                <BattlefieldGrid
+                    combat={combatWithAnimation}
+                    tab="overview"
+                    zoom={1}
+                    onAnimatingChange={onAnimatingChange}
+                    displayedLogCount={1}
+                />
+            );
+            expect(onAnimatingChange).toHaveBeenCalledWith(true);
+        });
+
+        it('does not call onAnimatingChange again during phase transitions', () => {
+            const onAnimatingChange = vi.fn();
+            render(
+                <BattlefieldGrid
+                    combat={combatWithAnimation}
+                    tab="overview"
+                    zoom={1}
+                    onAnimatingChange={onAnimatingChange}
+                    displayedLogCount={1}
+                />
+            );
+
+            // Should be called once with true on animation start
+            expect(onAnimatingChange.mock.calls.filter(c => c[0] === true).length).toBe(1);
+            onAnimatingChange.mockClear();
+
+            // Advance past windup (100ms) into strike — activeAnimation stays non-null,
+            // so the dep-array condition doesn't change and onAnimatingChange must not fire
+            act(() => vi.advanceTimersByTime(150));
+
+            expect(onAnimatingChange.mock.calls.filter(c => c[0] === true).length).toBe(0);
+        });
+
+        it('calls onAnimatingChange(false) after all animation phases complete', () => {
+            const onAnimatingChange = vi.fn();
+            render(
+                <BattlefieldGrid
+                    combat={combatWithAnimation}
+                    tab="overview"
+                    zoom={1}
+                    onAnimatingChange={onAnimatingChange}
+                    displayedLogCount={1}
+                />
+            );
+
+            onAnimatingChange.mockClear();
+
+            // Attack animation: windup(100) + strike(300) + impact(200) + return(200) = 800ms
+            act(() => vi.advanceTimersByTime(900));
+
+            expect(onAnimatingChange).toHaveBeenCalledWith(false);
+        });
+
+        it('calls onAnimatingChange(false) on unmount to prevent stuck animating state', () => {
+            const onAnimatingChange = vi.fn();
+            const { unmount } = render(
+                <BattlefieldGrid
+                    combat={mockCombat}
+                    tab="overview"
+                    zoom={1}
+                    onAnimatingChange={onAnimatingChange}
+                />
+            );
+
+            onAnimatingChange.mockClear();
+            unmount();
+
+            expect(onAnimatingChange).toHaveBeenCalledWith(false);
+        });
     });
 });

--- a/frontend/src/components/NpcChatPanel.test.jsx
+++ b/frontend/src/components/NpcChatPanel.test.jsx
@@ -232,6 +232,9 @@ describe('NpcChatPanel', () => {
       await waitFor(() => {
         expect(npcChat.respond).toHaveBeenCalled()
       })
+
+      // Flush the finally block's setLoading(false) state update
+      await new Promise(resolve => setTimeout(resolve, 0))
     })
 
     it('disables options while NPC is responding', async () => {
@@ -311,6 +314,9 @@ describe('NpcChatPanel', () => {
       await waitFor(() => {
         expect(npcChat.respond).toHaveBeenCalled()
       })
+
+      // Flush the finally block's setLoading(false) state update
+      await new Promise(resolve => setTimeout(resolve, 0))
     })
   })
 

--- a/frontend/src/components/RightPanel.jsx
+++ b/frontend/src/components/RightPanel.jsx
@@ -2,7 +2,7 @@ import Battlefield from './Battlefield'
 import WorldMap from './WorldMap'
 import CollapsibleRoomDescription from './CollapsibleRoomDescription'
 
-export default function RightPanel({ mode, combat, location, onMoveToLocation, exploredTiles, currentLogIndex, displayedLogCount, hoveredTargetId, showDescription, onDescriptionInteract }) {
+export default function RightPanel({ mode, combat, location, onMoveToLocation, exploredTiles, currentLogIndex, displayedLogCount, hoveredTargetId, showDescription, onDescriptionInteract, onAnimatingChange }) {
   return (
     <div className="flex-1 flex flex-col bg-dark-panel border-2 border-orange rounded-lg overflow-hidden retro-glow">
       {/* Header */}
@@ -27,6 +27,7 @@ export default function RightPanel({ mode, combat, location, onMoveToLocation, e
             currentLogIndex={currentLogIndex}
             displayedLogCount={displayedLogCount}
             hoveredTargetId={hoveredTargetId}
+            onAnimatingChange={onAnimatingChange}
           />
         ) : (
           <WorldMap location={location} onMoveToLocation={onMoveToLocation} exploredTiles={exploredTiles} />

--- a/frontend/src/hooks/useCombatCoordinator.js
+++ b/frontend/src/hooks/useCombatCoordinator.js
@@ -25,6 +25,7 @@ export function useCombatCoordinator({
     combat,
     inCombat,
     displayedLogCount,
+    isBattlefieldAnimating,
     performAction,
     fetchCombatStatus,
     playSFX,
@@ -67,7 +68,7 @@ export function useCombatCoordinator({
 
         if (!inCombat && maybeEnd && (maybeEnd.status === 'victory' || maybeEnd.status === 'defeat')) {
             setEndState(maybeEnd)
-            if (!isCombatLogProcessing && !hasPendingLogs && maybeEnd.id && maybeEnd.id !== lastEndStateId) {
+            if (!isCombatLogProcessing && !hasPendingLogs && !isBattlefieldAnimating && maybeEnd.id && maybeEnd.id !== lastEndStateId) {
                 // Mark handled immediately so re-renders don't schedule a second timer
                 setLastEndStateId(maybeEnd.id)
                 sessionStorage.setItem('hov_last_end_state_id', maybeEnd.id)
@@ -87,7 +88,7 @@ export function useCombatCoordinator({
                 }, VICTORY_DIALOG_DELAY_MS)
             }
         }
-    }, [inCombat, combat?.end_state, isCombatLogProcessing, lastEndStateId, displayedLogCount, combat?.log, playSting])
+    }, [inCombat, combat?.end_state, isCombatLogProcessing, isBattlefieldAnimating, lastEndStateId, displayedLogCount, combat?.log, playSting])
 
     // Cancel any pending end-state timer when the hook unmounts
     useEffect(() => {

--- a/frontend/src/hooks/useCombatCoordinator.js
+++ b/frontend/src/hooks/useCombatCoordinator.js
@@ -39,9 +39,10 @@ export function useCombatCoordinator({
     const [lastEndStateId, setLastEndStateId] = useState(
         () => sessionStorage.getItem('hov_last_end_state_id')
     )
-    // True from when the end-state timer is scheduled until the dialog fires.
-    // Lets GamePage keep mode='combat' during the delay without relying on lastEndStateId.
-    const [endStatePending, setEndStatePending] = useState(false)
+    // Ref (not state) so the update is visible synchronously to GamePage's effect
+    // in the same render cycle where the kill is detected. useState would queue
+    // the update for the next render, causing a one-frame flash to exploration mode.
+    const endStatePendingRef = useRef(false)
 
     // Combat log processing state
     const [isCombatLogProcessing, setIsCombatLogProcessing] = useState(false)
@@ -70,12 +71,12 @@ export function useCombatCoordinator({
                 // Mark handled immediately so re-renders don't schedule a second timer
                 setLastEndStateId(maybeEnd.id)
                 sessionStorage.setItem('hov_last_end_state_id', maybeEnd.id)
-                setEndStatePending(true)
+                endStatePendingRef.current = true
 
                 const isVictory = maybeEnd.status === 'victory'
                 endStateTimerRef.current = setTimeout(() => {
                     endStateTimerRef.current = null
-                    setEndStatePending(false)
+                    endStatePendingRef.current = false
                     if (isVictory) {
                         setShowVictoryDialog(true)
                         // Play fanfare as a one-shot sting (non-looping)
@@ -178,7 +179,7 @@ export function useCombatCoordinator({
         showLootDialog,
         endState,
         lastEndStateId,
-        endStatePending,
+        endStatePendingRef,
         isCombatLogProcessing,
         currentLogIndex,
         hoveredTargetId,

--- a/frontend/src/hooks/useCombatCoordinator.js
+++ b/frontend/src/hooks/useCombatCoordinator.js
@@ -68,11 +68,18 @@ export function useCombatCoordinator({
 
         if (!inCombat && maybeEnd && (maybeEnd.status === 'victory' || maybeEnd.status === 'defeat')) {
             setEndState(maybeEnd)
+            // Lock mode='combat' only while this end state hasn't been dispatched
+            // to the countdown timer yet. Once lastEndStateId records the ID the
+            // condition flips false, so post-dialog cleanup (loot collection, etc.)
+            // can exit to exploration. Setting this unconditionally re-locked combat
+            // mode on every re-render after the timer fired.
+            if (maybeEnd.id !== lastEndStateId) {
+                endStatePendingRef.current = true
+            }
             if (!isCombatLogProcessing && !hasPendingLogs && !isBattlefieldAnimating && maybeEnd.id && maybeEnd.id !== lastEndStateId) {
                 // Mark handled immediately so re-renders don't schedule a second timer
                 setLastEndStateId(maybeEnd.id)
                 sessionStorage.setItem('hov_last_end_state_id', maybeEnd.id)
-                endStatePendingRef.current = true
 
                 const isVictory = maybeEnd.status === 'victory'
                 endStateTimerRef.current = setTimeout(() => {

--- a/frontend/src/hooks/useCombatCoordinator.regression-1.test.js
+++ b/frontend/src/hooks/useCombatCoordinator.regression-1.test.js
@@ -1,0 +1,183 @@
+// Regression: animation gate + endStatePendingRef
+// Found by /qa on 2026-05-28
+// Report: .gstack/qa-reports/qa-report-localhost-2026-05-28.md
+//
+// Branch: claude/relaxed-pascal-77upy (worktree Alpha)
+// Changes tested:
+//   - feat: gate end-of-combat timer on battlefield animations finishing
+//   - fix: use ref instead of state for endStatePending to eliminate mode flicker
+
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useCombatCoordinator } from './useCombatCoordinator'
+
+const VICTORY_COMBAT = {
+    end_state: { id: 'victory-anim-1', status: 'victory', message: 'You won!' },
+    log: []
+}
+
+const baseParams = {
+    combat: null,
+    inCombat: false,
+    displayedLogCount: 0,
+    isBattlefieldAnimating: false,
+    performAction: vi.fn(),
+    fetchCombatStatus: vi.fn(),
+    playSFX: vi.fn(),
+    playSting: vi.fn(),
+}
+
+describe('useCombatCoordinator — animation gate + endStatePendingRef regressions', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.clearAllMocks()
+        sessionStorage.clear()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    describe('isBattlefieldAnimating gate', () => {
+        it('does NOT start the end-state timer while animations are running', () => {
+            // Precondition that triggered the bug: combat ends but death animation
+            // still playing on BattlefieldGrid — timer should be blocked.
+            const { result } = renderHook(() =>
+                useCombatCoordinator({
+                    ...baseParams,
+                    combat: VICTORY_COMBAT,
+                    inCombat: false,
+                    isBattlefieldAnimating: true,
+                })
+            )
+
+            act(() => vi.advanceTimersByTime(10000))
+
+            expect(result.current.showVictoryDialog).toBe(false)
+        })
+
+        it('starts the end-state timer once animations finish', () => {
+            const { result, rerender } = renderHook(
+                ({ isBattlefieldAnimating }) =>
+                    useCombatCoordinator({
+                        ...baseParams,
+                        combat: VICTORY_COMBAT,
+                        inCombat: false,
+                        isBattlefieldAnimating,
+                    }),
+                { initialProps: { isBattlefieldAnimating: true } }
+            )
+
+            // While animating — no dialog
+            act(() => vi.advanceTimersByTime(10000))
+            expect(result.current.showVictoryDialog).toBe(false)
+
+            // Animations finish — timer should now start
+            rerender({ isBattlefieldAnimating: false })
+
+            act(() => vi.advanceTimersByTime(10000))
+            expect(result.current.showVictoryDialog).toBe(true)
+        })
+
+        it('does NOT fire the timer for defeat either when animations are running', () => {
+            const defeatCombat = {
+                end_state: { id: 'defeat-anim-1', status: 'defeat', message: 'You died.' },
+                log: []
+            }
+
+            const { result } = renderHook(() =>
+                useCombatCoordinator({
+                    ...baseParams,
+                    combat: defeatCombat,
+                    inCombat: false,
+                    isBattlefieldAnimating: true,
+                })
+            )
+
+            act(() => vi.advanceTimersByTime(10000))
+
+            expect(result.current.showDefeatDialog).toBe(false)
+        })
+
+        it('does NOT re-fire the timer if animations finish AFTER lastEndStateId already matched', () => {
+            // Guard against a race where isBattlefieldAnimating flips false
+            // after another re-render already consumed the end_state id.
+            const { result, rerender } = renderHook(
+                ({ isBattlefieldAnimating }) =>
+                    useCombatCoordinator({
+                        ...baseParams,
+                        combat: VICTORY_COMBAT,
+                        inCombat: false,
+                        isBattlefieldAnimating,
+                    }),
+                { initialProps: { isBattlefieldAnimating: false } }
+            )
+
+            // First render (no animation) — timer fires and dialog shows
+            act(() => vi.advanceTimersByTime(10000))
+            expect(result.current.showVictoryDialog).toBe(true)
+
+            // Close dialog
+            act(() => { result.current.setShowVictoryDialog(false) })
+
+            // Now animations "finish" (isBattlefieldAnimating goes true→false again)
+            // Should NOT re-fire because lastEndStateId already matches
+            rerender({ isBattlefieldAnimating: true })
+            rerender({ isBattlefieldAnimating: false })
+            act(() => vi.advanceTimersByTime(10000))
+
+            expect(result.current.showVictoryDialog).toBe(false)
+        })
+    })
+
+    describe('endStatePendingRef replaces endStatePending state', () => {
+        it('exposes endStatePendingRef as a ref object (not a boolean)', () => {
+            const { result } = renderHook(() =>
+                useCombatCoordinator({ ...baseParams })
+            )
+
+            // Must be a ref object with a .current property, not a plain boolean
+            expect(result.current.endStatePendingRef).toBeDefined()
+            expect(typeof result.current.endStatePendingRef).toBe('object')
+            expect(result.current.endStatePendingRef).toHaveProperty('current')
+        })
+
+        it('endStatePendingRef.current is false initially', () => {
+            const { result } = renderHook(() =>
+                useCombatCoordinator({ ...baseParams })
+            )
+
+            expect(result.current.endStatePendingRef.current).toBe(false)
+        })
+
+        it('endStatePendingRef.current is true while end-state timer is pending', () => {
+            const { result } = renderHook(() =>
+                useCombatCoordinator({
+                    ...baseParams,
+                    combat: VICTORY_COMBAT,
+                    inCombat: false,
+                    isBattlefieldAnimating: false,
+                })
+            )
+
+            // Immediately after render (before timer fires) ref should be true
+            expect(result.current.endStatePendingRef.current).toBe(true)
+        })
+
+        it('endStatePendingRef.current resets to false after timer fires', () => {
+            const { result } = renderHook(() =>
+                useCombatCoordinator({
+                    ...baseParams,
+                    combat: VICTORY_COMBAT,
+                    inCombat: false,
+                    isBattlefieldAnimating: false,
+                })
+            )
+
+            act(() => vi.advanceTimersByTime(10000))
+
+            expect(result.current.endStatePendingRef.current).toBe(false)
+            expect(result.current.showVictoryDialog).toBe(true)
+        })
+    })
+})

--- a/frontend/src/hooks/useCombatCoordinator.test.js
+++ b/frontend/src/hooks/useCombatCoordinator.test.js
@@ -11,6 +11,7 @@ describe('useCombatCoordinator', () => {
         combat: null,
         inCombat: false,
         displayedLogCount: 0,
+        isBattlefieldAnimating: false,
         performAction: vi.fn(),
         fetchCombatStatus: vi.fn(),
         playSFX: vi.fn(),

--- a/frontend/src/hooks/useCombatCoordinator.test.js
+++ b/frontend/src/hooks/useCombatCoordinator.test.js
@@ -54,6 +54,7 @@ describe('useCombatCoordinator', () => {
     describe('victory/defeat dialog handling', () => {
         beforeEach(() => {
             vi.useFakeTimers()
+            sessionStorage.clear()
         })
 
         afterEach(() => {
@@ -151,6 +152,46 @@ describe('useCombatCoordinator', () => {
             )
 
             expect(result.current.showVictoryDialog).toBe(false)
+        })
+
+        it('should call playSting with fanfare on victory', () => {
+            const playSting = vi.fn()
+            const combat = {
+                end_state: {
+                    id: 'victory-fanfare-test',
+                    status: 'victory',
+                    message: 'You won!'
+                },
+                log: []
+            }
+
+            renderHook(() =>
+                useCombatCoordinator({ ...defaultParams, combat, inCombat: false, playSting })
+            )
+
+            act(() => vi.advanceTimersByTime(5000))
+
+            expect(playSting).toHaveBeenCalledWith('fanfare')
+        })
+
+        it('should not call playSting for defeat', () => {
+            const playSting = vi.fn()
+            const combat = {
+                end_state: {
+                    id: 'defeat-fanfare-test',
+                    status: 'defeat',
+                    message: 'You lost!'
+                },
+                log: []
+            }
+
+            renderHook(() =>
+                useCombatCoordinator({ ...defaultParams, combat, inCombat: false, playSting })
+            )
+
+            act(() => vi.advanceTimersByTime(5000))
+
+            expect(playSting).not.toHaveBeenCalled()
         })
 
         it('should not show same end state twice', () => {

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -66,7 +66,7 @@ export default function GamePage() {
     showLootDialog,
     endState,
     lastEndStateId,
-    endStatePending,
+    endStatePendingRef,
     isCombatLogProcessing,
     currentLogIndex,
     hoveredTargetId,
@@ -339,10 +339,10 @@ export default function GamePage() {
         setEndState(maybeEnd)
 
         // Keep mode locked to 'combat' while the dialog is pending (timer running)
-        // or while the dialog is open. endStatePending bridges the gap between when
-        // lastEndStateId is updated (immediately, to prevent duplicate timers) and
-        // when showVictoryDialog/showDefeatDialog becomes true (after the delay).
-        const isDialogActive = showVictoryDialog || showDefeatDialog || endStatePending;
+        // or while the dialog is open. endStatePendingRef.current is a ref so it
+        // reflects the value set by useCombatCoordinator's effect in the same render
+        // cycle — state would be one render stale, causing a flash to exploration.
+        const isDialogActive = showVictoryDialog || showDefeatDialog || endStatePendingRef.current;
 
         if (isDialogActive) {
           setMode('combat')
@@ -358,7 +358,7 @@ export default function GamePage() {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inCombat, combat, eventQueue, currentEvent, endStatePending, showVictoryDialog, showDefeatDialog])
+  }, [inCombat, combat, eventQueue, currentEvent, showVictoryDialog, showDefeatDialog])
 
   /**
    * Manage SFX when modes change

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -43,6 +43,7 @@ export default function GamePage() {
   const [mode, setMode] = useState('exploration') // 'exploration' or 'combat'
   const [isInteractionTyping, setIsInteractionTyping] = useState(false)
   const [displayedLogCount, setDisplayedLogCount] = useState(0)
+  const [isBattlefieldAnimating, setIsBattlefieldAnimating] = useState(false)
 
   // Beta end dialog state
   const [showBetaEndDialog, setShowBetaEndDialog] = useState(false)
@@ -85,6 +86,7 @@ export default function GamePage() {
     combat,
     inCombat,
     displayedLogCount,
+    isBattlefieldAnimating,
     performAction,
     fetchCombatStatus,
     playSFX,
@@ -607,6 +609,7 @@ export default function GamePage() {
           hoveredTargetId={hoveredTargetId}
           showDescription={isMobile}
           onDescriptionInteract={isMobile ? () => setActiveMobileTab('character') : undefined}
+          onAnimatingChange={setIsBattlefieldAnimating}
         />
       </div>
 

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -26,7 +26,7 @@ export default function GamePage() {
   const { location, loading: worldLoading, moveToLocation, refetch: refetchWorld } = useWorld()
   const { exploredTiles, setExploredTiles, refetch: refetchExploration } = useExploration()
   const { combat, inCombat, fetchCombatStatus, performAction } = useCombat()
-  const { playBGM, playSFX } = useAudio()
+  const { playBGM, playSFX, playSting } = useAudio()
   const { triggerTick } = useAutosave(player)
   const { error: showError } = useToast()
 
@@ -90,7 +90,7 @@ export default function GamePage() {
     performAction,
     fetchCombatStatus,
     playSFX,
-    playBGM
+    playSting
   })
 
   // Event management hook

--- a/src/story/ch02.py
+++ b/src/story/ch02.py
@@ -811,11 +811,27 @@ class Ch02KingSlimeMemoryFlash(MemoryFlash):
         )
 
     def check_conditions(self):
+        story = getattr(self.player.universe, "story", {})
+        if story.get("king_slime_flash_fired"):
+            # Already completed; clean up if still lingering in events_here.
+            if self in getattr(self.tile, "events_here", []):
+                self.tile.events_here.remove(self)
+            return
+        if self.needs_input:
+            # Mid-flash — waiting for the player to click Continue.
+            # Don't call process() again or the dialog will re-stack.
+            return
         if any(
             i.__class__.__name__ == "MineralFragment"
             for i in getattr(self.player, "inventory", [])
         ):
             self.pass_conditions_to_process()
+
+    def process(self, user_input=None):
+        super().process(user_input)
+        if user_input is not None:
+            # Completion pass — mark as fired so reloads/re-checks can't replay it.
+            self.player.universe.story["king_slime_flash_fired"] = "1"
 
 
 class AfterKingSlimeReturn(Event):

--- a/tests/test_ch02_memory_flash_guards.py
+++ b/tests/test_ch02_memory_flash_guards.py
@@ -1,0 +1,124 @@
+"""
+Tests for Ch02KingSlimeMemoryFlash guard conditions and story flag behavior.
+
+Covers the fix for the MemoryFlash multi-fire bug (PR #202):
+- check_conditions must bail early when needs_input=True (mid-flash)
+- check_conditions must bail early when king_slime_flash_fired story flag is set
+- process('continue') must persist the king_slime_flash_fired flag
+- process(None) must NOT set the flag (only the completion pass does)
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+# ch02 checks `i.__class__.__name__ == "MineralFragment"` — the class name must match exactly.
+MineralFragment = type('MineralFragment', (), {})
+
+
+class TestCh02KingSlimeMemoryFlashGuards(unittest.TestCase):
+
+    def setUp(self):
+        self.tile = Mock()
+        self.tile.events_here = []
+
+        self.player = Mock()
+        self.player.universe = Mock()
+        self.player.universe.story = {}
+        self.player.inventory = []
+
+    def _make_flash(self):
+        from story.ch02 import Ch02KingSlimeMemoryFlash
+        flash = Ch02KingSlimeMemoryFlash(player=self.player, tile=self.tile)
+        self.tile.events_here.append(flash)
+        return flash
+
+    # ------------------------------------------------------------------
+    # check_conditions guards
+    # ------------------------------------------------------------------
+
+    def test_check_conditions_skips_when_needs_input_true(self):
+        """Mid-flash (needs_input=True) must not re-queue the flash."""
+        flash = self._make_flash()
+        flash.needs_input = True
+        flash.pass_conditions_to_process = Mock()
+
+        flash.check_conditions()
+
+        flash.pass_conditions_to_process.assert_not_called()
+
+    def test_check_conditions_skips_when_story_flag_set(self):
+        """After king_slime_flash_fired is set, check_conditions must not fire."""
+        self.player.universe.story["king_slime_flash_fired"] = "1"
+        flash = self._make_flash()
+        flash.pass_conditions_to_process = Mock()
+
+        flash.check_conditions()
+
+        flash.pass_conditions_to_process.assert_not_called()
+
+    def test_check_conditions_removes_self_when_story_flag_set(self):
+        """When the story flag guard trips, the event removes itself from tile.events_here."""
+        self.player.universe.story["king_slime_flash_fired"] = "1"
+        flash = self._make_flash()
+        self.assertIn(flash, self.tile.events_here)
+
+        flash.check_conditions()
+
+        self.assertNotIn(flash, self.tile.events_here)
+
+    def test_check_conditions_fires_with_mineral_fragment(self):
+        """check_conditions calls pass_conditions_to_process when a MineralFragment is in inventory."""
+        self.player.inventory = [MineralFragment()]
+        flash = self._make_flash()
+        flash.pass_conditions_to_process = Mock()
+
+        flash.check_conditions()
+
+        flash.pass_conditions_to_process.assert_called_once()
+
+    def test_check_conditions_does_not_fire_without_mineral_fragment(self):
+        """check_conditions does not fire when no MineralFragment is in inventory."""
+        class IronSword:
+            pass
+        self.player.inventory = [IronSword()]
+        flash = self._make_flash()
+        flash.pass_conditions_to_process = Mock()
+
+        flash.check_conditions()
+
+        flash.pass_conditions_to_process.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # process() story flag
+    # ------------------------------------------------------------------
+
+    @patch('src.story.effects.memory_border')
+    @patch('src.story.effects.cprint')
+    @patch('src.story.effects.time.sleep')
+    def test_process_completion_sets_story_flag(self, _sleep, _cprint, _border):
+        """process('continue') must set king_slime_flash_fired='1' in player.universe.story."""
+        flash = self._make_flash()
+
+        flash.process("continue")
+
+        self.assertEqual(self.player.universe.story.get("king_slime_flash_fired"), "1")
+
+    @patch('src.story.effects.memory_border')
+    @patch('src.story.effects.cprint')
+    @patch('src.story.effects.time.sleep')
+    def test_process_first_pass_does_not_set_story_flag(self, _sleep, _cprint, _border):
+        """process(None) (first display pass) must NOT set king_slime_flash_fired."""
+        flash = self._make_flash()
+
+        flash.process(None)
+
+        self.assertNotIn("king_slime_flash_fired", self.player.universe.story)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Mode flicker fix**: after killing the last enemy the game briefly dropped to exploration mode, then snapped back to combat ~3–4 seconds later with the victory screen, replaying all SFX and animations. Root cause was `endStatePending` being `useState` — React state updates are async, so `GamePage`'s effect saw `false` in the same render cycle that `useCombatCoordinator` set it to `true`. Switched to `useRef` so the update is synchronous and immediately visible.
- **Animation gate**: the 5-second grace-period timer could start while `BattlefieldGrid` still had animations running (specifically the death burst, synthesized from the kill blow and not tracked by LeftPanel's log-reveal loop). Threaded `isAnimating` state (`activeAnimation || animationQueue.length > 0`) up from `BattlefieldGrid → Battlefield → RightPanel → GamePage → useCombatCoordinator` via an `onAnimatingChange` callback. The timer now waits for all three gates: `!isCombatLogProcessing && !hasPendingLogs && !isBattlefieldAnimating`.
- **King Slime HP**: bumped from 200 → 400 for a more appropriate boss-tier challenge.
- **Story wiring**: `Ch02KingSlimeMemoryFlash` now auto-fires via `check_conditions()` once Jean picks up `MineralFragment` (previously was never triggered). Gorran teleport now has a fallback that finds him in `combat_list_allies` if he's no longer in the atrium tile.
- **Regression tests**: 8 new frontend tests covering the animation gate and `endStatePendingRef` behaviour.

## Test plan

- [ ] Kill the last enemy in combat — battlefield stays visible for the full ~5 seconds; no flash to world map
- [ ] Death burst animation plays fully before the countdown begins
- [ ] Battle SFX / animations do not replay when the victory screen appears
- [ ] Dismiss victory screen — clean transition to exploration
- [ ] Same checks for the defeat path
- [ ] King Slime fight lasts noticeably longer; confirm `AfterDefeatingKingSlime` still fires
- [ ] Picking up `MineralFragment` after the King Slime fight triggers the memory flash
- [ ] Gorran appears in the arena after the fight
- [ ] `python -m pytest -q` — 3306 passed (1 pre-existing flaky in `test_merchandise_system`, unrelated)
- [ ] `cd frontend && npm test -- --run` — 1246 passed (70 test files)

https://claude.ai/code/session_01QPEiWodZ25opBSmCrrvFhL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPEiWodZ25opBSmCrrvFhL)_