### PR TITLE
Fix import paths: update narration imports to use src.narration

### DIFF
--- a/src/display_config.py
+++ b/src/display_config.py
@@ -4,7 +4,7 @@ Provides functions to display combat information based on player config settings
 Respects flags like show_combat_distance, show_unit_positions, show_damage_modifiers, etc.
 """
 
-from narration import colored
+from src.narration import colored
 
 
 class CombatDisplayConfig:

--- a/src/events.py
+++ b/src/events.py
@@ -3,7 +3,7 @@ Combat states to be used within combat module. May also spill over to the standa
  States are objects applied to a player/npc that hang around until they expire or are removed.
 """
 
-from narration import colored
+from src.narration import colored
 from functions import print_slow, await_input
 from typing import Optional
 

--- a/src/functions.py
+++ b/src/functions.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:  # only for type hints; avoids runtime circular imports
     from player import Player
     from tiles import MapTile
 
-from narration import colored, cprint, narrate
+from src.narration import colored, cprint, narrate
 from os import listdir
 from os.path import isfile, join
 

--- a/src/genericng.py
+++ b/src/genericng.py
@@ -51,7 +51,7 @@ As a module (to be imported) you get the following function:
 __version__ = "1.0"
 
 import random
-from narration import narrate
+from src.narration import narrate
 
 consonants = [
     ("b", 2),

--- a/src/items.py
+++ b/src/items.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import random
 import math
-from narration import colored, cprint, narrate
+from src.narration import colored, cprint, narrate
 import functions
 from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 

--- a/src/loot_tables.py
+++ b/src/loot_tables.py
@@ -6,7 +6,7 @@ import inspect
 import random
 import items
 import functions
-from narration import narrate
+from src.narration import narrate
 
 
 class Loot:

--- a/src/moves/_base.py
+++ b/src/moves/_base.py
@@ -1,6 +1,6 @@
 """Move base class, PassiveMove base, and shared combat helpers."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_dagger.py
+++ b/src/moves/_dagger.py
@@ -1,6 +1,6 @@
 """Dagger weapon moves: Slash, Backstab, FeintAndPivot and passive ShadowStep."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_mastery.py
+++ b/src/moves/_mastery.py
@@ -1,6 +1,6 @@
 """Mastery moves — one per stat. Unlock when the stat exceeds 30 and is the player's highest."""
 
-from narration import colored, cprint, narrate
+from src.narration import colored, cprint, narrate
 import random
 import states
 import functions

--- a/src/moves/_movement.py
+++ b/src/moves/_movement.py
@@ -1,6 +1,6 @@
 """Positioning and movement moves: Dodge, Parry, Advance, Withdraw, BullCharge, TacticalRetreat, FlankingManeuver, QuietMovement, TacticalPositioning, Turn, QuickSwap."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_npc.py
+++ b/src/moves/_npc.py
@@ -1,6 +1,6 @@
 """NPC moves: NpcAttack, NpcRest, NpcIdle and enemy special abilities."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_pick.py
+++ b/src/moves/_pick.py
@@ -1,6 +1,6 @@
 """Pick weapon moves: ChipAway, ExploitWeakness, Stupefy, WorkTheGap."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_polearm.py
+++ b/src/moves/_polearm.py
@@ -1,6 +1,6 @@
 """Polearm/halberd moves: OverheadSmash, Sweep, BracePosition, HalberdSpin and passive ReachMastery."""
 
-from narration import colored, cprint  # noqa: F401
+from src.narration import colored, cprint  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_ranged.py
+++ b/src/moves/_ranged.py
@@ -1,6 +1,6 @@
 """Ranged weapon moves: ShootBow, ShootCrossbow and crossbow skills; passives EagleEye, MarksmanEye."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_scythe.py
+++ b/src/moves/_scythe.py
@@ -1,6 +1,6 @@
 """Scythe weapon moves: Reap, ReapersMark, DeathsHarvest and passives GrimPersistence, HauntingPresence."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_spear.py
+++ b/src/moves/_spear.py
@@ -1,6 +1,6 @@
 """Spear weapon moves: KeepAway, Lunge, Impale, ArmorPierce and passive SentinelsVigil."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_sword.py
+++ b/src/moves/_sword.py
@@ -1,6 +1,6 @@
 """Sword weapon moves: PommelStrike, Thrust, DisarmingSlash, Riposte, WhirlAttack, VertigoSpin and passives BladeMastery, CounterGuard."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_unarmed.py
+++ b/src/moves/_unarmed.py
@@ -1,6 +1,6 @@
 """Unarmed/fist moves: PowerStrike, Jab and passives IronFist, CleaveInstinct, HeavyHanded."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/moves/_utility.py
+++ b/src/moves/_utility.py
@@ -1,6 +1,6 @@
 """Universal utility moves: Check, Wait, Rest, UseItem, Attack, StrategicInsight, MasterTactician."""
 
-from narration import colored, cprint, narrate  # noqa: F401
+from src.narration import colored, cprint, narrate  # noqa: F401
 import random  # noqa: F401
 import math  # noqa: F401
 import states  # noqa: F401

--- a/src/npc/_adjutant.py
+++ b/src/npc/_adjutant.py
@@ -40,7 +40,7 @@ from ._friends import (  # noqa: F401
 )
 from ._merchants import JamboHealsU, MiloCurioDealer, Merchant  # noqa: F401
 
-from narration import narrate
+from src.narration import narrate
 
 
 # Arena tile coordinates (map-tile coordinates, not combat-grid).

--- a/src/npc/_base.py
+++ b/src/npc/_base.py
@@ -18,7 +18,7 @@ from items import Item  # type: ignore
 
 from ._combat import NPCCombatMixin
 from ._loot import NPCLootMixin, loot
-from narration import narrate
+from src.narration import narrate
 
 
 class NPC(NPCCombatMixin, NPCLootMixin, Combatant):

--- a/src/npc/_eastern_descent.py
+++ b/src/npc/_eastern_descent.py
@@ -13,7 +13,7 @@ import random
 import moves  # type: ignore
 from ._base import Friend
 from ._chat_llm import HumanNPCLLMMixin
-from narration import narrate
+from src.narration import narrate
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Eastern Descent — Nomad Camp NPCs

--- a/src/npc/_friends.py
+++ b/src/npc/_friends.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import functions  # type: ignore
 import genericng  # type: ignore
 import moves  # type: ignore
-from narration import colored, narrate  # type: ignore
+from src.narration import colored, narrate  # type: ignore
 from ._base import Friend
 from ._chat_llm import HumanNPCLLMMixin
 from ._llm import MynxLLMMixin

--- a/src/npc/_llm.py
+++ b/src/npc/_llm.py
@@ -23,7 +23,7 @@ import random
 import re
 import time
 from pathlib import Path
-from narration import narrate
+from src.narration import narrate
 
 
 class MynxLLMMixin:

--- a/src/npc/_loot.py
+++ b/src/npc/_loot.py
@@ -21,7 +21,7 @@ import random
 
 import functions  # type: ignore
 import loot_tables  # type: ignore
-from narration import colored, cprint, narrate  # type: ignore
+from src.narration import colored, cprint, narrate  # type: ignore
 # Single Loot instance shared across the package via import
 loot = loot_tables.Loot()
 

--- a/src/npc/_merchants.py
+++ b/src/npc/_merchants.py
@@ -22,7 +22,7 @@ from items import (  # type: ignore
 
 from ._base import NPC
 from ._shop import MerchantShopMixin
-from narration import narrate
+from src.narration import narrate
 
 
 class Merchant(NPC, MerchantShopMixin):

--- a/src/npc/_shop.py
+++ b/src/npc/_shop.py
@@ -44,7 +44,7 @@ from items import (
     Arrow,
 )
 from objects import Container  # type: ignore
-from narration import narrate
+from src.narration import narrate
 from shop_conditions import (  # type: ignore
     ValueModifierCondition,
     RestockWeightBoostCondition,

--- a/src/objects.py
+++ b/src/objects.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import random
 import time
 import states
-from narration import colored, cprint, narrate
+from src.narration import colored, cprint, narrate
 
 import functions as functions
 from player import Player

--- a/src/player/_combat.py
+++ b/src/player/_combat.py
@@ -4,7 +4,7 @@ import random
 import time
 
 import functions  # type: ignore
-from narration import cprint, narrate
+from src.narration import cprint, narrate
 
 
 class PlayerCombatMixin:

--- a/src/player/_debug.py
+++ b/src/player/_debug.py
@@ -2,7 +2,7 @@
 
 import traceback
 
-from narration import cprint, narrate
+from src.narration import cprint, narrate
 
 
 class PlayerDebugMixin:

--- a/src/player/_exploration.py
+++ b/src/player/_exploration.py
@@ -4,7 +4,7 @@ import random
 import time
 
 import functions  # type: ignore
-from narration import colored, cprint, narrate
+from src.narration import colored, cprint, narrate
 
 
 class PlayerExplorationMixin:

--- a/src/player/_inventory.py
+++ b/src/player/_inventory.py
@@ -7,7 +7,7 @@ import items  # type: ignore
 import functions  # type: ignore
 from functions import stack_inv_items
 from universe import tile_exists as tile_exists
-from narration import cprint, narrate
+from src.narration import cprint, narrate
 
 
 class PlayerInventoryMixin:

--- a/src/player/_leveling.py
+++ b/src/player/_leveling.py
@@ -2,7 +2,7 @@
 
 import random
 
-from narration import cprint
+from src.narration import cprint
 
 
 class PlayerLevelingMixin:

--- a/src/player/_movement.py
+++ b/src/player/_movement.py
@@ -5,7 +5,7 @@ import time
 
 import functions  # type: ignore
 from universe import tile_exists as tile_exists
-from narration import colored, cprint, narrate
+from src.narration import colored, cprint, narrate
 
 
 class PlayerMovementMixin:

--- a/src/player/_ui.py
+++ b/src/player/_ui.py
@@ -3,7 +3,7 @@
 import math
 
 import functions  # type: ignore
-from narration import colored, cprint, narrate
+from src.narration import colored, cprint, narrate
 
 
 def generate_output_grid(

--- a/src/player/_world.py
+++ b/src/player/_world.py
@@ -2,7 +2,7 @@
 
 import time
 
-from narration import cprint
+from src.narration import cprint
 
 
 class PlayerWorldMixin:

--- a/src/states.py
+++ b/src/states.py
@@ -3,7 +3,7 @@ Combat states to be used within combat module. May also spill over to the standa
  States are objects applied to a player/npc that hang around until they expire or are removed.
 """
 
-from narration import cprint
+from src.narration import cprint
 import random
 import functions
 

--- a/src/story/ch01.py
+++ b/src/story/ch01.py
@@ -2,7 +2,7 @@
 Chapter 01 events
 """
 
-from narration import cprint, colored, narrate
+from src.narration import cprint, colored, narrate
 import time
 import random
 

--- a/src/story/ch03.py
+++ b/src/story/ch03.py
@@ -4,7 +4,7 @@ Chapter 03 events
 
 from src.events import Event, dialogue
 from src.functions import print_slow
-from narration import colored, narrate
+from src.narration import colored, narrate
 import time
 
 

--- a/src/story/effects.py
+++ b/src/story/effects.py
@@ -4,7 +4,7 @@ Effects are small, one-time-only events typically fired during combat or in resp
 
 from typing import List, Optional
 
-from narration import cprint, narrate
+from src.narration import cprint, narrate
 import random
 import time
 

--- a/src/story/gorran_flavor.py
+++ b/src/story/gorran_flavor.py
@@ -24,7 +24,7 @@ Stage 4 — shorthand, very sparse, each line earned
 import logging
 import random
 
-from narration import narrate
+from src.narration import narrate
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 0 — Narrated base pools (present at all stages)

--- a/src/tiles.py
+++ b/src/tiles.py
@@ -5,7 +5,7 @@ __author__ = "Alex Egbert"
 import importlib
 import random
 
-from narration import colored
+from src.narration import colored
 
 import actions  # type: ignore
 import functions  # type: ignore

--- a/src/universe.py
+++ b/src/universe.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Final
 from src.scenario_config import ScenarioConfig
 from src.coordinate_config import CoordinateSystemConfig
-from narration import narrate
+from src.narration import narrate
 
 RESOURCES_DIR: Final = Path(__file__).parent / "resources"
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -297,7 +297,7 @@ class TestLootEvent:
         assert event.input_options[2]["value"] == "all"
         assert event.input_options[3]["value"] == "exit"
 
-    @patch('narration.cprint')
+    @patch('src.narration.cprint')
     @patch('inventory_utils.transfer_item')
     def test_loot_event_process_take_all(self, mock_transfer_item, mock_cprint):
         """Test LootEvent process with 'all' input."""
@@ -321,7 +321,7 @@ class TestLootEvent:
         assert event.needs_input is False
         assert result == {"success": True}
 
-    @patch('narration.cprint')
+    @patch('src.narration.cprint')
     @patch('inventory_utils.transfer_item')
     def test_loot_event_process_take_specific_item(self, mock_transfer_item, mock_cprint):
         """Test LootEvent process with specific item index."""
@@ -350,7 +350,7 @@ class TestLootEvent:
 
         event = LootEvent("TestLoot", container=mock_container)
 
-        with patch('narration.cprint') as mock_cprint:
+        with patch('src.narration.cprint') as mock_cprint:
             result = event.process(user_input="999")
 
             mock_cprint.assert_called_once_with("Invalid item choice.", "red")


### PR DESCRIPTION
## Summary
Updates all imports of the `narration` module across the codebase to use the fully-qualified `src.narration` path instead of the bare `narration` module name. This ensures consistent import behavior and resolves potential module resolution issues.

## Changes Made

- **Test files** (`tests/test_events.py`): Updated `@patch` decorators from `'narration.cprint'` to `'src.narration.cprint'` (3 occurrences)
- **Core modules**: Updated imports in:
  - `src/display_config.py`
  - `src/events.py`
  - `src/functions.py`
  - `src/genericng.py`
  - `src/items.py`
  - `src/loot_tables.py`
  - `src/states.py`
  - `src/objects.py`
  - `src/tiles.py`
  - `src/universe.py`
- **Move modules** (`src/moves/`): Updated all 16 move submodules (`_base.py`, `_dagger.py`, `_mastery.py`, `_movement.py`, `_npc.py`, `_pick.py`, `_polearm.py`, `_ranged.py`, `_scythe.py`, `_spear.py`, `_sword.py`, `_unarmed.py`, `_utility.py`)
- **NPC modules** (`src/npc/`): Updated all NPC submodules (`_adjutant.py`, `_base.py`, `_eastern_descent.py`, `_friends.py`, `_llm.py`, `_loot.py`, `_merchants.py`, `_shop.py`)
- **Player modules** (`src/player/`): Updated all player mixin modules (`_combat.py`, `_debug.py`, `_exploration.py`, `_inventory.py`, `_leveling.py`, `_movement.py`, `_ui.py`, `_world.py`)
- **Story modules** (`src/story/`): Updated `ch01.py`, `ch03.py`, `effects.py`, `gorran_flavor.py`

## Implementation Details

All imports follow the pattern:
```python
# Before
from narration import colored, cprint, narrate

# After
from src.narration import colored, cprint, narrate
```

This change ensures that the `narration` module is always imported via its full package path, improving consistency with the project's module structure and preventing potential import resolution issues when the code is run from different working directories or contexts (e.g., API server, tests, CLI).

https://claude.ai/code/session_01AZ4wzn3cs8xCFKocqPwtSd