### PR TITLE
feat(api): expose weapon/armor stats, bonuses, and equip comparison in inventory serializer

### DIFF
--- a/frontend/src/components/ItemDetailDialog.jsx
+++ b/frontend/src/components/ItemDetailDialog.jsx
@@ -3,6 +3,49 @@ import apiClient from '../api/client'
 import { player as playerApi } from '../api/endpoints'
 import BookReaderDialog from './BookReaderDialog'
 
+// Display labels for the scalar stat-bonus keys the backend emits (see
+// inventory.py's _BONUS_ATTRS) — keep in sync if new bonus stats are added.
+const BONUS_STAT_LABELS = {
+  strength: 'STR',
+  finesse: 'FIN',
+  maxhp: 'Max HP',
+  maxfatigue: 'Max Fatigue',
+  speed: 'SPD',
+  endurance: 'END',
+  charisma: 'CHA',
+  intelligence: 'INT',
+  faith: 'FTH',
+  weight_tolerance: 'Weight Tolerance',
+}
+
+// Equip-comparison recommendation styling (see inventory.py's ItemComparisonSerializer)
+const REC_COLORS = { upgrade: '#00ff88', downgrade: '#ff6666', sidegrade: '#ffcc00' }
+const REC_LABELS = { upgrade: '↑ UPGRADE', downgrade: '↓ DOWNGRADE', sidegrade: '↔ SIDEGRADE' }
+
+const capitalize = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s)
+const formatSigned = (value) => `${value >= 0 ? '+' : ''}${value}`
+const formatSignedPercent = (value) => `${value >= 0 ? '+' : ''}${Math.round(value * 100)}%`
+
+// Describes a single consumable effect descriptor (see inventory.py's
+// _CONSUMABLE_EFFECTS) without per-target context, for the main item panel.
+function describeEffect(effect) {
+  switch (effect.type) {
+    case 'heal': {
+      const statLabel = effect.stat === 'hp' ? 'HP' : 'Fatigue'
+      const [min, max] = effect.range || [effect.power, effect.power]
+      return min === max ? `Restores ${min} ${statLabel}` : `Restores ${min}-${max} ${statLabel}`
+    }
+    case 'status_remove':
+      return `Cures ${effect.status_name}`
+    case 'status_apply':
+      return `Inflicts ${effect.status_name} for ${effect.duration} beats`
+    case 'attr_buff':
+      return `${formatSigned(effect.amount)} ${effect.label || effect.stat?.toUpperCase()} for ${effect.duration} beats`
+    default:
+      return null
+  }
+}
+
 export default function ItemDetailDialog({ item, player, onClose, onBack, onRefetch, onItemRemoved, onItemUpdated, combatMode = false }) {
   const [isLoading, setIsLoading] = useState(false)
   const [actionMessage, setActionMessage] = useState('')
@@ -320,6 +363,38 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
             </div>
           )}
 
+          {/* Damage Property (weapons) */}
+          {typeof item.damage === 'number' && (
+            <div style={{
+              backgroundColor: 'rgba(30, 15, 0, 0.6)',
+              padding: '6px',
+              textAlign: 'center',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+            }}>
+              <div style={{ color: '#ffaa00', fontWeight: 'bold', fontSize: '13px', marginBottom: '3px' }}>Damage</div>
+              <div style={{ color: '#ff8866', fontSize: '14px' }}>
+                ⚔️ {item.damage}{item.damage_type ? ` (${capitalize(item.damage_type)})` : ''}
+              </div>
+            </div>
+          )}
+
+          {/* Protection Property (armor) */}
+          {typeof item.protection === 'number' && (
+            <div style={{
+              backgroundColor: 'rgba(30, 15, 0, 0.6)',
+              padding: '6px',
+              textAlign: 'center',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+            }}>
+              <div style={{ color: '#ffaa00', fontWeight: 'bold', fontSize: '13px', marginBottom: '3px' }}>Protection</div>
+              <div style={{ color: '#88ccff', fontSize: '14px' }}>🛡️ {item.protection}</div>
+            </div>
+          )}
+
           {/* Weight Property */}
           <div style={{
             backgroundColor: 'rgba(30, 15, 0, 0.6)',
@@ -377,6 +452,113 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
           )}
 
         </div>
