### PR TITLE
feat(frontend): add Flee button above Tactical Advisor panel (issue #212)

### DIFF
--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -75,6 +75,10 @@ export const combat = {
       payload = {
         move_type: 'cancel'
       }
+    } else if (actionType === 'flee') {
+      payload = {
+        move_type: 'flee'
+      }
     }
 
     return apiClient.post('/combat/move', payload)

--- a/frontend/src/components/FleeButton.jsx
+++ b/frontend/src/components/FleeButton.jsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+
+const ORANGE = '#FF8800'
+const BG = '#0a0a0a'
+const MUTED = '#666'
+
+export default function FleeButton({ onFlee, isMobile = false }) {
+  const [confirming, setConfirming] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [hovered, setHovered] = useState(false)
+
+  const fontSize = isMobile ? '11px' : '13px'
+  const padding = isMobile ? '4px 10px' : '6px 16px'
+
+  const handleConfirm = async () => {
+    setIsLoading(true)
+    try {
+      await onFlee()
+    } catch (_err) {
+      // flee failed — reset button state; combat status poll reflects current state
+    } finally {
+      setIsLoading(false)
+      setConfirming(false)
+    }
+  }
+
+  if (confirming) {
+    return (
+      <div
+        data-testid="flee-confirm-prompt"
+        style={{
+          border: `1px solid ${ORANGE}`,
+          background: BG,
+          padding: '8px 12px',
+          fontFamily: 'monospace',
+          fontSize,
+          color: ORANGE,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '6px',
+        }}
+      >
+        <span>Flee combat? This will end the fight.</span>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button
+            data-testid="flee-confirm-yes"
+            onClick={handleConfirm}
+            disabled={isLoading}
+            style={{
+              background: ORANGE,
+              color: BG,
+              border: 'none',
+              padding,
+              fontSize,
+              fontFamily: 'monospace',
+              fontWeight: 'bold',
+              cursor: isLoading ? 'not-allowed' : 'pointer',
+              opacity: isLoading ? 0.7 : 1,
+            }}
+          >
+            {isLoading ? 'Fleeing...' : 'Confirm Flee'}
+          </button>
+          <button
+            data-testid="flee-confirm-cancel"
+            onClick={() => setConfirming(false)}
+            disabled={isLoading}
+            style={{
+              background: 'transparent',
+              color: MUTED,
+              border: `1px solid ${MUTED}`,
+              padding,
+              fontSize,
+              fontFamily: 'monospace',
+              cursor: isLoading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      data-testid="flee-btn"
+      onClick={() => setConfirming(true)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        background: hovered ? `${ORANGE}22` : BG,
+        color: ORANGE,
+        border: `1px solid ${ORANGE}66`,
+        padding,
+        fontSize,
+        fontFamily: 'monospace',
+        fontWeight: 'bold',
+        cursor: 'pointer',
+        width: '100%',
+        textAlign: 'left',
+        boxShadow: hovered ? `0 0 10px ${ORANGE}66` : 'none',
+        transition: 'all 0.15s ease',
+      }}
+    >
+      ⚡ FLEE COMBAT
+    </button>
+  )
+}

--- a/frontend/src/components/FleeButton.test.jsx
+++ b/frontend/src/components/FleeButton.test.jsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import FleeButton from './FleeButton'
+
+describe('FleeButton', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders the flee button in idle state', () => {
+    render(<FleeButton onFlee={vi.fn()} />)
+    expect(screen.getByTestId('flee-btn')).toBeDefined()
+    expect(screen.queryByTestId('flee-confirm-prompt')).toBeNull()
+  })
+
+  it('clicking flee button shows inline confirmation and hides idle button', () => {
+    render(<FleeButton onFlee={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('flee-btn'))
+    expect(screen.getByTestId('flee-confirm-prompt')).toBeDefined()
+    expect(screen.queryByTestId('flee-btn')).toBeNull()
+  })
+
+  it('Cancel dismisses confirmation and restores idle button', () => {
+    render(<FleeButton onFlee={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('flee-btn'))
+    fireEvent.click(screen.getByTestId('flee-confirm-cancel'))
+    expect(screen.queryByTestId('flee-confirm-prompt')).toBeNull()
+    expect(screen.getByTestId('flee-btn')).toBeDefined()
+  })
+
+  it('Confirm Flee calls onFlee once', async () => {
+    const onFlee = vi.fn().mockResolvedValue(undefined)
+    render(<FleeButton onFlee={onFlee} />)
+    fireEvent.click(screen.getByTestId('flee-btn'))
+    fireEvent.click(screen.getByTestId('flee-confirm-yes'))
+    await waitFor(() => expect(onFlee).toHaveBeenCalledTimes(1))
+  })
+
+  it('shows disabled and loading text while onFlee is pending', async () => {
+    let resolve
+    const onFlee = vi.fn(() => new Promise(r => { resolve = r }))
+    render(<FleeButton onFlee={onFlee} />)
+    fireEvent.click(screen.getByTestId('flee-btn'))
+    fireEvent.click(screen.getByTestId('flee-confirm-yes'))
+
+    await waitFor(() => {
+      const confirmBtn = screen.getByTestId('flee-confirm-yes')
+      expect(confirmBtn.disabled).toBe(true)
+      expect(confirmBtn.textContent).toBe('Fleeing...')
+    })
+
+    resolve()
+  })
+
+  it('resets to idle after onFlee resolves', async () => {
+    const onFlee = vi.fn().mockResolvedValue(undefined)
+    render(<FleeButton onFlee={onFlee} />)
+    fireEvent.click(screen.getByTestId('flee-btn'))
+    fireEvent.click(screen.getByTestId('flee-confirm-yes'))
+    await waitFor(() => expect(screen.queryByTestId('flee-confirm-prompt')).toBeNull())
+    expect(screen.getByTestId('flee-btn')).toBeDefined()
+  })
+
+  it('resets to idle even when onFlee rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const onFlee = vi.fn().mockRejectedValue(new Error('network error'))
+    render(<FleeButton onFlee={onFlee} />)
+    fireEvent.click(screen.getByTestId('flee-btn'))
+    fireEvent.click(screen.getByTestId('flee-confirm-yes'))
+    await waitFor(() => expect(screen.queryByTestId('flee-confirm-prompt')).toBeNull())
+    expect(screen.getByTestId('flee-btn')).toBeDefined()
+    consoleError.mockRestore()
+  })
+
+  it('applies mobile font size when isMobile is true', () => {
+    const { container } = render(<FleeButton onFlee={vi.fn()} isMobile={true} />)
+    const btn = container.querySelector('[data-testid="flee-btn"]')
+    expect(btn.style.fontSize).toBe('11px')
+  })
+})

--- a/frontend/src/components/LeftPanel.jsx
+++ b/frontend/src/components/LeftPanel.jsx
@@ -17,6 +17,7 @@ import CombatInputDialog from './CombatInputDialog'
 import { getAnimationDuration } from '../utils/animationConfigs'
 import CombatCheckDialog from './CombatCheckDialog'
 import SuggestedMovesPanel from './SuggestedMovesPanel'
+import FleeButton from './FleeButton'
 import FeedbackDialog from './FeedbackDialog'
 import CooldownTray from './CooldownTray'
 import ShopDialog from './ShopDialog'
@@ -127,6 +128,12 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
 
   // Determine if it's player's turn - ONLY if not processing log and combat hasn't ended
   const isMyTurn = (combat?.awaiting_input || false) && !isBusyProcessing && !combat?.end_state && !isEventDialogActive
+
+  // Flee is viable only when it's the player's turn and all enemies are >= 20 ft away
+  const canFlee = isMyTurn &&
+    Array.isArray(combat?.enemies) &&
+    combat.enemies.length > 0 &&
+    combat.enemies.every(e => (e.distance ?? 0) >= 20)
 
   // Get active player data (merging combat status if in combat)
   const activePlayer = (mode === 'combat' && combat?.player)
@@ -728,6 +735,14 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
                 onCombatAction('cancel', {})
               }
             }}
