### PR TITLE
Center-align item usage action message text

### DIFF
--- a/frontend/src/components/ItemDetailDialog.jsx
+++ b/frontend/src/components/ItemDetailDialog.jsx
@@ -46,7 +46,7 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
         setActionMessage(`✓ ${item.name} used on ${ally.name}!`)
         setActionResult({
           message: (
-            <div style={{ whiteSpace: 'pre-wrap', textAlign: 'left', fontSize: '14px', fontFamily: 'monospace' }}>
+            <div style={{ whiteSpace: 'pre-wrap', textAlign: 'center', fontSize: '14px', fontFamily: 'monospace' }}>
               <strong>{player?.name || 'Player'}</strong> used <span style={{ color: '#ffff00' }}>{item.name}</span> on <strong>{ally.name}</strong>.{data.message ? `\n\n${data.message}` : ''}
             </div>
           )


### PR DESCRIPTION
## Summary
Updated the text alignment of item usage action messages in the ItemDetailDialog component from left-aligned to center-aligned for better visual consistency with the UI layout.

## Changes
- Changed `textAlign` style property from `'left'` to `'center'` in the action result message div of ItemDetailDialog
- This affects the display of messages shown when a player uses an item on an ally during combat

## Details
The action message that displays when an item is used (e.g., "Player used Potion on Ally") now renders with center alignment instead of left alignment, improving the visual presentation of the action feedback in the dialog.

https://claude.ai/code/session_01Hf8rKBNo4HkNMvfQF48J8t