### PR TITLE
refactor(moves): unify fatigue scaling with carry weight and strength

### DIFF
--- a/src/moves/__init__.py
+++ b/src/moves/__init__.py
@@ -22,7 +22,7 @@ All public names are re-exported here so existing imports of the form
 continue to work without any changes in calling code.
 """
 
-from ._base import Move, PassiveMove, _ensure_weapon_exp, default_animations
+from ._base import Move, PassiveMove, _ensure_weapon_exp, _apply_carry_fatigue, default_animations
 from ._utility import (
     StrategicInsight,
     MasterTactician,
@@ -93,6 +93,7 @@ __all__ = [
     "Move",
     "PassiveMove",
     "_ensure_weapon_exp",
+    "_apply_carry_fatigue",
     "default_animations",
     # Utility
     "StrategicInsight",

--- a/src/moves/_base.py
+++ b/src/moves/_base.py
@@ -9,6 +9,7 @@ import items  # noqa: F401
 import positions  # noqa: F401
 from animations import animate_to_main_screen as animate  # noqa: F401
 
+
 def _apply_carry_fatigue(user, fatigue_cost):
     """Scale fatigue_cost up proportionally to carry weight burden.
 

--- a/src/moves/_base.py
+++ b/src/moves/_base.py
@@ -420,9 +420,11 @@ class Move:  # master class for all moves
         recoil = max(1, recoil)
 
         # Fatigue cost calculation — endurance gives modest relief (coeff 2);
+        # strength reduces how much weapon weight burdens the fighter;
         # carry weight adds proportional burden on top.
+        wt_mult = max(4, 10 - 0.2 * self.user.strength)
         fatigue_cost = (
-            85 + (self.user.eq_weapon.weight * 10) - (2 * self.user.endurance)
+            85 + int(self.user.eq_weapon.weight * wt_mult) - (2 * self.user.endurance)
         )
         fatigue_cost += int(mod_fatigue)
         fatigue_cost = max(floor_fatigue, int(fatigue_cost))

--- a/src/moves/_base.py
+++ b/src/moves/_base.py
@@ -9,6 +9,23 @@ import items  # noqa: F401
 import positions  # noqa: F401
 from animations import animate_to_main_screen as animate  # noqa: F401
 
+def _apply_carry_fatigue(user, fatigue_cost):
+    """Scale fatigue_cost up proportionally to carry weight burden.
+
+    +0% at 0% carry, +50% at 100% carry, capped at +75% at 150% carry.
+    Returns the original cost unchanged for NPCs (no weight_tolerance).
+    """
+    try:
+        wt = float(getattr(user, "weight_tolerance", 0) or 0)
+        if wt > 0:
+            wc = float(getattr(user, "weight_current", 0) or 0)
+            weight_pct = min(wc / wt, 1.5)
+            fatigue_cost = int(math.ceil(fatigue_cost * (1.0 + 0.5 * weight_pct)))
+    except (TypeError, ValueError):
+        pass
+    return fatigue_cost
+
+
 # Helper to ensure weapon subtype EXP pools exist (referenced in parry/hit/standard_execute_attack)
 
 
@@ -365,6 +382,7 @@ class Move:  # master class for all moves
         mod_fatigue=0,
         mod_range_min=0,
         mod_range_max=0,
