### PR TITLE
fix(states): beats_max=0 / steps_max=0 now correctly means permanent

### DIFF
--- a/src/states.py
+++ b/src/states.py
@@ -74,7 +74,7 @@ class State:  # master class for all states
     def process(self, target):
         if self.combat and target.in_combat:
             self.effect(target)
-            if self.beats_max >= 0:
+            if self.beats_max > 0:
                 self.beats_left -= 1
                 if self.beats_left <= 0:
                     target.states.remove(self)
@@ -83,7 +83,7 @@ class State:  # master class for all states
                     self.on_removal(target)
         elif self.world and not target.in_combat:
             self.effect(target)
-            if self.steps_max >= 0:
+            if self.steps_max > 0:
                 self.steps_left -= 1
                 if self.steps_left <= 0:
                     target.states.remove(self)

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -421,8 +421,21 @@ def test_state_infinite_duration():
     for _ in range(10):
         state.process(target)
 
-    # Should still be in states (negative max means infinite)
-    # The code checks if beats_max >= 0 before decrementing
+    # Should still be in states (beats_max <= 0 means infinite, never ticks down)
+    assert state in target.states
+
+
+def test_state_zero_beats_max_is_permanent():
+    """beats_max=0 (the default) must persist indefinitely — regression for the >= 0 bug."""
+    target = Mock()
+    target.in_combat = True
+    target.states = []
+    state = State("Permanent", target, beats_max=0, combat=True)
+    target.states.append(state)
+
+    for _ in range(20):
+        state.process(target)
+
     assert state in target.states
 
 


### PR DESCRIPTION
State.process() used `>= 0` as the expiry guard, so zero-duration states
(e.g. PhoenixRevive) would tick down and expire on the first combat beat
instead of persisting indefinitely. Change both guards to `> 0` so that
the documented convention (0 = no expiry) is honoured.

Fixes #205

https://claude.ai/code/session_01EEPG1dPrUv8ReUY6XHPaUA