### PR TITLE
Close inventory dialog when item used in combat mode

### DIFF
--- a/frontend/src/components/InventoryDialog.jsx
+++ b/frontend/src/components/InventoryDialog.jsx
@@ -8,7 +8,7 @@ import { INVENTORY_TABS, categorizeItems, getRarityColor, getItemIcon } from '..
  * InventoryDialog - Main container for the player's inventory
  * Displays items in categories and allows inspection via ItemDetailDialog
  */
-export default function InventoryDialog({ items, player, onClose, onRefetch, combatMode = false, onItemUsedInCombat }) {
+export default function InventoryDialog({ items, player, onClose, onRefetch, combatMode = false }) {
   const [activeTab, setActiveTab] = useState(combatMode ? 'consumables' : 'weapons')
   const [selectedItem, setSelectedItem] = useState(null)
   const [localInventory, setLocalInventory] = useState(items || player?.inventory || [])
@@ -82,12 +82,12 @@ export default function InventoryDialog({ items, player, onClose, onRefetch, com
             <ItemDetailDialog
               item={selectedItem}
               player={player}
+              onClose={onClose}
               onBack={() => setSelectedItem(null)}
               onRefetch={onRefetch}
               onItemRemoved={() => setSelectedItem(null)}
               onItemUpdated={(id, updates) => setSelectedItem(prev => prev && prev.id === id ? { ...prev, ...updates } : prev)}
               combatMode={combatMode}
-              onItemUsedInCombat={onItemUsedInCombat}
             />
           ) : (
             <>

--- a/frontend/src/components/InventoryDialog.jsx
+++ b/frontend/src/components/InventoryDialog.jsx
@@ -8,7 +8,7 @@ import { INVENTORY_TABS, categorizeItems, getRarityColor, getItemIcon } from '..
  * InventoryDialog - Main container for the player's inventory
  * Displays items in categories and allows inspection via ItemDetailDialog
  */
-export default function InventoryDialog({ items, player, onClose, onRefetch, combatMode = false }) {
+export default function InventoryDialog({ items, player, onClose, onRefetch, combatMode = false, onItemUsedInCombat }) {
   const [activeTab, setActiveTab] = useState(combatMode ? 'consumables' : 'weapons')
   const [selectedItem, setSelectedItem] = useState(null)
   const [localInventory, setLocalInventory] = useState(items || player?.inventory || [])
@@ -87,6 +87,7 @@ export default function InventoryDialog({ items, player, onClose, onRefetch, com
               onItemRemoved={() => setSelectedItem(null)}
               onItemUpdated={(id, updates) => setSelectedItem(prev => prev && prev.id === id ? { ...prev, ...updates } : prev)}
               combatMode={combatMode}
+              onItemUsedInCombat={onItemUsedInCombat}
             />
           ) : (
             <>

--- a/frontend/src/components/ItemDetailDialog.jsx
+++ b/frontend/src/components/ItemDetailDialog.jsx
@@ -3,7 +3,7 @@ import apiClient from '../api/client'
 import { player as playerApi } from '../api/endpoints'
 import BookReaderDialog from './BookReaderDialog'
 
-export default function ItemDetailDialog({ item, player, onClose, onBack, onRefetch, onItemRemoved, onItemUpdated, combatMode = false, onItemUsedInCombat }) {
+export default function ItemDetailDialog({ item, player, onClose, onBack, onRefetch, onItemRemoved, onItemUpdated, combatMode = false }) {
   const [isLoading, setIsLoading] = useState(false)
   const [actionMessage, setActionMessage] = useState('')
   const [showDropConfirm, setShowDropConfirm] = useState(false)
@@ -670,8 +670,8 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
               <button
                 onClick={() => {
                   setActionResult(null)
-                  if (combatMode && onItemUsedInCombat) {
-                    onItemUsedInCombat() // Close entire inventory in combat
+                  if (combatMode && onClose) {
+                    onClose() // Close entire inventory in combat
                   } else {
                     onBack() // Go back to inventory list
                   }

--- a/frontend/src/components/ItemDetailDialog.jsx
+++ b/frontend/src/components/ItemDetailDialog.jsx
@@ -3,7 +3,7 @@ import apiClient from '../api/client'
 import { player as playerApi } from '../api/endpoints'
 import BookReaderDialog from './BookReaderDialog'
 
-export default function ItemDetailDialog({ item, player, onClose, onBack, onRefetch, onItemRemoved, onItemUpdated, combatMode = false }) {
+export default function ItemDetailDialog({ item, player, onClose, onBack, onRefetch, onItemRemoved, onItemUpdated, combatMode = false, onItemUsedInCombat }) {
   const [isLoading, setIsLoading] = useState(false)
   const [actionMessage, setActionMessage] = useState('')
   const [showDropConfirm, setShowDropConfirm] = useState(false)
@@ -670,7 +670,11 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
               <button
                 onClick={() => {
                   setActionResult(null)
-                  onBack() // Go back to inventory list
+                  if (combatMode && onItemUsedInCombat) {
+                    onItemUsedInCombat() // Close entire inventory in combat
+                  } else {
+                    onBack() // Go back to inventory list
+                  }
                 }}
                 style={{
                   padding: '8px 32px',

--- a/frontend/src/components/ItemDetailDialog.test.jsx
+++ b/frontend/src/components/ItemDetailDialog.test.jsx
@@ -443,6 +443,83 @@ describe('ItemDetailDialog', () => {
     });
   });
 
+  it('closes entire inventory dialog when item is used in combat mode', async () => {
+    const consumableItem = {
+      ...mockItem,
+      can_equip: false,
+      can_use: true,
+      maintype: 'Consumable',
+      name: 'Health Potion',
+    };
+
+    const mockOnItemUsedInCombat = vi.fn();
+    apiClient.post.mockResolvedValue({ data: { success: true, message: 'You feel better.' } });
+
+    render(
+      <ItemDetailDialog
+        item={consumableItem}
+        player={mockPlayer}
+        onBack={mockOnBack}
+        onItemRemoved={mockOnItemRemoved}
+        onRefetch={mockOnRefetch}
+        combatMode={true}
+        onItemUsedInCombat={mockOnItemUsedInCombat}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/Use/i));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith('/inventory/use', { item_id: 1 });
+      expect(screen.getByText(/You feel better./i)).toBeDefined();
+    });
+
+    // Click Ok on success dialog
+    fireEvent.click(screen.getByText(/Ok/i));
+
+    // Should call onItemUsedInCombat instead of onBack
+    expect(mockOnItemUsedInCombat).toHaveBeenCalled();
+    expect(mockOnBack).not.toHaveBeenCalled();
+  });
+
+  it('calls onBack (not onItemUsedInCombat) when item is used outside combat', async () => {
+    const consumableItem = {
+      ...mockItem,
+      can_equip: false,
+      can_use: true,
+      maintype: 'Consumable',
+      name: 'Health Potion',
+    };
+
+    const mockOnItemUsedInCombat = vi.fn();
+    apiClient.post.mockResolvedValue({ data: { success: true, message: 'You feel better.' } });
+
+    render(
+      <ItemDetailDialog
+        item={consumableItem}
+        player={mockPlayer}
+        onBack={mockOnBack}
+        onItemRemoved={mockOnItemRemoved}
+        onRefetch={mockOnRefetch}
+        combatMode={false}
+        onItemUsedInCombat={mockOnItemUsedInCombat}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/Use/i));
+
+    await waitFor(() => {
+      expect(screen.getByText(/You feel better./i)).toBeDefined();
+    });
+
+    // Click Ok on success dialog
+    fireEvent.click(screen.getByText(/Ok/i));
+
+    // Should call onBack, not onItemUsedInCombat
+    expect(mockOnBack).toHaveBeenCalled();
+    expect(mockOnItemUsedInCombat).not.toHaveBeenCalled();
+  });
+
   // ---------------------------------------------------------------------------
   // Book reading (handleRead)
   // ---------------------------------------------------------------------------

--- a/frontend/src/components/ItemDetailDialog.test.jsx
+++ b/frontend/src/components/ItemDetailDialog.test.jsx
@@ -452,18 +452,17 @@ describe('ItemDetailDialog', () => {
       name: 'Health Potion',
     };
 
-    const mockOnItemUsedInCombat = vi.fn();
     apiClient.post.mockResolvedValue({ data: { success: true, message: 'You feel better.' } });
 
     render(
       <ItemDetailDialog
         item={consumableItem}
         player={mockPlayer}
+        onClose={mockOnClose}
         onBack={mockOnBack}
         onItemRemoved={mockOnItemRemoved}
         onRefetch={mockOnRefetch}
         combatMode={true}
-        onItemUsedInCombat={mockOnItemUsedInCombat}
       />
     );
 
@@ -477,12 +476,12 @@ describe('ItemDetailDialog', () => {
     // Click Ok on success dialog
     fireEvent.click(screen.getByText(/Ok/i));
 
-    // Should call onItemUsedInCombat instead of onBack
-    expect(mockOnItemUsedInCombat).toHaveBeenCalled();
+    // Should call onClose instead of onBack
+    expect(mockOnClose).toHaveBeenCalled();
     expect(mockOnBack).not.toHaveBeenCalled();
   });
 
-  it('calls onBack (not onItemUsedInCombat) when item is used outside combat', async () => {
+  it('calls onBack (not onClose) when item is used outside combat', async () => {
     const consumableItem = {
       ...mockItem,
       can_equip: false,
@@ -491,18 +490,17 @@ describe('ItemDetailDialog', () => {
       name: 'Health Potion',
     };
 
-    const mockOnItemUsedInCombat = vi.fn();
     apiClient.post.mockResolvedValue({ data: { success: true, message: 'You feel better.' } });
 
     render(
       <ItemDetailDialog
         item={consumableItem}
         player={mockPlayer}
+        onClose={mockOnClose}
         onBack={mockOnBack}
         onItemRemoved={mockOnItemRemoved}
         onRefetch={mockOnRefetch}
         combatMode={false}
-        onItemUsedInCombat={mockOnItemUsedInCombat}
       />
     );
 
@@ -515,9 +513,9 @@ describe('ItemDetailDialog', () => {
     // Click Ok on success dialog
     fireEvent.click(screen.getByText(/Ok/i));
 
-    // Should call onBack, not onItemUsedInCombat
+    // Should call onBack, not onClose
     expect(mockOnBack).toHaveBeenCalled();
-    expect(mockOnItemUsedInCombat).not.toHaveBeenCalled();
+    expect(mockOnClose).not.toHaveBeenCalled();
   });
 
   // ---------------------------------------------------------------------------

--- a/frontend/src/components/LeftPanel.jsx
+++ b/frontend/src/components/LeftPanel.jsx
@@ -823,7 +823,6 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
           onClose={() => setShowInventory(false)}
           onRefetch={onRefetch}
           combatMode={mode === 'combat'}
-          onItemUsedInCombat={() => setShowInventory(false)}
         />
       )}
 

--- a/frontend/src/components/LeftPanel.jsx
+++ b/frontend/src/components/LeftPanel.jsx
@@ -823,6 +823,7 @@ function LeftPanel({ player, location, mode, combat, isEventDialogActive = false
           onClose={() => setShowInventory(false)}
           onRefetch={onRefetch}
           combatMode={mode === 'combat'}
+          onItemUsedInCombat={() => setShowInventory(false)}
         />
       )}
 


### PR DESCRIPTION
## Summary
When a consumable item is used during combat, the entire inventory dialog now closes instead of just returning to the item list. This improves UX by immediately returning the player to the combat interface after using an item.

## Changes
- **ItemDetailDialog.jsx**: Added `onItemUsedInCombat` prop and updated the success dialog OK button handler to call `onItemUsedInCombat()` when in combat mode, otherwise call `onBack()` for normal inventory browsing
- **InventoryDialog.jsx**: Added `onItemUsedInCombat` prop and passed it through to `ItemDetailDialog`
- **LeftPanel.jsx**: Passed `onItemUsedInCombat={() => setShowInventory(false)}` to `InventoryDialog` to close the entire inventory when an item is used in combat
- **ItemDetailDialog.test.jsx**: Added two new test cases:
  - Verifies that `onItemUsedInCombat` is called (not `onBack`) when an item is used in combat mode
  - Verifies that `onBack` is called (not `onItemUsedInCombat`) when an item is used outside combat mode

## Implementation Details
The solution uses a conditional callback pattern: when `combatMode` is true and `onItemUsedInCombat` is provided, the item detail dialog invokes that callback instead of the standard `onBack` callback. This allows the parent component (LeftPanel) to control the behavior—closing the entire inventory in combat while maintaining the normal back-navigation behavior in regular inventory browsing.

https://claude.ai/code/session_01DitcWYT51gdff3XXAcSkZf