### PR TITLE
fix(EventDialog): enable internal scroll and remove height constraints

### DIFF
--- a/frontend/src/components/EventDialog.jsx
+++ b/frontend/src/components/EventDialog.jsx
@@ -224,7 +224,7 @@ function EventDialog({ event, history = [], onClose, onSubmitInput }) {
             zIndex={3000}
             maxWidth={dialogMaxWidth}
             width={dialogWidth}
-            allowInternalScroll={false}
+            allowInternalScroll={true}
         >
             <div
                 ref={dialogRef}
@@ -236,8 +236,6 @@ function EventDialog({ event, history = [], onClose, onSubmitInput }) {
                     flexDirection: 'column',
                     gap: spacing.lg,
                     outline: 'none',
-                    height: '100%',
-                    maxHeight: '75vh', // Keep dialog from getting too tall
                 }}
             >
                 {/* Event History Toggle (only if multiple messages) */}


### PR DESCRIPTION
## Summary
Enables internal scrolling in the EventDialog component and removes fixed height constraints to allow the dialog to adapt to its content naturally.

## Changes
- Set `allowInternalScroll={true}` on the Dialog component to permit scrolling of dialog content when needed
- Removed `height: '100%'` constraint from the dialog content container
- Removed `maxHeight: '75vh'` constraint that was artificially limiting dialog height

## Details
These changes allow the EventDialog to better accommodate variable content lengths. Previously, the dialog was constrained to a maximum of 75vh height with no internal scrolling, which could cause content to be cut off or overflow awkwardly. With internal scrolling enabled and height constraints removed, the dialog will now:
- Grow naturally to fit its content up to reasonable viewport limits
- Provide scrollable content when the dialog exceeds available space
- Improve UX for event histories and other variable-length content

https://claude.ai/code/session_014J3VBecCuHDtmuxh1aT4fJ