+          />
+        )}
+
+        {/* Flee button — only when all enemies are >= 20 ft away */}
+        {canFlee && (
+          <FleeButton
+            onFlee={() => onCombatAction('flee', {})}
+            isMobile={isMobile}
           />
         )}
 

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2120,8 +2120,8 @@ class GameService:
         if session_id:
             adapter.session_id = session_id
 
-        # Check if adapter is ready for input (unless cancelling, which should always be allowed)
-        if not adapter.awaiting_input and move_type != "cancel":
+        # Check if adapter is ready for input (unless cancelling/fleeing, which should always be allowed)
+        if not adapter.awaiting_input and move_type not in ("cancel", "flee"):
             return {
                 "error": "Not awaiting input",
                 "details": f"awaiting_input={adapter.awaiting_input}, input_type={adapter.input_type}",
@@ -2252,6 +2252,9 @@ class GameService:
                 "target_id": actual_target_id,
             }
             return adapter.process_command(command)
+
+        elif move_type == "flee":
+            return self.flee_combat(player)
 
         else:
             return {"error": f"Unknown move type: {move_type}"}
@@ -3261,6 +3264,17 @@ class GameService:
         """
         if not getattr(player, "in_combat", False):
             return {"error": "Not in combat"}
+
+        enemies = getattr(player, "combat_list", [])
+        for enemy in enemies:
+            prox = getattr(enemy, "combat_proximity", 0)
+            dist = prox.get(player, 0) if isinstance(prox, dict) else prox
+            if dist < 20:
+                return {
+                    "success": False,
+                    "fled": False,
+                    "error": "Cannot flee — enemies are too close",
+                }
 
         # Clear enemy combat state so they don't immediately re-engage on next interaction
         for enemy in list(getattr(player, "combat_list", [])):

--- a/tests/test_game_service_workflows.py
+++ b/tests/test_game_service_workflows.py
@@ -265,8 +265,9 @@ class TestCombatWorkflows:
     def test_combat_workflow_flee_from_combat(
         self, game_service, player_with_universe, mock_enemy
     ):
-        """Test fleeing from combat transitions to not-in-combat."""
+        """Test fleeing from combat transitions to not-in-combat when enemies are far enough."""
         player_with_universe.in_combat = True
+        mock_enemy.combat_proximity = {player_with_universe: 25}
         player_with_universe.combat_list = [mock_enemy]
 
         result = game_service.flee_combat(player_with_universe)
@@ -274,6 +275,21 @@ class TestCombatWorkflows:
         assert result.get("success") is True
         assert result.get("fled") is True
         assert player_with_universe.in_combat is False
+
+    def test_combat_workflow_flee_blocked_when_enemy_too_close(
+        self, game_service, player_with_universe, mock_enemy
+    ):
+        """Test that fleeing is blocked when any enemy is within 20 ft."""
+        player_with_universe.in_combat = True
+        mock_enemy.combat_proximity = {player_with_universe: 10}
+        player_with_universe.combat_list = [mock_enemy]
+
+        result = game_service.flee_combat(player_with_universe)
+
+        assert result.get("success") is False
+        assert result.get("fled") is False
+        assert "too close" in result.get("error", "")
+        assert player_with_universe.in_combat is True
 
     def test_combat_workflow_cannot_flee_when_not_in_combat(
         self, game_service, player_with_universe

--- a/tests/test_game_service_workflows.py
+++ b/tests/test_game_service_workflows.py
@@ -1425,11 +1425,12 @@ class TestFleeCombatCleanup:
 
     @pytest.fixture
     def in_combat_player(self, player_with_universe, mock_enemy):
-        """Player with a fully populated combat state."""
+        """Player with a fully populated combat state, enemy at flee-viable distance."""
         player_with_universe.in_combat = True
         player_with_universe.combat_list = [mock_enemy]
         mock_enemy.in_combat = True
         mock_enemy.aggro = True
+        mock_enemy.combat_proximity = 25  # >= 20 ft so flee is not blocked by distance check
         return player_with_universe
 
     def test_flee_sets_in_combat_false(self, game_service, in_combat_player):
@@ -1515,6 +1516,16 @@ class TestFleeCombatCleanup:
         assert living in in_combat_player.combat_list_allies
         assert dead not in in_combat_player.combat_list_allies
         assert living.in_combat is False
+
+    def test_flee_blocked_when_enemy_too_close(self, game_service, player_with_universe, mock_enemy):
+        """flee_combat returns an error when any enemy is within 20 ft."""
+        player_with_universe.in_combat = True
+        mock_enemy.combat_proximity = 10  # < 20 ft
+        player_with_universe.combat_list = [mock_enemy]
+        result = game_service.flee_combat(player_with_universe)
+        assert result.get("success") is False
+        assert result.get("fled") is False
+        assert "too close" in result.get("error", "")
 
     def test_flee_returns_success_payload(self, game_service, in_combat_player):
         result = game_service.flee_combat(in_combat_player)


### PR DESCRIPTION
- New FleeButton component with inline confirmation prompt; orange retro
  styling signals urgency; manages confirming/isLoading state internally
- LeftPanel renders FleeButton above SuggestedMovesPanel when canFlee is
  true (isMyTurn + all enemies >= 20 ft via combat.enemies[].distance)
- endpoints.js performAction gains 'flee' case → POST /combat/move
  { move_type: 'flee' }
- game_service.execute_move gains 'flee' dispatch branch; awaiting_input
  guard exempts flee alongside cancel
- flee_combat validates that all enemies are >= 20 ft (mirrors button
  visibility rule) before setting player.in_combat = False
- 8 Vitest unit tests covering idle state, confirmation flow, cancel,
  loading state, resolve/reject reset, mobile sizing
- Updated test_combat_workflow_flee_from_combat to set combat_proximity
  >= 20; added test for the new "too close" rejection path

https://claude.ai/code/session_01Vq2CoKQghrYCpfb5KbbP4j