+        floor_fatigue=10,
     ):
         """
         Standard evaluation sequence for typical attack-type abilities
@@ -401,12 +419,14 @@ class Move:  # master class for all moves
         recoil += int(mod_recoil)
         recoil = max(1, recoil)
 
-        # Fatigue cost calculation
+        # Fatigue cost calculation — endurance gives modest relief (coeff 2);
+        # carry weight adds proportional burden on top.
         fatigue_cost = (
-            85 + (self.user.eq_weapon.weight * 10) - (5 * self.user.endurance)
+            85 + (self.user.eq_weapon.weight * 10) - (2 * self.user.endurance)
         )
         fatigue_cost += int(mod_fatigue)
-        fatigue_cost = max(10, int(fatigue_cost))
+        fatigue_cost = max(floor_fatigue, int(fatigue_cost))
+        fatigue_cost = _apply_carry_fatigue(self.user, fatigue_cost)
 
         # Range calculation
         mvrange = (

--- a/src/moves/_dagger.py
+++ b/src/moves/_dagger.py
@@ -106,9 +106,10 @@ class Slash(
 
         recoil = int(1 + (self.user.eq_weapon.weight / 2))
 
+        wt_mult = max(4, 10 - 0.2 * self.user.strength)
         fatigue_cost = int(
             math.ceil(
-                85 + (self.user.eq_weapon.weight * 10) - (2 * self.user.endurance)
+                85 + (self.user.eq_weapon.weight * wt_mult) - (2 * self.user.endurance)
             )
         )
         fatigue_cost = max(10, fatigue_cost)

--- a/src/moves/_dagger.py
+++ b/src/moves/_dagger.py
@@ -12,6 +12,7 @@ from ._base import (
     Move,
     PassiveMove,
     _ensure_weapon_exp,
+    _apply_carry_fatigue,
 )  # noqa: F401
 
 
@@ -107,11 +108,11 @@ class Slash(
 
         fatigue_cost = int(
             math.ceil(
-                85 + (self.user.eq_weapon.weight * 10) - (5 * self.user.endurance)
+                85 + (self.user.eq_weapon.weight * 10) - (2 * self.user.endurance)
             )
         )
-        if fatigue_cost <= 10:
-            fatigue_cost = 10
+        fatigue_cost = max(10, fatigue_cost)
+        fatigue_cost = _apply_carry_fatigue(self.user, fatigue_cost)
 
         mvrange = self.user.eq_weapon.wpnrange
 

--- a/src/moves/_ranged.py
+++ b/src/moves/_ranged.py
@@ -12,6 +12,7 @@ from ._base import (
     Move,
     PassiveMove,
     _ensure_weapon_exp,
+    _apply_carry_fatigue,
 )  # noqa: F401
 
 
@@ -35,9 +36,8 @@ class ShootBow(
         execute = 1
         recoil = 1  # bows do not have significant recoil
         cooldown = 3
-        fatigue_cost = 100 - (5 * player.endurance)
-        if fatigue_cost <= 10:
-            fatigue_cost = 10
+        fatigue_cost = max(10, 100 - (2 * player.endurance))
+        fatigue_cost = _apply_carry_fatigue(player, fatigue_cost)
         mvrange = (6, 50)
         super().__init__(
             name="Shoot Bow",
@@ -216,9 +216,8 @@ class ShootBow(
         cooldown = 3 - int(self.user.speed / 20)
         if cooldown < 0:
             cooldown = 0
-        fatigue_cost = int(math.ceil(100 - (5 * self.user.endurance)))
-        if fatigue_cost <= 10:
-            fatigue_cost = 10
+        fatigue_cost = max(10, int(math.ceil(100 - (2 * self.user.endurance))))
+        fatigue_cost = _apply_carry_fatigue(self.user, fatigue_cost)
         # effective_range = self.user.eq_weapon.range_base + (100 / self.user.eq_weapon.range_decay)
         # weapon_name = self.user.eq_weapon.name
         # self.stage_announce[1] = colored("Jean lets his " + weapon_name + " fly!", "green")
@@ -357,7 +356,7 @@ class ShootCrossbow(Move):
         execute = 1
         recoil = 2
         cooldown = 5
-        fatigue_cost = max(10, 100 - (5 * user.endurance))
+        fatigue_cost = _apply_carry_fatigue(user, max(10, 100 - (2 * user.endurance)))
         super().__init__(
             name="Shoot Crossbow",
             description=description,
@@ -405,7 +404,7 @@ class ShootCrossbow(Move):
             + int(self.user.strength * wpn.str_mod)
             + int(self.user.finesse * wpn.fin_mod),
         )
-        self.fatigue_cost = max(10, 100 - (5 * self.user.endurance))
+        self.fatigue_cost = _apply_carry_fatigue(self.user, max(10, 100 - (2 * self.user.endurance)))
         self.mvrange = getattr(wpn, "wpnrange", (6, 40))
 
     def execute(self, player):
@@ -475,7 +474,7 @@ class BroadheadBolt(Move):
         execute = 1
         recoil = 2
         cooldown = 6
-        fatigue_cost = max(10, 110 - (5 * user.endurance))
+        fatigue_cost = _apply_carry_fatigue(user, max(10, 110 - (2 * user.endurance)))
         super().__init__(
             name="Broadhead Bolt",
             description=description,
@@ -523,7 +522,7 @@ class BroadheadBolt(Move):
             + int(self.user.strength * wpn.str_mod)
             + int(self.user.finesse * wpn.fin_mod),
         )
-        self.fatigue_cost = max(15, 110 - (5 * self.user.endurance))
+        self.fatigue_cost = _apply_carry_fatigue(self.user, max(15, 110 - (2 * self.user.endurance)))
         self.mvrange = getattr(wpn, "wpnrange", (6, 40))
 
     def execute(self, player):
@@ -546,7 +545,7 @@ class AimedShot(Move):
         execute = 1
         recoil = 2
         cooldown = 8
-        fatigue_cost = max(10, 90 - (5 * user.endurance))
+        fatigue_cost = _apply_carry_fatigue(user, max(10, 90 - (2 * user.endurance)))
         super().__init__(
             name="Aimed Shot",
             description=description,
@@ -594,7 +593,7 @@ class AimedShot(Move):
             + int(self.user.finesse * wpn.fin_mod)
         )
         self.power = max(1, int(base * 1.5))
-        self.fatigue_cost = max(10, 90 - (5 * self.user.endurance))
+        self.fatigue_cost = _apply_carry_fatigue(self.user, max(10, 90 - (2 * self.user.endurance)))
         self.mvrange = getattr(wpn, "wpnrange", (6, 40))
 
     def execute(self, player):
@@ -666,7 +665,7 @@ class PinningBolt(Move):
         execute = 1
         recoil = 2
         cooldown = 6
-        fatigue_cost = max(10, 100 - (5 * user.endurance))
+        fatigue_cost = _apply_carry_fatigue(user, max(10, 100 - (2 * user.endurance)))
         super().__init__(
             name="Pinning Bolt",
             description=description,
@@ -714,7 +713,7 @@ class PinningBolt(Move):
             + int(self.user.strength * wpn.str_mod)
             + int(self.user.finesse * wpn.fin_mod),
         )
-        self.fatigue_cost = max(10, 100 - (5 * self.user.endurance))
+        self.fatigue_cost = _apply_carry_fatigue(self.user, max(10, 100 - (2 * self.user.endurance)))
         self.mvrange = getattr(wpn, "wpnrange", (6, 40))
 
     def execute(self, player):

--- a/src/moves/_sword.py
+++ b/src/moves/_sword.py
@@ -75,6 +75,8 @@ class PommelStrike(Move):
             self.power,
             self.base_damage_type,
             mod_prep=(-1 * (self.user.eq_weapon.weight * 3)),
+            mod_fatigue=-5,
+            floor_fatigue=12,
         )
         self.power = evaluation[0]
         self.base_damage_type = evaluation[1]
@@ -384,6 +386,8 @@ class Thrust(Move):
             base_power=-5,
             base_damage_type="piercing",
             mod_prep=-10,
+            mod_fatigue=-30,
+            floor_fatigue=8,
         )
         self.power = evaluation[0]
         self.base_damage_type = evaluation[1]
@@ -453,6 +457,8 @@ class DisarmingSlash(Move):
         evaluation = self.standard_evaluate_attack(
             base_power=-8,
             base_damage_type="slashing",
+            mod_fatigue=5,
+            floor_fatigue=15,
         )
         self.power = evaluation[0]
         self.base_damage_type = evaluation[1]
@@ -589,6 +595,8 @@ class Riposte(Move):
         evaluation = self.standard_evaluate_attack(
             base_power=10,
             base_damage_type="slashing",
+            mod_fatigue=-10,
+            floor_fatigue=12,
         )
         self.power = evaluation[0]
         self.base_damage_type = evaluation[1]

--- a/src/moves/_unarmed.py
+++ b/src/moves/_unarmed.py
@@ -11,6 +11,7 @@ from animations import animate_to_main_screen as animate  # noqa: F401
 from ._base import (
     Move,
     PassiveMove,
+    _apply_carry_fatigue,
 )  # noqa: F401
 
 
@@ -91,9 +92,8 @@ class PowerStrike(Move):
         if cooldown < 0:
             cooldown = 0
         cooldown += 3
-        fatigue_cost = 100 - (3 * self.user.endurance)
-        if fatigue_cost <= 25:
-            fatigue_cost = 25
+        fatigue_cost = max(25, 100 - (2 * self.user.endurance))
+        fatigue_cost = _apply_carry_fatigue(self.user, fatigue_cost)
         self.power = power
         self.stage_beat[0] = prep
         self.stage_beat[1] = execute

--- a/src/moves/_utility.py
+++ b/src/moves/_utility.py
@@ -482,9 +482,10 @@ class Attack(Move):  # basic attack function, always uses equipped weapon, playe
 
         recoil = int(1 + (self.user.eq_weapon.weight / 2))
 
+        wt_mult = max(4, 10 - 0.2 * self.user.strength)
         fatigue_cost = int(
             math.ceil(
-                70 + (self.user.eq_weapon.weight * 10) - (2 * self.user.endurance)
+                70 + (self.user.eq_weapon.weight * wt_mult) - (2 * self.user.endurance)
             )
         )
         fatigue_cost = max(10, fatigue_cost)

--- a/src/moves/_utility.py
+++ b/src/moves/_utility.py
@@ -12,6 +12,7 @@ from ._base import (
     Move,
     PassiveMove,
     default_animations,
+    _apply_carry_fatigue,
 )  # noqa: F401
 
 
@@ -395,9 +396,9 @@ class Attack(Move):  # basic attack function, always uses equipped weapon, playe
         if cooldown < 0:
             cooldown = 0
         weapon = "fist"  # modified later, based on player weapon
-        fatigue_cost = int(math.ceil(100 - (5 * player.endurance)))
-        if fatigue_cost <= 10:
-            fatigue_cost = 10
+        fatigue_cost = int(math.ceil(100 - (2 * player.endurance)))
+        fatigue_cost = max(10, fatigue_cost)
+        fatigue_cost = _apply_carry_fatigue(player, fatigue_cost)
         mvrange = (0, 5)
         super().__init__(
             name="Attack",
@@ -483,11 +484,11 @@ class Attack(Move):  # basic attack function, always uses equipped weapon, playe
 
         fatigue_cost = int(
             math.ceil(
-                70 + (self.user.eq_weapon.weight * 10) - (5 * self.user.endurance)
+                70 + (self.user.eq_weapon.weight * 10) - (2 * self.user.endurance)
             )
         )
-        if fatigue_cost <= 10:
-            fatigue_cost = 10
+        fatigue_cost = max(10, fatigue_cost)
+        fatigue_cost = _apply_carry_fatigue(self.user, fatigue_cost)
 
         mvrange = self.user.eq_weapon.wpnrange
 


### PR DESCRIPTION
## Summary

Refactored fatigue cost calculations across all move types to introduce a unified carry-weight fatigue penalty system and adjust endurance/strength scaling. This improves game balance by making heavy armor/equipment more impactful on stamina consumption while allowing strength to mitigate weapon weight burden.

## Key Changes

- **New `_apply_carry_fatigue()` helper** (`_base.py`): Scales fatigue costs proportionally to carry weight burden (+0% at 0% carry, +50% at 100% carry, capped at +75% at 150% carry). Returns cost unchanged for NPCs.

- **Endurance scaling reduced**: Changed from `5 * endurance` to `2 * endurance` across all move types (melee, ranged, unarmed, utility). Endurance now provides more modest fatigue relief.

- **Strength-based weapon weight mitigation** (`standard_evaluate_attack`): Introduced `wt_mult = max(4, 10 - 0.2 * strength)` to scale weapon weight fatigue cost. Higher strength reduces the fatigue penalty from heavy weapons (capped at 4x multiplier minimum).

- **Carry weight fatigue applied universally**: All fatigue cost calculations now call `_apply_carry_fatigue()` after base calculation, affecting:
  - Melee attacks (sword, dagger, unarmed, utility)
  - Ranged attacks (bow, crossbow, bolt variants, aimed shot, pinning bolt)
  - Special moves (power strike, etc.)

- **Per-move fatigue tuning** (`_sword.py`): Added `mod_fatigue` and `floor_fatigue` parameters to `standard_evaluate_attack()` for fine-grained balance adjustments on specific abilities (e.g., Pommel Strike: -5 fatigue, floor 12; Thrust: -30 fatigue, floor 8).

- **Exported `_apply_carry_fatigue`** from `moves/__init__.py` for use across move submodules.

## Implementation Details

- Fatigue calculation now follows: `base_cost + weapon_weight_scaled + endurance_relief + mod_fatigue → max(floor_fatigue, ...) → apply_carry_fatigue()`
- Carry weight penalty is applied *after* flooring to ensure minimum costs are respected
- NPCs (no `weight_tolerance` attribute) bypass carry fatigue scaling silently
- All changes maintain backward compatibility; move signatures unchanged except for new optional `floor_fatigue` parameter

https://claude.ai/code/session_01KCCsq6ZozAwrgy5FwChYgk