+
+        {/* Comparison vs. currently equipped item in the same slot */}
+        {item.comparison && (
+          <div style={{
+            backgroundColor: 'rgba(30, 15, 0, 0.6)',
+            border: `1px solid ${REC_COLORS[item.comparison.recommendation] || '#664400'}`,
+            borderRadius: '4px',
+            padding: '8px 10px',
+          }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '6px' }}>
+              <span style={{ color: '#ffaa00', fontWeight: 'bold', fontSize: '13px', textTransform: 'uppercase' }}>
+                vs. Equipped{item.comparison.current ? `: ${item.comparison.current.name}` : ''}
+              </span>
+              <span style={{ color: REC_COLORS[item.comparison.recommendation] || '#ffee99', fontWeight: 'bold', fontSize: '12px' }}>
+                {REC_LABELS[item.comparison.recommendation] || item.comparison.recommendation}
+              </span>
+            </div>
+            {item.comparison.reason && (
+              <div style={{ color: '#ffee99', fontSize: '13px', marginBottom: item.comparison.differences ? '8px' : 0 }}>
+                {item.comparison.reason}
+              </div>
+            )}
+            {item.comparison.differences && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+                <DiffChip label="DMG" value={item.comparison.differences.damage_diff} />
+                <DiffChip label="DEF" value={item.comparison.differences.protection_diff} />
+                <DiffChip label="WT" value={item.comparison.differences.weight_diff} invert />
+                <DiffChip label="VAL" value={item.comparison.differences.value_diff} suffix="g" />
+                {Object.entries(item.comparison.differences.bonus_diffs || {}).map(([stat, diff]) => (
+                  <DiffChip key={`bonus-${stat}`} label={BONUS_STAT_LABELS[stat] || capitalize(stat)} value={diff} />
+                ))}
+                {Object.entries(item.comparison.differences.resistance_diffs || {}).map(([type, diff]) => (
+                  <DiffChip key={`res-${type}`} label={`${capitalize(type)} Res`} value={diff} percent />
+                ))}
+                {Object.entries(item.comparison.differences.status_resistance_diffs || {}).map(([type, diff]) => (
+                  <DiffChip key={`sres-${type}`} label={`${capitalize(type)} Resist`} value={diff} percent />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Consumable Effects */}
+        {item.effects && item.effects.length > 0 && (
+          <div style={{
+            backgroundColor: 'rgba(30, 15, 0, 0.6)',
+            border: '1px solid #664400',
+            borderRadius: '4px',
+            padding: '8px 10px',
+          }}>
+            <div style={{ color: '#ffaa00', fontWeight: 'bold', fontSize: '13px', textTransform: 'uppercase', marginBottom: '6px' }}>
+              Effects
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+              {item.effects.map((effect, i) => {
+                const text = describeEffect(effect)
+                return text ? (
+                  <div key={i} style={{ color: '#aaffcc', fontSize: '13px' }}>
+                    ✦ {text}
+                  </div>
+                ) : null
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Stat Bonuses */}
+        {item.bonuses && Object.keys(item.bonuses).length > 0 && (
+          <div style={{
+            backgroundColor: 'rgba(30, 15, 0, 0.6)',
+            border: '1px solid #664400',
+            borderRadius: '4px',
+            padding: '8px 10px',
+          }}>
+            <div style={{ color: '#ffaa00', fontWeight: 'bold', fontSize: '13px', textTransform: 'uppercase', marginBottom: '6px' }}>
+              Bonuses
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+              {Object.entries(item.bonuses).map(([stat, value]) => (
+                <DiffChip key={stat} label={BONUS_STAT_LABELS[stat] || capitalize(stat)} value={value} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Resistances (damage + status) */}
+        {((item.resistances && Object.keys(item.resistances).length > 0) ||
+          (item.status_resistances && Object.keys(item.status_resistances).length > 0)) && (
+          <div style={{
+            backgroundColor: 'rgba(30, 15, 0, 0.6)',
+            border: '1px solid #664400',
+            borderRadius: '4px',
+            padding: '8px 10px',
+          }}>
+            <div style={{ color: '#ffaa00', fontWeight: 'bold', fontSize: '13px', textTransform: 'uppercase', marginBottom: '6px' }}>
+              Resistances
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+              {Object.entries(item.resistances || {}).map(([type, value]) => (
+                <DiffChip key={`res-${type}`} label={`${type.toUpperCase()} Res`} value={value} percent />
+              ))}
+              {Object.entries(item.status_resistances || {}).map(([type, value]) => (
+                <DiffChip key={`sres-${type}`} label={`${capitalize(type)} Resist`} value={value} percent />
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Equipped Status — outside the grid to avoid auto-fit column count distortion */}
         {item.is_equipped && (
@@ -1019,5 +1201,31 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
         />
       )}
     </div>
+  )
+}
+
+// Renders a labeled signed value (stat bonus, resistance, or equip-comparison
+// diff). `invert` flips the good/bad color (e.g. weight: lower is better).
+function DiffChip({ label, value, suffix = '', invert = false, percent = false }) {
+  if (!value) return null
+  const isGood = invert ? value < 0 : value > 0
+  const color = isGood ? '#00ff88' : '#ff6666'
+  const displayValue = percent ? formatSignedPercent(value) : formatSigned(value)
+  return (
+    <span style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '3px',
+      padding: '2px 7px',
+      borderRadius: '3px',
+      fontSize: '11px',
+      fontWeight: 'bold',
+      fontFamily: 'monospace',
+      border: `1px solid ${color}66`,
+      backgroundColor: `${color}1a`,
+      color,
+    }}>
+      {label} {displayValue}{suffix}
+    </span>
   )
 }

--- a/frontend/src/components/ItemDetailDialog.test.jsx
+++ b/frontend/src/components/ItemDetailDialog.test.jsx
@@ -647,4 +647,131 @@ describe('ItemDetailDialog', () => {
     fireEvent.mouseEnter(dropButton);
     fireEvent.mouseLeave(dropButton);
   });
+
+  // ---------------------------------------------------------------------------
+  // Stat details: damage/protection, bonuses, resistances, effects, comparison
+  // ---------------------------------------------------------------------------
+  describe('stat details', () => {
+    it('shows damage and damage type for weapons', () => {
+      const weapon = { ...mockItem, damage: 25, damage_type: 'slashing' };
+      render(<ItemDetailDialog item={weapon} player={mockPlayer} onBack={mockOnBack} />);
+
+      expect(screen.getByText(/25.*\(Slashing\)/)).toBeDefined();
+    });
+
+    it('shows protection for armor', () => {
+      const armor = { ...mockItem, damage: undefined, protection: 12, maintype: 'Armor', subtype: 'Armor' };
+      render(<ItemDetailDialog item={armor} player={mockPlayer} onBack={mockOnBack} />);
+
+      expect(screen.getByText('Protection')).toBeDefined();
+      expect(screen.getByText(/🛡️ 12/)).toBeDefined();
+    });
+
+    it('does not show a Protection cell when item.protection is absent', () => {
+      render(<ItemDetailDialog item={mockItem} player={mockPlayer} onBack={mockOnBack} />);
+      expect(screen.queryByText('Protection')).toBeNull();
+    });
+
+    it('renders stat bonus chips', () => {
+      const enchanted = { ...mockItem, bonuses: { strength: 3, finesse: -1 } };
+      render(<ItemDetailDialog item={enchanted} player={mockPlayer} onBack={mockOnBack} />);
+
+      expect(screen.getByText('Bonuses')).toBeDefined();
+      expect(screen.getByText(/STR \+3/)).toBeDefined();
+      expect(screen.getByText(/FIN -1/)).toBeDefined();
+    });
+
+    it('does not render a Bonuses section when item.bonuses is absent', () => {
+      render(<ItemDetailDialog item={mockItem} player={mockPlayer} onBack={mockOnBack} />);
+      expect(screen.queryByText('Bonuses')).toBeNull();
+    });
+
+    it('renders resistance and status resistance chips', () => {
+      const resistant = {
+        ...mockItem,
+        resistances: { fire: 0.3 },
+        status_resistances: { poison: -0.1 },
+      };
+      render(<ItemDetailDialog item={resistant} player={mockPlayer} onBack={mockOnBack} />);
+
+      expect(screen.getByText('Resistances')).toBeDefined();
+      expect(screen.getByText(/FIRE Res \+30%/)).toBeDefined();
+      expect(screen.getByText(/Poison Resist -10%/)).toBeDefined();
+    });
+
+    it('renders consumable effect descriptions in the main panel', () => {
+      const potion = {
+        ...mockItem,
+        can_use: true,
+        maintype: 'Consumable',
+        effects: [
+          { type: 'heal', stat: 'hp', power: 60, range: [48, 72] },
+          { type: 'status_remove', status_name: 'Poisoned' },
+        ],
+      };
+      render(<ItemDetailDialog item={potion} player={mockPlayer} onBack={mockOnBack} />);
+
+      expect(screen.getByText('Effects')).toBeDefined();
+      expect(screen.getByText(/Restores 48-72 HP/)).toBeDefined();
+      expect(screen.getByText(/Cures Poisoned/)).toBeDefined();
+    });
+
+    it('does not render an Effects section when item.effects is absent', () => {
+      render(<ItemDetailDialog item={mockItem} player={mockPlayer} onBack={mockOnBack} />);
+      expect(screen.queryByText('Effects')).toBeNull();
+    });
+
+    it('renders an empty_to_item comparison as an upgrade with no equipped item', () => {
+      const candidate = {
+        ...mockItem,
+        comparison: {
+          comparison_type: 'empty_to_item',
+          current: null,
+          candidate: { name: 'Iron Sword' },
+          recommendation: 'upgrade',
+          reason: 'No item currently equipped',
+        },
+      };
+      render(<ItemDetailDialog item={candidate} player={mockPlayer} onBack={mockOnBack} />);
+
+      expect(screen.getByText(/vs\. Equipped/)).toBeDefined();
+      expect(screen.getByText(/UPGRADE/)).toBeDefined();
+      expect(screen.getByText('No item currently equipped')).toBeDefined();
+    });
+
+    it('renders an item_to_item comparison with diff chips and the equipped item name', () => {
+      const candidate = {
+        ...mockItem,
+        comparison: {
+          comparison_type: 'item_to_item',
+          current: { name: 'Rusty Sword' },
+          candidate: { name: 'Iron Sword' },
+          differences: {
+            damage_diff: 5,
+            protection_diff: 0,
+            weight_diff: -1,
+            value_diff: 20,
+            bonus_diffs: {},
+            resistance_diffs: {},
+            status_resistance_diffs: {},
+          },
+          recommendation: 'upgrade',
+          reason: 'Damage +5, Weight -1',
+        },
+      };
+      render(<ItemDetailDialog item={candidate} player={mockPlayer} onBack={mockOnBack} />);
+
+      expect(screen.getByText(/vs\. Equipped: Rusty Sword/)).toBeDefined();
+      expect(screen.getByText(/DMG \+5/)).toBeDefined();
+      expect(screen.getByText(/WT -1/)).toBeDefined();
+      expect(screen.getByText(/VAL \+20g/)).toBeDefined();
+      // protection_diff of 0 should not render a DEF chip
+      expect(screen.queryByText(/DEF/)).toBeNull();
+    });
+
+    it('does not render a comparison block when item.comparison is absent', () => {
+      render(<ItemDetailDialog item={mockItem} player={mockPlayer} onBack={mockOnBack} />);
+      expect(screen.queryByText(/vs\. Equipped/)).toBeNull();
+    });
+  });
 });

--- a/src/api/serializers/inventory.py
+++ b/src/api/serializers/inventory.py
@@ -41,18 +41,103 @@ _CONSUMABLE_EFFECTS = {
     ],
 }
 
+# Scalar stat-bonus attributes an item/enchantment may add, mapped to their
+# player-stat label. Mirrors functions.py:refresh_stat_bonuses' bonuses_map —
+# keep these in sync since that function is the authoritative source.
+_BONUS_ATTRS = {
+    "add_str": "strength",
+    "add_fin": "finesse",
+    "add_maxhp": "maxhp",
+    "add_maxfatigue": "maxfatigue",
+    "add_speed": "speed",
+    "add_endurance": "endurance",
+    "add_charisma": "charisma",
+    "add_intelligence": "intelligence",
+    "add_faith": "faith",
+    "add_weight_tolerance": "weight_tolerance",
+}
+
+# Accessory subtypes that don't auto-replace on equip (see inventory.py
+# equip_item) — a player can have multiple equipped at once, so there's no
+# single "slot counterpart" to compare against.
+_MULTI_EQUIP_ACCESSORY_SUBTYPES = ["Ring", "Bracelet", "Earring"]
+
+
+def _collect_item_bonuses(item) -> Dict:
+    """Collect non-zero scalar stat bonuses an item grants, keyed by stat label."""
+    return {
+        label: getattr(item, attr)
+        for attr, label in _BONUS_ATTRS.items()
+        if getattr(item, attr, 0)
+    }
+
+
+def _get_equip_slot_status(player, item):
+    """
+    Determine whether `item` has a single comparable equip-slot counterpart.
+
+    Returns (comparable, counterpart):
+        comparable: False for multi-equip accessory subtypes (Ring/Bracelet/
+            Earring), which have no single slot counterpart to compare against.
+        counterpart: the currently-equipped item occupying that slot, or None
+            if the slot is empty.
+    """
+    maintype = getattr(item, "maintype", None)
+    if not maintype:
+        return False, None
+    subtype = getattr(item, "subtype", None)
+    if maintype == "Accessory" and subtype in _MULTI_EQUIP_ACCESSORY_SUBTYPES:
+        return False, None
+
+    inventory_list = getattr(player, "inventory_list", None) or getattr(
+        player, "inventory", []
+    )
+    for other_item in inventory_list:
+        if other_item is item or not getattr(other_item, "isequipped", False):
+            continue
+        if getattr(other_item, "maintype", None) != maintype:
+            continue
+        if maintype == "Accessory" and getattr(other_item, "subtype", None) != subtype:
+            continue
+        return True, other_item
+    return True, None
+
+
+def _diff_bonuses(current_item, candidate_item) -> Dict[str, float]:
+    """Compute the per-stat delta of scalar bonuses between two items."""
+    diffs = {}
+    for attr, label in _BONUS_ATTRS.items():
+        delta = getattr(candidate_item, attr, 0) - getattr(current_item, attr, 0)
+        if delta:
+            diffs[label] = delta
+    return diffs
+
+
+def _diff_resistance_dicts(current_item, candidate_item, attr_name: str) -> Dict[str, float]:
+    """Compute the per-key delta of a resistance-style dict attribute between two items."""
+    current = getattr(current_item, attr_name, None) or {}
+    candidate = getattr(candidate_item, attr_name, None) or {}
+    diffs = {}
+    for key in set(current) | set(candidate):
+        delta = candidate.get(key, 0) - current.get(key, 0)
+        if delta:
+            diffs[key] = delta
+    return diffs
+
 
 class InventoryItemSerializer:
     """Serialize a single item in player inventory."""
 
     @staticmethod
-    def serialize(item, index: int) -> Dict:
+    def serialize(item, index: int, player=None) -> Dict:
         """
         Serialize an item for inventory listing.
 
         Args:
             item: The item object to serialize
             index: The position in inventory
+            player: The owning Player, used to compute an equipped-item
+                comparison block. Omit to skip the comparison.
 
         Returns:
             Dictionary with item data suitable for JSON
@@ -90,6 +175,9 @@ class InventoryItemSerializer:
             item_data["damage"] = round(getattr(item, "damage", 0))
             item_data["str_mod"] = getattr(item, "str_mod", 0)
             item_data["fin_mod"] = getattr(item, "fin_mod", 0)
+            from items import get_base_damage_type  # local import: see game_service.py precedent
+
+            item_data["damage_type"] = get_base_damage_type(item)
 
         # Add armor-specific stats (Armor, Boots, Helm, Gloves, Accessory)
         if item_type in [
@@ -100,10 +188,33 @@ class InventoryItemSerializer:
             "Accessory",
         ] or maintype in ["Armor", "Boots", "Helm", "Gloves", "Accessory"]:
             item_data["protection"] = round(getattr(item, "protection", 0))
+            item_data["str_mod"] = getattr(item, "str_mod", 0)
+            if hasattr(item, "fin_mod"):
+                item_data["fin_mod"] = getattr(item, "fin_mod", 0)
 
         # Add composable effects array for usable (consumable) items
         if item_data["can_use"]:
             item_data["effects"] = _CONSUMABLE_EFFECTS.get(item_type, [])
+
+        # Add stat bonuses and resistances granted by this item (enchantments)
+        if item_data["can_equip"]:
+            bonuses = _collect_item_bonuses(item)
+            if bonuses:
+                item_data["bonuses"] = bonuses
+            resistances = getattr(item, "add_resistance", None)
+            if resistances:
+                item_data["resistances"] = dict(resistances)
+            status_resistances = getattr(item, "add_status_resistance", None)
+            if status_resistances:
+                item_data["status_resistances"] = dict(status_resistances)
+
+        # Add a comparison against the currently-equipped counterpart, if any
+        if player is not None and item_data["can_equip"] and not item_data["is_equipped"]:
+            comparable, counterpart = _get_equip_slot_status(player, item)
+            if comparable:
+                item_data["comparison"] = ItemComparisonSerializer.serialize(
+                    counterpart, item
+                )
 
         return item_data
 
@@ -130,7 +241,7 @@ class InventorySerializer:
             player, "inventory", []
         )
         for idx, item in enumerate(inventory_list):
-            items.append(InventoryItemSerializer.serialize(item, idx))
+            items.append(InventoryItemSerializer.serialize(item, idx, player))
             total_weight += getattr(item, "weight", 0.0)
 
         return {
@@ -308,7 +419,7 @@ class ItemDetailSerializer:
             "can_use": hasattr(item, "use"),
             "can_drop": True,  # Most items can be dropped
             "stats": {
-                "armor": round(getattr(item, "armor", 0)),
+                "protection": round(getattr(item, "protection", 0)),
                 "damage": round(getattr(item, "damage", 0)),
                 "magic_attack": getattr(item, "magic_attack", 0),
                 "magic_defense": getattr(item, "magic_defense", 0),
@@ -359,8 +470,8 @@ class ItemComparisonSerializer:
         damage_diff = getattr(candidate_item, "damage", 0) - getattr(
             current_item, "damage", 0
         )
-        armor_diff = getattr(candidate_item, "armor", 0) - getattr(
-            current_item, "armor", 0
+        protection_diff = getattr(candidate_item, "protection", 0) - getattr(
+            current_item, "protection", 0
         )
         weight_diff = getattr(candidate_item, "weight", 0) - getattr(
             current_item, "weight", 0
@@ -368,16 +479,32 @@ class ItemComparisonSerializer:
         value_diff = getattr(candidate_item, "value", 0) - getattr(
             current_item, "value", 0
         )
+        bonus_diffs = _diff_bonuses(current_item, candidate_item)
+        resistance_diffs = _diff_resistance_dicts(
+            current_item, candidate_item, "add_resistance"
+        )
+        status_resistance_diffs = _diff_resistance_dicts(
+            current_item, candidate_item, "add_status_resistance"
+        )
 
         # Determine recommendation
-        if damage_diff > 0 and armor_diff >= 0:
+        if damage_diff > 0 and protection_diff >= 0:
             recommendation = "upgrade"
-        elif damage_diff >= 0 and armor_diff > 0:
+        elif damage_diff >= 0 and protection_diff > 0:
             recommendation = "upgrade"
-        elif damage_diff < 0 and armor_diff < 0:
+        elif damage_diff < 0 and protection_diff < 0:
             recommendation = "downgrade"
         else:
             recommendation = "sidegrade"
+
+        reason_parts = []
+        if damage_diff:
+            reason_parts.append(f"Damage {'+' if damage_diff > 0 else ''}{damage_diff}")
+        if protection_diff:
+            reason_parts.append(
+                f"Protection {'+' if protection_diff > 0 else ''}{protection_diff}"
+            )
+        reason_parts.append(f"Weight {'+' if weight_diff > 0 else ''}{weight_diff}")
 
         return {
             "comparison_type": "item_to_item",
@@ -385,12 +512,13 @@ class ItemComparisonSerializer:
             "candidate": candidate_data,
             "differences": {
                 "damage_diff": damage_diff,
-                "armor_diff": armor_diff,
+                "protection_diff": protection_diff,
                 "weight_diff": weight_diff,
                 "value_diff": value_diff,
+                "bonus_diffs": bonus_diffs,
+                "resistance_diffs": resistance_diffs,
+                "status_resistance_diffs": status_resistance_diffs,
             },
             "recommendation": recommendation,
-            "reason": f"Damage {'+' if damage_diff > 0 else ''}{damage_diff}, "
-            f"Armor {'+' if armor_diff > 0 else ''}{armor_diff}, "
-            f"Weight {'+' if weight_diff > 0 else ''}{weight_diff}",
+            "reason": ", ".join(reason_parts),
         }

--- a/tests/api/test_inventory_serializers.py
+++ b/tests/api/test_inventory_serializers.py
@@ -71,6 +71,7 @@ class MockArmor(MockItem):
     def __init__(self, name="Leather Armor", armor=5, **kwargs):
         super().__init__(name=name, **kwargs)
         self.armor = armor
+        self.protection = armor
         self.stat_bonuses = {"defense": 3}
         self.resistance_bonuses = {"piercing": 0.8}
 
@@ -324,7 +325,7 @@ class TestItemDetailSerializer:
         item = MockItem()
         result = ItemDetailSerializer.serialize(item)
 
-        assert result["stats"]["armor"] == 0
+        assert result["stats"]["protection"] == 0
         assert result["stats"]["damage"] == 0
         assert result["bonuses"]["stat_bonuses"] == {}
 
@@ -384,7 +385,7 @@ class TestItemComparisonSerializer:
 
         result = ItemComparisonSerializer.serialize(current, candidate)
 
-        assert result["differences"]["armor_diff"] == 7
+        assert result["differences"]["protection_diff"] == 7
         assert result["recommendation"] == "upgrade"
 
 

--- a/tests/test_serializers_coverage.py
+++ b/tests/test_serializers_coverage.py
@@ -990,6 +990,18 @@ class TestInventorySerializer:
         item.str_mod = 1
         item.fin_mod = 0
         item.protection = 0
+        item.add_str = 0
+        item.add_fin = 0
+        item.add_maxhp = 0
+        item.add_maxfatigue = 0
+        item.add_speed = 0
+        item.add_endurance = 0
+        item.add_charisma = 0
+        item.add_intelligence = 0
+        item.add_faith = 0
+        item.add_weight_tolerance = 0
+        item.add_resistance = {}
+        item.add_status_resistance = {}
         return item
 
     def test_serialize_weapon_item(self):
@@ -1042,6 +1054,148 @@ class TestInventorySerializer:
         item.interactions = ["use", "drop"]
         result = self.InventoryItemSerializer.serialize(item, 0)
         assert result["effects"] == []
+
+    def test_serialize_weapon_damage_type(self):
+        item = self._make_item()
+        item.subtype = "Sword"
+        result = self.InventoryItemSerializer.serialize(item, 0)
+        assert result["damage_type"] == "slashing"
+
+    def test_serialize_weapon_damage_type_enchanted_override(self):
+        item = self._make_item()
+        item.subtype = "Sword"
+        item.base_damage_type = "fire"
+        result = self.InventoryItemSerializer.serialize(item, 0)
+        assert result["damage_type"] == "fire"
+
+    def test_serialize_item_with_stat_bonuses(self):
+        item = self._make_item()
+        item.add_str = 2
+        item.add_speed = 3
+        result = self.InventoryItemSerializer.serialize(item, 0)
+        assert result["bonuses"] == {"strength": 2, "speed": 3}
+
+    def test_serialize_item_without_bonuses_omits_key(self):
+        item = self._make_item()
+        result = self.InventoryItemSerializer.serialize(item, 0)
+        assert "bonuses" not in result
+
+    def test_serialize_item_with_resistances(self):
+        item = self._make_item()
+        item.add_resistance = {"fire": 0.2}
+        item.add_status_resistance = {"poison": 0.5}
+        result = self.InventoryItemSerializer.serialize(item, 0)
+        assert result["resistances"] == {"fire": 0.2}
+        assert result["status_resistances"] == {"poison": 0.5}
+
+    def test_serialize_item_without_resistances_omits_keys(self):
+        item = self._make_item()
+        result = self.InventoryItemSerializer.serialize(item, 0)
+        assert "resistances" not in result
+        assert "status_resistances" not in result
+
+    def test_serialize_item_comparison_with_real_counterpart(self):
+        equipped = self._make_item()
+        equipped.isequipped = True
+        equipped.damage = 10.0
+        equipped.add_str = 1
+
+        candidate = self._make_item()
+        candidate.isequipped = False
+        candidate.damage = 18.0
+        candidate.add_str = 3
+
+        player = MagicMock()
+        player.inventory_list = [equipped, candidate]
+
+        result = self.InventoryItemSerializer.serialize(candidate, 1, player)
+        comparison = result["comparison"]
+        assert comparison["comparison_type"] == "item_to_item"
+        assert comparison["differences"]["damage_diff"] == 8.0
+        assert comparison["differences"]["bonus_diffs"] == {"strength": 2}
+
+    def test_serialize_item_comparison_empty_slot(self):
+        candidate = self._make_item()
+        candidate.isequipped = False
+
+        player = MagicMock()
+        player.inventory_list = [candidate]
+
+        result = self.InventoryItemSerializer.serialize(candidate, 0, player)
+        assert result["comparison"]["comparison_type"] == "empty_to_item"
+
+    def test_serialize_item_no_maintype_skips_comparison(self):
+        candidate = self._make_item(maintype=None)
+        candidate.isequipped = False
+
+        player = MagicMock()
+        player.inventory_list = [candidate]
+
+        result = self.InventoryItemSerializer.serialize(candidate, 0, player)
+        assert "comparison" not in result
+
+    def test_serialize_item_multi_equip_accessory_skips_comparison(self):
+        candidate = self._make_item(item_type="Accessory", maintype="Accessory")
+        candidate.subtype = "Ring"
+        candidate.isequipped = False
+
+        player = MagicMock()
+        player.inventory_list = [candidate]
+
+        result = self.InventoryItemSerializer.serialize(candidate, 0, player)
+        assert "comparison" not in result
+
+    def test_serialize_item_equipped_skips_comparison(self):
+        item = self._make_item()
+        item.isequipped = True
+
+        player = MagicMock()
+        player.inventory_list = [item]
+
+        result = self.InventoryItemSerializer.serialize(item, 0, player)
+        assert "comparison" not in result
+
+    def test_get_equip_slot_status_skips_other_maintypes(self):
+        from src.api.serializers.inventory import _get_equip_slot_status
+
+        unrelated = self._make_item(item_type="Helm", maintype="Helm")
+        unrelated.isequipped = True
+        candidate = self._make_item()  # maintype="Weapon"
+
+        player = MagicMock()
+        player.inventory_list = [unrelated, candidate]
+
+        comparable, counterpart = _get_equip_slot_status(player, candidate)
+        assert comparable is True
+        assert counterpart is None
+
+    def test_get_equip_slot_status_skips_mismatched_accessory_subtype(self):
+        from src.api.serializers.inventory import _get_equip_slot_status
+
+        equipped_necklace = self._make_item(item_type="Accessory", maintype="Accessory")
+        equipped_necklace.subtype = "Necklace"
+        equipped_necklace.isequipped = True
+
+        candidate = self._make_item(item_type="Accessory", maintype="Accessory")
+        candidate.subtype = "Circlet"
+
+        player = MagicMock()
+        player.inventory_list = [equipped_necklace, candidate]
+
+        comparable, counterpart = _get_equip_slot_status(player, candidate)
+        assert comparable is True
+        assert counterpart is None
+
+    def test_diff_resistance_dicts_with_real_deltas(self):
+        from src.api.serializers.inventory import _diff_resistance_dicts
+
+        current = self._make_item()
+        current.add_resistance = {"fire": 0.1, "ice": 0.3}
+        candidate = self._make_item()
+        candidate.add_resistance = {"fire": 0.4, "earth": 0.2}
+
+        diffs = _diff_resistance_dicts(current, candidate, "add_resistance")
+        assert diffs == {"fire": pytest.approx(0.3), "ice": -0.3, "earth": 0.2}
 
     def test_inventory_serializer_with_inventory_list(self):
         player = MagicMock()
@@ -1169,6 +1323,7 @@ class TestInventorySerializer:
         item.weight = 1.5
         item.value = 250
         item.armor = 0.0
+        item.protection = 0.0
         item.damage = 20.0
         item.magic_attack = 0
         item.magic_defense = 0
@@ -1195,6 +1350,7 @@ class TestInventorySerializer:
         candidate.weight = 2.0
         candidate.value = 100
         candidate.armor = 0.0
+        candidate.protection = 0.0
         candidate.damage = 12.0
         candidate.magic_attack = 0
         candidate.magic_defense = 0
@@ -1218,6 +1374,7 @@ class TestInventorySerializer:
         current.weight = 2.0
         current.value = 50
         current.armor = 0.0
+        current.protection = 0.0
         current.damage = 8.0
         current.magic_attack = 0
         current.magic_defense = 0
@@ -1237,6 +1394,7 @@ class TestInventorySerializer:
         candidate.weight = 2.0
         candidate.value = 150
         candidate.armor = 0.0
+        candidate.protection = 0.0
         candidate.damage = 20.0
         candidate.magic_attack = 0
         candidate.magic_defense = 0
@@ -1260,6 +1418,7 @@ class TestInventorySerializer:
         current.weight = 2.0
         current.value = 300
         current.armor = 10.0
+        current.protection = 10.0
         current.damage = 25.0
         current.magic_attack = 0
         current.magic_defense = 0
@@ -1279,6 +1438,7 @@ class TestInventorySerializer:
         candidate.weight = 1.0
         candidate.value = 30
         candidate.armor = 0.0
+        candidate.protection = 0.0
         candidate.damage = 5.0
         candidate.magic_attack = 0
         candidate.magic_defense = 0
@@ -1301,6 +1461,7 @@ class TestInventorySerializer:
         current.weight = 2.0
         current.value = 100
         current.armor = 5.0
+        current.protection = 5.0
         current.damage = 15.0
         current.magic_attack = 0
         current.magic_defense = 0
@@ -1320,6 +1481,7 @@ class TestInventorySerializer:
         candidate.weight = 2.0
         candidate.value = 100
         candidate.armor = 8.0
+        candidate.protection = 8.0
         candidate.damage = 10.0
         candidate.magic_attack = 0
         candidate.magic_defense = 0


### PR DESCRIPTION
Item payloads now include damage/damage_type for weapons, protection for
armor-type items, enchantment-derived stat bonuses and resistances, and
a comparison against the currently-equipped counterpart for equippable
items — laying the groundwork for richer item-inspection UI.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lo9ihBhSNKt5Fjtgv9eHf9