### PR TITLE
Fix attribute setting to accept both bare and "_base" suffixed names

### DIFF
--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -2555,6 +2555,13 @@ class GameService:
                         not hasattr(skill, "learnable_when")
                         or skill.learnable_when(player)
                     )
+
+                    # Stat-gated mastery skills stay hidden entirely until their
+                    # linked stat is dominant — don't show them as a disabled
+                    # option the player can never act on.
+                    if not stat_ok and not is_known:
+                        continue
+
                     category_skills.append(
                         {
                             "name": skill.name,

--- a/src/npc/_adjutant.py
+++ b/src/npc/_adjutant.py
@@ -169,15 +169,23 @@ class TheAdjutant(Friend):
         return {"success": True, "level": player.level, "exp": player.exp}
 
     def set_attributes(self, player, attrs):
-        """Set one or more of Jean's base attributes from a {name: value} dict."""
+        """Set one or more of Jean's base attributes from a {name: value} dict.
+
+        Accepts either the bare stat name ("speed") or the "_base" suffixed
+        form ("speed_base") — both are common conventions elsewhere in the
+        API (e.g. level-up allocation), so both must resolve here or callers
+        silently no-op (the value is dropped but the call still reports
+        success).
+        """
         updated = {}
         for attr, value in (attrs or {}).items():
-            if attr not in PLAYER_ATTRS:
+            base_attr = attr[:-5] if attr.endswith("_base") else attr
+            if base_attr not in PLAYER_ATTRS:
                 continue
             v = int(value)
-            setattr(player, attr, v)
-            setattr(player, attr + "_base", v)
-            updated[attr] = v
+            setattr(player, base_attr, v)
+            setattr(player, base_attr + "_base", v)
+            updated[base_attr] = v
         return {"success": True, "updated": updated}
 
     def set_heat(self, player, heat):

--- a/tests/test_adjutant.py
+++ b/tests/test_adjutant.py
@@ -99,6 +99,37 @@ def test_set_attributes_updates_known_and_ignores_unknown():
     assert result["updated"] == {"strength": 15}
 
 
+def test_set_attributes_accepts_base_suffixed_names():
+    """Regression: passing 'speed_base' previously silently no-op'd —
+    set_attributes only matched bare names, so the value was dropped while
+    the call still reported success with an empty 'updated' dict."""
+    adj = TheAdjutant()
+    player = MockPlayer()
+    result = adj.set_attributes(player, {"speed_base": 50})
+    assert player.speed == 50 and player.speed_base == 50
+    assert result["updated"] == {"speed": 50}
+
+
+def test_set_attributes_base_suffix_normalizes_to_bare_key():
+    adj = TheAdjutant()
+    player = MockPlayer()
+    result = adj.set_attributes(
+        player, {"strength_base": 20, "finesse": 25, "bogus_base": 1}
+    )
+    assert player.strength == 20 and player.strength_base == 20
+    assert player.finesse == 25 and player.finesse_base == 25
+    assert result["updated"] == {"strength": 20, "finesse": 25}
+
+
+def test_set_attributes_bare_suffix_only_is_ignored():
+    """An attr that is exactly '_base' (all suffix, no stat name) normalizes
+    to the empty string, which isn't in PLAYER_ATTRS, so it's safely skipped."""
+    adj = TheAdjutant()
+    player = MockPlayer()
+    result = adj.set_attributes(player, {"_base": 99})
+    assert result["updated"] == {}
+
+
 def test_set_heat_clamps():
     adj = TheAdjutant()
     player = MockPlayer()

--- a/tests/test_game_service_extended.py
+++ b/tests/test_game_service_extended.py
@@ -532,6 +532,76 @@ class TestGetPlayerSkills:
         assert "known_moves" in result
         assert "skill_tree" in result
 
+    def test_get_player_skills_hides_unmet_mastery_skill(
+        self, game_service, extended_mock_player
+    ):
+        """A stat-gated mastery skill whose learnable_when() is False and that
+        isn't known yet should be omitted entirely, not listed as disabled."""
+        mastery_skill = MagicMock()
+        mastery_skill.name = "Lightning Assault"
+        mastery_skill.learnable_when.return_value = False
+        extended_mock_player.skilltree.subtypes["Basic"][mastery_skill] = 2500
+        extended_mock_player.skill_exp["Basic"] = 3300
+        extended_mock_player.known_moves = []
+
+        result = game_service.get_player_skills(extended_mock_player)
+        names = [s["name"] for s in result["skill_tree"]["Basic"]]
+        assert "Lightning Assault" not in names
+
+    def test_get_player_skills_shows_mastery_skill_when_dominant(
+        self, game_service, extended_mock_player
+    ):
+        """Once learnable_when() is True, the mastery skill appears and is
+        flagged can_learn given sufficient exp and not already known."""
+        mastery_skill = MagicMock()
+        mastery_skill.name = "Lightning Assault"
+        mastery_skill.learnable_when.return_value = True
+        extended_mock_player.skilltree.subtypes["Basic"][mastery_skill] = 2500
+        extended_mock_player.skill_exp["Basic"] = 3300
+        extended_mock_player.known_moves = []
+
+        result = game_service.get_player_skills(extended_mock_player)
+        entries = [s for s in result["skill_tree"]["Basic"] if s["name"] == "Lightning Assault"]
+        assert len(entries) == 1
+        assert entries[0]["can_learn"] is True
+        assert entries[0]["is_known"] is False
+
+    def test_get_player_skills_keeps_known_mastery_skill_even_if_unmet(
+        self, game_service, extended_mock_player
+    ):
+        """A mastery skill the player already knows must stay listed (as
+        known) even if the dominant-stat condition no longer holds — only
+        not-yet-learned skills are hidden by the gate."""
+        mastery_skill = MagicMock()
+        mastery_skill.name = "Lightning Assault"
+        mastery_skill.learnable_when.return_value = False
+        extended_mock_player.skilltree.subtypes["Basic"][mastery_skill] = 2500
+
+        known_move = MagicMock()
+        known_move.name = "Lightning Assault"
+        extended_mock_player.known_moves = [known_move]
+
+        result = game_service.get_player_skills(extended_mock_player)
+        entries = [s for s in result["skill_tree"]["Basic"] if s["name"] == "Lightning Assault"]
+        assert len(entries) == 1
+        assert entries[0]["is_known"] is True
+        assert entries[0]["can_learn"] is False
+
+    def test_get_player_skills_non_gated_skill_unaffected(
+        self, game_service, extended_mock_player
+    ):
+        """A skill without learnable_when (or one that always returns True)
+        is never hidden by the new gate, regardless of exp."""
+        plain_skill = MagicMock(spec=["name"])
+        plain_skill.name = "Dodge"
+        extended_mock_player.skilltree.subtypes["Basic"][plain_skill] = 100
+        extended_mock_player.skill_exp["Basic"] = 0
+        extended_mock_player.known_moves = []
+
+        result = game_service.get_player_skills(extended_mock_player)
+        names = [s["name"] for s in result["skill_tree"]["Basic"]]
+        assert "Dodge" in names
+
 
 # ============================================================================
 # AWARD SYSTEM TESTS


### PR DESCRIPTION
## Summary
Fixed the `set_attributes` method in the adjutant NPC to accept both bare stat names (e.g., "speed") and "_base" suffixed forms (e.g., "speed_base"), normalizing them to a single internal representation. Also improved skill visibility logic to hide stat-gated mastery skills entirely when their stat requirement is not met, rather than showing them as disabled options.

## Changes

- **`src/npc/_adjutant.py`**: Updated `set_attributes()` to normalize incoming attribute names by stripping the "_base" suffix if present, then validate against `PLAYER_ATTRS` using the normalized name. This allows callers using either convention (common elsewhere in the API) to work correctly without silently dropping values.

- **`src/api/services/game_service.py`**: Enhanced `get_player_skills()` to skip stat-gated mastery skills entirely when their stat requirement is not met and the skill is not yet known. Previously these would appear as disabled options the player could never act on; now they remain hidden until the stat becomes dominant.

## Implementation Details

- The attribute normalization uses a simple check: `base_attr = attr[:-5] if attr.endswith("_base") else attr`
- Both the bare attribute and its "_base" variant are still set on the player object (preserving existing behavior)
- The updated dict returned to the caller uses the normalized name for consistency
- Skill filtering is applied early in the loop to avoid unnecessary processing of hidden skills

https://claude.ai/code/session_01JPN24igZhPJUhVq2WDewwf