### PR TITLE
fix(combat): properly clean up combat state on flee

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ src/__pycache__/
 .pytest_cache/
 .coverage
 .coverage.*
+coverage.xml
 htmlcov/
 .venv/
 venv/

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2215,6 +2215,9 @@ class GameService:
             command = {"type": "cancel_selection"}
             return adapter.process_command(command)
 
+        elif move_type == "flee":
+            return self.flee_combat(player)
+
         elif move_type == "select_move_and_target":
             if not isinstance(move_id, str) or not move_id:
                 return {"error": "Invalid move name"}
@@ -3259,26 +3262,41 @@ class GameService:
         if not getattr(player, "in_combat", False):
             return {"error": "Not in combat"}
 
-        # 50% chance to flee (stub)
-        success = True  # In real implementation, would check speed/chance
+        # Clear enemy combat state so they don't immediately re-engage on next interaction
+        for enemy in list(getattr(player, "combat_list", [])):
+            enemy.in_combat = False
+            enemy.aggro = False
 
-        if success:
-            player.in_combat = False
-            return {
-                "success": True,
-                "fled": True,
-                "message": "Fled from combat successfully",
-            }
-        else:
-            enemies = getattr(player, "combat_list", [])
-            return {
-                "success": False,
-                "fled": False,
-                "message": "Failed to flee!",
-                "battle_state": CombatStateSerializer.serialize_combat_state(
-                    player, enemies
-                ),
-            }
+        player.in_combat = False
+        player.combat_list = []
+
+        # Clear ally combat state (keep living allies, just drop their in_combat flag)
+        for ally in getattr(player, "combat_list_allies", [])[1:]:
+            ally.in_combat = False
+        player.combat_list_allies = [player] + [
+            a for a in getattr(player, "combat_list_allies", [])[1:] if a.is_alive()
+        ]
+
+        player.current_move = None
+
+        # Strip non-persistent status effects (mirrors end-of-combat cleanup)
+        player.states = [
+            s for s in getattr(player, "states", [])
+            if getattr(s, "persistent", True)
+        ]
+
+        if hasattr(player, "_combat_adapter"):
+            del player._combat_adapter
+        if hasattr(player, "combat_adapter_state"):
+            del player.combat_adapter_state
+        if hasattr(player, "_combat_deferred_enemies"):
+            del player._combat_deferred_enemies
+
+        return {
+            "success": True,
+            "fled": True,
+            "message": "Fled from combat successfully",
+        }
 
     def _get_turn_order(
         self, player: "player_module.Player", enemies: List[Any]

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -3270,12 +3270,13 @@ class GameService:
         player.in_combat = False
         player.combat_list = []
 
-        # Clear ally combat state (keep living allies, just drop their in_combat flag)
-        for ally in getattr(player, "combat_list_allies", [])[1:]:
-            ally.in_combat = False
-        player.combat_list_allies = [player] + [
+        # Clear ally combat state — filter to living allies first, then clear their flags
+        living_allies = [
             a for a in getattr(player, "combat_list_allies", [])[1:] if a.is_alive()
         ]
+        for ally in living_allies:
+            ally.in_combat = False
+        player.combat_list_allies = [player] + living_allies
 
         player.current_move = None
 
@@ -3291,6 +3292,8 @@ class GameService:
             del player.combat_adapter_state
         if hasattr(player, "_combat_deferred_enemies"):
             del player._combat_deferred_enemies
+        if hasattr(player, "combat_end_summary"):
+            del player.combat_end_summary
 
         return {
             "success": True,

--- a/tests/test_game_service_workflows.py
+++ b/tests/test_game_service_workflows.py
@@ -1397,3 +1397,122 @@ class TestComplexWorkflows:
 
         # Original quest should still be active
         assert len(player_with_universe.active_quests) == 1
+
+
+# =============================================================================
+# FLEE COMBAT — STATE CLEANUP TESTS
+# =============================================================================
+
+
+class TestFleeCombatCleanup:
+    """Verify flee_combat fully tears down combat state (regression guard for #206)."""
+
+    @pytest.fixture
+    def in_combat_player(self, player_with_universe, mock_enemy):
+        """Player with a fully populated combat state."""
+        player_with_universe.in_combat = True
+        player_with_universe.combat_list = [mock_enemy]
+        mock_enemy.in_combat = True
+        mock_enemy.aggro = True
+        return player_with_universe
+
+    def test_flee_sets_in_combat_false(self, game_service, in_combat_player):
+        game_service.flee_combat(in_combat_player)
+        assert in_combat_player.in_combat is False
+
+    def test_flee_empties_combat_list(self, game_service, in_combat_player):
+        game_service.flee_combat(in_combat_player)
+        assert in_combat_player.combat_list == []
+
+    def test_flee_clears_enemy_in_combat_flag(self, game_service, in_combat_player, mock_enemy):
+        game_service.flee_combat(in_combat_player)
+        assert mock_enemy.in_combat is False
+
+    def test_flee_clears_enemy_aggro(self, game_service, in_combat_player, mock_enemy):
+        game_service.flee_combat(in_combat_player)
+        assert mock_enemy.aggro is False
+
+    def test_flee_resets_current_move(self, game_service, in_combat_player):
+        in_combat_player.current_move = MagicMock()
+        game_service.flee_combat(in_combat_player)
+        assert in_combat_player.current_move is None
+
+    def test_flee_removes_combat_adapter(self, game_service, in_combat_player):
+        in_combat_player._combat_adapter = MagicMock()
+        game_service.flee_combat(in_combat_player)
+        assert not hasattr(in_combat_player, "_combat_adapter")
+
+    def test_flee_removes_combat_adapter_state(self, game_service, in_combat_player):
+        in_combat_player.combat_adapter_state = {"events_triggered": []}
+        game_service.flee_combat(in_combat_player)
+        assert not hasattr(in_combat_player, "combat_adapter_state")
+
+    def test_flee_removes_combat_deferred_enemies(self, game_service, in_combat_player):
+        in_combat_player._combat_deferred_enemies = [MagicMock()]
+        game_service.flee_combat(in_combat_player)
+        assert not hasattr(in_combat_player, "_combat_deferred_enemies")
+
+    def test_flee_removes_combat_end_summary(self, game_service, in_combat_player):
+        in_combat_player.combat_end_summary = {"victory": False}
+        game_service.flee_combat(in_combat_player)
+        assert not hasattr(in_combat_player, "combat_end_summary")
+
+    def test_flee_strips_non_persistent_status_effects(self, game_service, in_combat_player):
+        persistent = MagicMock()
+        persistent.persistent = True
+        transient = MagicMock()
+        transient.persistent = False
+        in_combat_player.states = [persistent, transient]
+        game_service.flee_combat(in_combat_player)
+        assert persistent in in_combat_player.states
+        assert transient not in in_combat_player.states
+
+    def test_flee_tolerates_no_combat_adapter(self, game_service, in_combat_player):
+        # _combat_adapter set to None in fixture — hasattr is True; test the absent case
+        del in_combat_player._combat_adapter
+        result = game_service.flee_combat(in_combat_player)
+        assert result.get("fled") is True
+
+    def test_flee_tolerates_empty_combat_list(self, game_service, player_with_universe):
+        player_with_universe.in_combat = True
+        player_with_universe.combat_list = []
+        result = game_service.flee_combat(player_with_universe)
+        assert result.get("fled") is True
+
+    def test_flee_tolerates_no_allies(self, game_service, in_combat_player):
+        in_combat_player.combat_list_allies = []
+        result = game_service.flee_combat(in_combat_player)
+        assert result.get("fled") is True
+        assert in_combat_player.combat_list_allies == [in_combat_player]
+
+    def test_flee_keeps_living_allies_clears_dead(self, game_service, in_combat_player):
+        living = MagicMock()
+        living.is_alive.return_value = True
+        living.in_combat = True
+        dead = MagicMock()
+        dead.is_alive.return_value = False
+        dead.in_combat = True
+        in_combat_player.combat_list_allies = [in_combat_player, living, dead]
+
+        game_service.flee_combat(in_combat_player)
+
+        assert living in in_combat_player.combat_list_allies
+        assert dead not in in_combat_player.combat_list_allies
+        assert living.in_combat is False
+
+    def test_flee_returns_success_payload(self, game_service, in_combat_player):
+        result = game_service.flee_combat(in_combat_player)
+        assert result == {"success": True, "fled": True, "message": "Fled from combat successfully"}
+
+    def test_execute_move_routes_flee_to_flee_combat(self, game_service, in_combat_player):
+        """execute_move with move_type='flee' must call flee_combat, not fall through to error."""
+        adapter = MagicMock()
+        adapter.awaiting_input = True
+        adapter.input_type = "move_selection"
+        in_combat_player._combat_adapter = adapter
+
+        with patch.object(game_service, "flee_combat", wraps=game_service.flee_combat) as spy:
+            result = game_service.execute_move(in_combat_player, "flee", "")
+            spy.assert_called_once_with(in_combat_player)
+
+        assert result.get("fled") is True


### PR DESCRIPTION
flee_combat was a stub that only set player.in_combat=False, leaving
enemies aggro'd and the _combat_adapter attached. On the next
interaction, check_for_combat would immediately re-initiate combat.

The fix clears enemy in_combat/aggro flags, empties combat_list, drops
the _combat_adapter and related transient state, strips non-persistent
status effects, and wires move_type=="flee" into execute_move so the
route can actually reach this method.

Fixes #206