### PR TITLE
Fix mastery stat comparison to require unique highest stat

### DIFF
--- a/frontend/src/components/NpcChatPanel.test.jsx
+++ b/frontend/src/components/NpcChatPanel.test.jsx
@@ -265,6 +265,11 @@ describe('NpcChatPanel', () => {
       await waitFor(() => {
         expect(npcChat.respond).toHaveBeenCalled()
       })
+
+      // Let the delayed mock response resolve before the test (and its
+      // jsdom environment) tears down, otherwise the finally block's
+      // setLoading(false) fires after teardown and throws.
+      await new Promise((resolve) => setTimeout(resolve, 150))
     })
   })
 

--- a/src/moves/_mastery.py
+++ b/src/moves/_mastery.py
@@ -12,7 +12,9 @@ def _all_stats(p):
 
 
 def _is_highest(p, stat_val):
-    return stat_val == max(_all_stats(p))
+    stats = _all_stats(p)
+    highest = max(stats)
+    return stat_val == highest and stats.count(highest) == 1
 
 
 class Pulverize(Move):

--- a/tests/test_moves_mastery.py
+++ b/tests/test_moves_mastery.py
@@ -123,15 +123,15 @@ class TestMasteryLearnableWhen:
         move = MoveClass(player)
         assert move.learnable_when(player) is False
 
-    def test_true_when_tied_for_highest_above_30(self, MoveClass, stat_name):
+    def test_false_when_tied_for_highest_above_30(self, MoveClass, stat_name):
         player = _make_player()
         setattr(player, stat_name, 35)
         # Tie with another stat at the same value
         other = "strength" if stat_name != "strength" else "finesse"
         setattr(player, other, 35)
         move = MoveClass(player)
-        # Both tied at 35 — the stat still equals max, so learnable
-        assert move.learnable_when(player) is True
+        # Tied at 35 — no single dominant stat, so not learnable
+        assert move.learnable_when(player) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixed the `_is_highest()` function in the mastery move logic to correctly identify when a stat is the unique highest value, rather than just being equal to the maximum.

## Changes
- Modified `_is_highest()` to check that the highest stat value appears exactly once across all stats
- This ensures mastery moves only trigger when a player has a single dominant stat, not when multiple stats are tied for highest

## Implementation Details
The fix adds an additional condition `stats.count(highest) == 1` to verify uniqueness. Previously, the function would return `True` if a stat matched the max value, even if multiple stats were tied at that maximum. This change aligns the behavior with the intended mastery mechanic where a stat must be strictly dominant to unlock mastery abilities.

https://claude.ai/code/session_01FWoGtQaJ7yVZ4Wfi1ndAr7