### PR TITLE
fix(combat): correct loop variable in _synchronize_distances proximity cleanup

### DIFF
--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -888,7 +888,7 @@ class ApiCombatAdapter:
             for each_enemy in player.combat_list:
                 remove_these = []
                 for each_ally_in_prox in each_enemy.combat_proximity:
-                    if not each_ally.is_alive():
+                    if not each_ally_in_prox.is_alive():
                         remove_these.append(each_ally_in_prox)
                 for each_ally_that_died in remove_these:
                     del each_enemy.combat_proximity[each_ally_that_died]


### PR DESCRIPTION
`_synchronize_distances` was checking `each_ally.is_alive()` (outer loop
variable) when iterating enemy proximity dicts, instead of
`each_ally_in_prox.is_alive()` (inner loop variable). This caused all
proximity entries for all allies to be wiped whenever any one outer ally
was dead, and dead inner entries to never be cleaned up when the outer
ally was alive — corrupting distance tracking for melee/range move
viability.

Fixes #207

https://claude.ai/code/session_017F83DRcinTABTh66bZr1Ae