### PR TITLE
Stack duplicate consumables in party panel item picker

### DIFF
--- a/frontend/src/components/PartyPanel.jsx
+++ b/frontend/src/components/PartyPanel.jsx
@@ -20,6 +20,20 @@ export default function PartyPanel({ player, onClose, onRefetch }) {
     (it) => it.can_use && !it.is_merchandise
   )
 
+  // Stack duplicate item instances (same name) into a single entry with a summed quantity,
+  // mirroring the inventory's stacking convention so the picker doesn't show repeated rows.
+  const stackedConsumables = Object.values(
+    consumables.reduce((stacks, item) => {
+      const existing = stacks[item.name]
+      if (existing) {
+        existing.quantity = (existing.quantity || 1) + (item.quantity || 1)
+      } else {
+        stacks[item.name] = { ...item, quantity: item.quantity || 1 }
+      }
+      return stacks
+    }, {})
+  )
+
   const handleUseItem = async (item, member) => {
     setIsLoading(true)
     try {
@@ -240,7 +254,7 @@ export default function PartyPanel({ player, onClose, onRefetch }) {
               💊 USE ON — {useItemTarget.name}
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', maxHeight: '50vh', overflowY: 'auto' }}>
-              {consumables.map((item) => (
+              {stackedConsumables.map((item) => (
                 <button
                   key={item.id}
                   onClick={() => handleUseItem(item, useItemTarget)}


### PR DESCRIPTION
## Summary
Consolidates duplicate consumable items (same name) into single entries with summed quantities in the party panel's item picker UI, matching the inventory's stacking convention and reducing visual clutter.

## Changes
- Added `stackedConsumables` computed value that groups consumables by name and sums their quantities using a reduce operation
- Updated the item picker render to use `stackedConsumables` instead of the raw `consumables` array
- Preserves all item properties while normalizing quantity to a numeric value (defaulting to 1 if undefined)

## Implementation Details
The stacking logic mirrors the inventory's existing convention by:
- Using an object keyed by item name as an intermediate accumulator
- Summing quantities for duplicate entries: `(existing.quantity || 1) + (item.quantity || 1)`
- Converting back to an array via `Object.values()` for rendering

This prevents the item picker from displaying multiple rows for the same consumable type, improving UX consistency across the application.

https://claude.ai/code/session_01WixMvkqLPLvXWoMoYRiVqH