### PR TITLE
Make ShootBow and ShootCrossbow always-known moves, not skilltree purchases

### DIFF
--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1998,11 +1998,13 @@ class ApiCombatAdapter:
             # Default to adjacent if no range specified but targeted
             range_min, range_max = 0, 5
 
-        # Special handling for bow
-        if move.name == "Shoot Bow" and self.player.eq_weapon:
-            range_max = self.player.eq_weapon.range_base + (
-                100 / self.player.eq_weapon.range_decay
-            )
+        # Moves that compute their range dynamically (e.g. ranged weapons
+        # whose effective range extends past their melee wpnrange via
+        # range_base/range_decay) override get_effective_range_max() —
+        # see Move.get_effective_range_max in src/moves/_base.py.
+        effective_max = move.get_effective_range_max(self.player)
+        if effective_max is not None:
+            range_max = effective_max
 
         # Iterate over combat_list instead of combat_proximity to ensure we use the correct enemy instances
         for enemy in self.player.combat_list:

--- a/src/moves/_ranged.py
+++ b/src/moves/_ranged.py
@@ -23,6 +23,15 @@ def _crossbow_close_range_penalty(user, range_min):
     return any(dist < range_min for dist in user.combat_proximity.values())
 
 
+def _weapon_effective_range_max(user):
+    """Return the weapon's decay-based long range, or None if inapplicable."""
+    wpn = getattr(user, "eq_weapon", None)
+    decay = getattr(wpn, "range_decay", 0) if wpn else 0
+    if wpn and decay:
+        return getattr(wpn, "range_base", 0) + (100 / decay)
+    return None
+
+
 class ShootBow(
     Move
 ):  # ranged attack with a bow, player only. Requires having arrows in inventory;
@@ -72,11 +81,7 @@ class ShootBow(
 
     def get_effective_range_max(self, user):
         """Return the effective maximum range, accounting for weapon range and decay."""
-        wpn = getattr(user, "eq_weapon", None)
-        decay = getattr(wpn, "range_decay", 0) if wpn else 0
-        if wpn and decay:
-            return getattr(wpn, "range_base", 0) + (100 / decay)
-        return None
+        return _weapon_effective_range_max(user)
 
     def calculate_hit_chance(
         self, enemy
@@ -235,10 +240,7 @@ class ShootBow(
             )
 
         range_min = self.mvrange[0]
-        effective_range = self.user.eq_weapon.range_base + (
-            100 / self.user.eq_weapon.range_decay
-        )
-        range_max = effective_range
+        range_max = self.get_effective_range_max(self.user)
         target_distance = player.combat_proximity[self.target]
         # close_range_distraction = 0  # all enemies will be checked;
         # # if any are closer than the weapon's min range, accuracy is halved
@@ -248,7 +250,7 @@ class ShootBow(
         #             close_range_distraction = 1
         #             break
         if (
-            range_min <= target_distance <= range_max
+            range_max is not None and range_min <= target_distance <= range_max
         ):  # check if target is still in range
             hit_chance = self.calculate_hit_chance(self.target)
             narrate(self.stage_announce[1])
@@ -368,6 +370,10 @@ class ShootCrossbow(Move):
         self.base_damage_type = "piercing"
         self.evaluate()
 
+    def get_effective_range_max(self, user):
+        """Return the effective maximum range, accounting for weapon range and decay."""
+        return _weapon_effective_range_max(user)
+
     def viable(self):
         if not getattr(self.user, "eq_weapon", None):
             return False
@@ -375,7 +381,10 @@ class ShootCrossbow(Move):
             return False
         if not hasattr(self.user, "combat_proximity"):
             return False
-        rmin, rmax = self.mvrange
+        rmin = self.mvrange[0]
+        rmax = self.get_effective_range_max(self.user)
+        if rmax is None:
+            return False
         return any(rmin <= dist <= rmax for dist in self.user.combat_proximity.values())
 
     def evaluate(self):
@@ -392,7 +401,6 @@ class ShootCrossbow(Move):
             + int(self.user.finesse * wpn.fin_mod),
         )
         self.fatigue_cost = _apply_carry_fatigue(self.user, max(10, 100 - (2 * self.user.endurance)))
-        self.mvrange = getattr(wpn, "wpnrange", (6, 40))
 
     def execute(self, player):
         glance = False
@@ -409,7 +417,7 @@ class ShootCrossbow(Move):
                 self.user.combat_position, self.target.combat_position
             )
 
-        rmin, rmax = self.mvrange
+        rmin = self.mvrange[0]
         if not self.viable():
             hit_chance = -1
         else:
@@ -486,6 +494,10 @@ class BroadheadBolt(Move):
         self.base_damage_type = "piercing"
         self.evaluate()
 
+    def get_effective_range_max(self, user):
+        """Return the effective maximum range, accounting for weapon range and decay."""
+        return _weapon_effective_range_max(user)
+
     def viable(self):
         if not getattr(self.user, "eq_weapon", None):
             return False
@@ -493,7 +505,10 @@ class BroadheadBolt(Move):
             return False
         if not hasattr(self.user, "combat_proximity"):
             return False
-        rmin, rmax = self.mvrange
+        rmin = self.mvrange[0]
+        rmax = self.get_effective_range_max(self.user)
+        if rmax is None:
+            return False
         return any(rmin <= dist <= rmax for dist in self.user.combat_proximity.values())
 
     def evaluate(self):
@@ -510,7 +525,6 @@ class BroadheadBolt(Move):
             + int(self.user.finesse * wpn.fin_mod),
         )
         self.fatigue_cost = _apply_carry_fatigue(self.user, max(15, 110 - (2 * self.user.endurance)))
-        self.mvrange = getattr(wpn, "wpnrange", (6, 40))
 
     def execute(self, player):
         self.standard_execute_attack(player, self.power, self.base_damage_type)
@@ -557,6 +571,10 @@ class AimedShot(Move):
         self.base_damage_type = "piercing"
         self.evaluate()
 
+    def get_effective_range_max(self, user):
+        """Return the effective maximum range, accounting for weapon range and decay."""
+        return _weapon_effective_range_max(user)
+
     def viable(self):
         if not getattr(self.user, "eq_weapon", None):
             return False
@@ -564,7 +582,10 @@ class AimedShot(Move):
             return False
         if not hasattr(self.user, "combat_proximity"):
             return False
-        rmin, rmax = self.mvrange
+        rmin = self.mvrange[0]
+        rmax = self.get_effective_range_max(self.user)
+        if rmax is None:
+            return False
         return any(rmin <= dist <= rmax for dist in self.user.combat_proximity.values())
 
     def evaluate(self):
@@ -581,7 +602,6 @@ class AimedShot(Move):
         )
         self.power = max(1, int(base * 1.5))
         self.fatigue_cost = _apply_carry_fatigue(self.user, max(10, 90 - (2 * self.user.endurance)))
-        self.mvrange = getattr(wpn, "wpnrange", (6, 40))
 
     def execute(self, player):
         glance = False
@@ -598,7 +618,7 @@ class AimedShot(Move):
                 self.user.combat_position, self.target.combat_position
             )
 
-        rmin, rmax = self.mvrange
+        rmin = self.mvrange[0]
         if not self.viable():
             hit_chance = -1
         else:
@@ -677,6 +697,10 @@ class PinningBolt(Move):
         self.base_damage_type = "piercing"
         self.evaluate()
 
+    def get_effective_range_max(self, user):
+        """Return the effective maximum range, accounting for weapon range and decay."""
+        return _weapon_effective_range_max(user)
+
     def viable(self):
         if not getattr(self.user, "eq_weapon", None):
             return False
@@ -684,7 +708,10 @@ class PinningBolt(Move):
             return False
         if not hasattr(self.user, "combat_proximity"):
             return False
-        rmin, rmax = self.mvrange
+        rmin = self.mvrange[0]
+        rmax = self.get_effective_range_max(self.user)
+        if rmax is None:
+            return False
         return any(rmin <= dist <= rmax for dist in self.user.combat_proximity.values())
 
     def evaluate(self):
@@ -701,7 +728,6 @@ class PinningBolt(Move):
             + int(self.user.finesse * wpn.fin_mod),
         )
         self.fatigue_cost = _apply_carry_fatigue(self.user, max(10, 100 - (2 * self.user.endurance)))
-        self.mvrange = getattr(wpn, "wpnrange", (6, 40))
 
     def execute(self, player):
         glance = False
@@ -718,7 +744,7 @@ class PinningBolt(Move):
                 self.user.combat_position, self.target.combat_position
             )
 
-        rmin, rmax = self.mvrange
+        rmin = self.mvrange[0]
         if not self.viable():
             hit_chance = -1
         else:

--- a/src/player/__init__.py
+++ b/src/player/__init__.py
@@ -164,6 +164,8 @@ class Player(
             moves.Advance(self),
             moves.Withdraw(self),
             moves.Attack(self),
+            moves.ShootBow(self),
+            moves.ShootCrossbow(self),
             moves.Dodge(self),
             moves.CrusaderOath(self),
         ]

--- a/src/skilltree.py
+++ b/src/skilltree.py
@@ -187,9 +187,6 @@ class Skilltree:
                 ): 350,  # passive: signature pick ability — stacking protection reduction
             },
             "Crossbow": {
-                moves.ShootCrossbow(
-                    user
-                ): 50,  # base ranged attack, longer reload than bow
                 moves.BroadheadBolt(user): 400,  # heavy bolt, +25 base power
                 moves.AimedShot(user): 500,  # 25-beat aim, +50% power, +15 accuracy
                 moves.PinningBolt(user): 600,  # damage + Disoriented on hit

--- a/tests/test_bow_and_abilities.py
+++ b/tests/test_bow_and_abilities.py
@@ -250,6 +250,119 @@ class TestBowAndArrows:
         assert self.player.fatigue >= shoot_bow.fatigue_cost, f"Player has enough fatigue - Player fatigue: {self.player.fatigue}, Cost: {shoot_bow.fatigue_cost}"
 
 
+class TestShootMovesAlwaysKnown:
+    """Regression tests for GitHub issue #238: Attack covers the player swinging
+    a bow/crossbow at an enemy, while ShootBow/ShootCrossbow cover firing
+    projectiles. Both must always be known by default and gated only by
+    viable() (weapon equipped + ammo present + target in range) — not by a
+    skilltree purchase.
+    """
+
+    def test_shoot_bow_and_crossbow_known_by_default(self):
+        """A fresh Player should know ShootBow and ShootCrossbow without learning them."""
+        player = Player()
+
+        # Engine modules (e.g. src/player) import moves via bare `import moves`,
+        # while tests import via `from src.moves import ...` — these resolve to
+        # distinct module objects, so isinstance() can't be relied on here.
+        # Match by class name instead (same workaround used in test_learn_all_skills.py).
+        assert any(m.__class__.__name__ == "ShootBow" for m in player.known_moves), \
+            "ShootBow should be in known_moves by default"
+        assert any(m.__class__.__name__ == "ShootCrossbow" for m in player.known_moves), \
+            "ShootCrossbow should be in known_moves by default"
+
+    def test_shoot_crossbow_not_purchasable_in_skilltree(self):
+        """ShootCrossbow must not appear as a purchasable Crossbow skill anymore."""
+        player = Player()
+
+        crossbow_skills = player.skilltree.subtypes["Crossbow"]
+        assert not any(skill.__class__.__name__ == "ShootCrossbow" for skill in crossbow_skills), \
+            "ShootCrossbow should no longer be purchasable via the skilltree"
+
+    def test_shoot_bow_not_in_bow_skilltree(self):
+        """ShootBow has never been (and should not become) a purchasable Bow skill."""
+        player = Player()
+
+        bow_skills = player.skilltree.subtypes["Bow"]
+        assert not any(skill.__class__.__name__ == "ShootBow" for skill in bow_skills), \
+            "ShootBow should not be purchasable via the skilltree"
+
+    def test_shoot_bow_from_known_moves_is_viable_with_bow_and_arrows(self):
+        """The default-known ShootBow instance should become viable once a bow
+        is equipped, arrows are carried, and an enemy is in range."""
+        player = Player()
+        player.combat_position = CombatPosition(x=15, y=25, facing=Direction.E)
+        player.combat_proximity = {}
+
+        shoot_bow = next(m for m in player.known_moves if m.__class__.__name__ == "ShootBow")
+
+        # Unarmed: not viable yet
+        assert not shoot_bow.viable()
+
+        player.eq_weapon = Longbow()
+        arrow = WoodenArrow()
+        arrow.count = 20
+        player.inventory.append(arrow)
+
+        enemy = NPC(
+            name="Target",
+            description="A test target",
+            damage=10,
+            aggro=True,
+            exp_award=50,
+            maxhp=100,
+            finesse=5,
+        )
+        enemy.hp = 100
+        enemy.is_alive = lambda: enemy.hp > 0
+        enemy.combat_position = CombatPosition(x=25, y=25, facing=Direction.W)
+        player.combat_proximity[enemy] = 10
+
+        assert shoot_bow.viable(), "ShootBow should be viable with a bow, arrows, and a target in range"
+
+    def test_shoot_crossbow_from_known_moves_is_viable_with_crossbow(self):
+        """The default-known ShootCrossbow instance should become viable once a
+        crossbow is equipped and an enemy is in range."""
+        from src.items import Crossbow as CrossbowWeapon
+
+        player = Player()
+        player.combat_proximity = {}
+
+        shoot_crossbow = next(m for m in player.known_moves if m.__class__.__name__ == "ShootCrossbow")
+
+        # Unarmed: not viable yet
+        assert not shoot_crossbow.viable()
+
+        player.eq_weapon = CrossbowWeapon()
+        # NOTE: the real Crossbow item never sets wpnrange (only the unused
+        # range_base/range_decay pair), so it inherits the Weapon base class's
+        # melee default of (0, 5) — a separate, pre-existing bug from this
+        # issue. Set it explicitly here so this test exercises ShootCrossbow's
+        # acquisition fix in isolation, not that unrelated item-stat bug.
+        player.eq_weapon.wpnrange = (6, 40)
+        # In real combat, combat_adapter calls advance()/evaluate() on every known
+        # move every beat, which refreshes cached fields like mvrange from the
+        # newly-equipped weapon. Mirror that refresh here rather than relying on
+        # the stale mvrange captured at Player() construction time (when Fists
+        # was equipped).
+        shoot_crossbow.evaluate()
+
+        enemy = NPC(
+            name="Target",
+            description="A test target",
+            damage=10,
+            aggro=True,
+            exp_award=50,
+            maxhp=100,
+            finesse=5,
+        )
+        enemy.hp = 100
+        enemy.is_alive = lambda: enemy.hp > 0
+        player.combat_proximity[enemy] = 15
+
+        assert shoot_crossbow.viable(), "ShootCrossbow should be viable with a crossbow and a target in range"
+
+
 class TestSpecialAbilities:
     """Test suite for special abilities with coordinate system."""
 

--- a/tests/test_bow_and_abilities.py
+++ b/tests/test_bow_and_abilities.py
@@ -334,17 +334,16 @@ class TestShootMovesAlwaysKnown:
         assert not shoot_crossbow.viable()
 
         player.eq_weapon = CrossbowWeapon()
-        # NOTE: the real Crossbow item never sets wpnrange (only the unused
-        # range_base/range_decay pair), so it inherits the Weapon base class's
-        # melee default of (0, 5) — a separate, pre-existing bug from this
-        # issue. Set it explicitly here so this test exercises ShootCrossbow's
-        # acquisition fix in isolation, not that unrelated item-stat bug.
-        player.eq_weapon.wpnrange = (6, 40)
-        # In real combat, combat_adapter calls advance()/evaluate() on every known
-        # move every beat, which refreshes cached fields like mvrange from the
-        # newly-equipped weapon. Mirror that refresh here rather than relying on
-        # the stale mvrange captured at Player() construction time (when Fists
-        # was equipped).
+        # Crossbow.wpnrange stays at the Weapon base class's melee default of
+        # (0, 5) — that's correct, since Attack (swinging the crossbow) uses
+        # wpnrange. ShootCrossbow's own range comes from the weapon's
+        # range_base/range_decay instead (mirroring ShootBow), so no wpnrange
+        # override is needed here.
+        # In real combat, combat_adapter calls advance()/evaluate() on every
+        # known move every beat, which refreshes cached fields like
+        # power/fatigue_cost from the newly-equipped weapon. Mirror that
+        # refresh here rather than relying on the stale values captured at
+        # Player() construction time (when Fists was equipped).
         shoot_crossbow.evaluate()
 
         enemy = NPC(
@@ -361,6 +360,88 @@ class TestShootMovesAlwaysKnown:
         player.combat_proximity[enemy] = 15
 
         assert shoot_crossbow.viable(), "ShootCrossbow should be viable with a crossbow and a target in range"
+
+    def test_attack_stays_melee_range_while_shoot_bow_reaches_long_range(self):
+        """Attack (swinging the bow) stays melee-range (wpnrange=(0,5)),
+        while ShootBow (firing an arrow) reaches its effective long range
+        via range_base/range_decay — same target, same weapon."""
+        player = Player()
+        player.combat_position = CombatPosition(x=15, y=25, facing=Direction.E)
+        player.combat_proximity = {}
+        player.eq_weapon = Longbow()
+        arrow = WoodenArrow()
+        arrow.count = 20
+        player.inventory.append(arrow)
+
+        attack = next(
+            m for m in player.known_moves if m.__class__.__name__ == "Attack"
+        )
+        shoot_bow = next(
+            m for m in player.known_moves if m.__class__.__name__ == "ShootBow"
+        )
+        attack.evaluate()
+
+        enemy = NPC(
+            name="Distant Target",
+            description="A test target",
+            damage=10,
+            aggro=True,
+            exp_award=50,
+            maxhp=100,
+            finesse=5,
+        )
+        enemy.hp = 100
+        enemy.is_alive = lambda: enemy.hp > 0
+        enemy.combat_position = CombatPosition(x=45, y=25, facing=Direction.W)
+        # past melee wpnrange, well within the bow's long range
+        player.combat_proximity[enemy] = 30
+
+        assert not attack.viable(), "Attack should stay melee-range and miss"
+        assert (
+            shoot_bow.viable()
+        ), "ShootBow should reach a target via range_base/range_decay"
+
+    def test_attack_stays_melee_range_while_shoot_crossbow_reaches_long_range(
+        self,
+    ):
+        """Attack (swinging the crossbow) stays melee-range (wpnrange=(0,5)),
+        while ShootCrossbow (firing a bolt) reaches its effective long range
+        via range_base/range_decay — same target, same weapon."""
+        from src.items import Crossbow as CrossbowWeapon
+
+        player = Player()
+        player.combat_proximity = {}
+        player.eq_weapon = CrossbowWeapon()
+
+        attack = next(
+            m for m in player.known_moves if m.__class__.__name__ == "Attack"
+        )
+        shoot_crossbow = next(
+            m
+            for m in player.known_moves
+            if m.__class__.__name__ == "ShootCrossbow"
+        )
+        attack.evaluate()
+        shoot_crossbow.evaluate()
+
+        enemy = NPC(
+            name="Distant Target",
+            description="A test target",
+            damage=10,
+            aggro=True,
+            exp_award=50,
+            maxhp=100,
+            finesse=5,
+        )
+        enemy.hp = 100
+        enemy.is_alive = lambda: enemy.hp > 0
+        # past melee wpnrange, well within the crossbow's long range
+        player.combat_proximity[enemy] = 30
+
+        assert not attack.viable(), "Attack should stay melee-range and miss"
+        assert (
+            shoot_crossbow.viable()
+        ), "ShootCrossbow should reach a target via range_base/range_decay"
 
 
 class TestSpecialAbilities:

--- a/tests/test_combat_adapter_coverage.py
+++ b/tests/test_combat_adapter_coverage.py
@@ -1427,6 +1427,9 @@ class TestGetAvailableTargets:
         move.targeted = True
         move.accepts_ally_target = accepts_ally
         move.verbose_targeting = False
+        # Mirrors the real Move.get_effective_range_max() default (None
+        # means "use mvrange[1]") — see src/moves/_base.py.
+        move.get_effective_range_max.return_value = None
         return move
 
     def test_enemy_in_range_included(self):
@@ -1483,12 +1486,19 @@ class TestGetAvailableTargets:
         player.combat_proximity = {enemy: 3}
         adapter = _make_adapter(player)
         move = MagicMock(
-            spec=["name", "targeted", "accepts_ally_target", "verbose_targeting"]
+            spec=[
+                "name",
+                "targeted",
+                "accepts_ally_target",
+                "verbose_targeting",
+                "get_effective_range_max",
+            ]
         )
         move.name = "Punch"
         move.targeted = True
         move.accepts_ally_target = False
         move.verbose_targeting = False
+        move.get_effective_range_max.return_value = None
         targets = adapter._get_available_targets(move)
         assert len(targets) == 1
 

--- a/tests/test_combat_adapter_gaps2.py
+++ b/tests/test_combat_adapter_gaps2.py
@@ -95,6 +95,9 @@ def _make_move(
     else:
         del m.mvrange
     m.verbose_targeting = verbose_targeting
+    # Mirrors the real Move.get_effective_range_max() default (None means
+    # "use mvrange[1]") — see src/moves/_base.py.
+    m.get_effective_range_max.return_value = None
     return m
 
 
@@ -541,19 +544,20 @@ class TestGetAvailableMovesReasons:
 
 class TestGetAvailableTargetsBranches:
     def test_bow_range_uses_weapon_range(self):
-        move = _make_move("Shoot Bow", targeted=True)
-        weapon = MagicMock()
-        weapon.range_base = 50
-        weapon.range_decay = 10
+        # ShootBow (and other ranged moves) override get_effective_range_max()
+        # to compute range_base + 100/range_decay — _get_available_targets
+        # must use that value instead of mvrange[1]. See
+        # Move.get_effective_range_max in src/moves/_base.py.
+        move = _make_move("Shoot Bow", targeted=True, mvrange=(6, 40))
+        move.get_effective_range_max.return_value = 60  # 50 + 100/10
         player = _make_player()
         player.known_moves = [move]
-        player.eq_weapon = weapon
         enemy = _make_enemy()
         player.combat_list = [enemy]
         player.combat_proximity = {enemy: 55}
         adapter = _make_adapter(player)
         targets = adapter._get_available_targets(move)
-        # Enemy at 55 should be in range if range_max = 50 + 100/10 = 60
+        # Enemy at 55 should be in range since range_max = 60
         assert len(targets) > 0
 
     def test_ally_targets_included_when_accepts_ally(self):

--- a/tests/test_ranged_moves_coverage.py
+++ b/tests/test_ranged_moves_coverage.py
@@ -99,6 +99,11 @@ def _make_crossbow_user(endurance=10, strength=5, finesse=10, intelligence=5):
     wpn.str_mod = 0.3
     wpn.fin_mod = 0.5
     wpn.wpnrange = (6, 40)
+    # Mirrors the real Crossbow item (src/items.py) — ShootCrossbow,
+    # BroadheadBolt, AimedShot, and PinningBolt compute their long range
+    # from these, not wpnrange.
+    wpn.range_base = 15
+    wpn.range_decay = 0.06
     user.eq_weapon = wpn
     user.combat_proximity = {}
     return user
@@ -689,11 +694,20 @@ class TestShootCrossbowEvaluate:
         assert move.power == 0
         assert move.fatigue_cost == 10
 
-    def test_evaluate_uses_weapon_range(self):
+    def test_evaluate_does_not_use_wpnrange(self):
+        """mvrange stays static (melee wpnrange is Attack's territory); the
+        long range comes from range_base/range_decay via
+        get_effective_range_max."""
         user = _make_crossbow_user()
         user.eq_weapon.wpnrange = (8, 60)
         move = ShootCrossbow(user)
-        assert move.mvrange == (8, 60)
+        assert move.mvrange == (6, 40)
+
+    def test_get_effective_range_max_uses_range_base_and_decay(self):
+        user = _make_crossbow_user()  # range_base=15, range_decay=0.06
+        move = ShootCrossbow(user)
+        expected = 15 + (100 / 0.06)
+        assert move.get_effective_range_max(user) == pytest.approx(expected)
 
 
 class TestShootCrossbowExecute:


### PR DESCRIPTION
## Summary

Fixes GitHub issue #238 by making `ShootBow` and `ShootCrossbow` default-known moves that are always available to the player, rather than purchasable skills in the skilltree. These moves represent firing projectiles and should be gated only by `viable()` checks (weapon equipped + ammo/range available), not by skill purchases. The melee `Attack` move continues to handle swinging the weapon itself and remains melee-range only.

## Key Changes

- **Player initialization** (`src/player/__init__.py`): Added `ShootBow` and `ShootCrossbow` to the default `known_moves` list so they are always available without purchase.

- **Skilltree removal** (`src/skilltree.py`): Removed `ShootCrossbow` from the Crossbow skill tree (it was never purchasable as a Bow skill, and `ShootBow` remains non-purchasable).

- **Range calculation refactor** (`src/moves/_ranged.py`):
  - Extracted `_weapon_effective_range_max()` helper to compute decay-based long range (`range_base + 100/range_decay`) consistently across all ranged moves.
  - Updated `ShootBow.get_effective_range_max()` to use the helper.
  - Fixed `ShootCrossbow`, `BroadheadBolt`, `AimedShot`, and `PinningBolt` to:
    - Use `get_effective_range_max()` for long-range viability checks instead of relying on `mvrange[1]`.
    - Removed hardcoded `mvrange` assignments in `evaluate()` (they now stay at the base melee default `(6, 40)`).
    - Updated `viable()` to compute `range_max` dynamically and return `False` if `get_effective_range_max()` returns `None`.

- **Combat adapter** (`src/api/combat_adapter.py`): Generalized range handling in `_get_available_targets()` to call `move.get_effective_range_max()` for any move that overrides it, replacing the hardcoded "Shoot Bow" special case.

- **Move base class** (`src/moves/_base.py`): Added default `get_effective_range_max()` method that returns `None` (meaning "use `mvrange[1]`"), allowing subclasses to override for dynamic range computation.

- **Comprehensive test coverage** (`tests/test_bow_and_abilities.py`): Added `TestShootMovesAlwaysKnown` class with 7 regression tests verifying:
  - `ShootBow` and `ShootCrossbow` are in `known_moves` by default.
  - They are not purchasable in the skilltree.
  - They become viable when equipped with the right weapon, ammo (for bow), and a target in range.
  - `Attack` stays melee-range while `ShootBow`/`ShootCrossbow` reach long range via `range_base/range_decay`.

- **Test updates** (`tests/test_ranged_moves_coverage.py`, `tests/test_combat_adapter_gaps2.py`, `tests/test_combat_adapter_coverage.py`): Updated mocks and assertions to reflect the new range calculation behavior and `get_effective_range_max()` method.

## Implementation Details

- **Separation of concerns**: `Attack` (melee swing) uses `wpnrange` and stays short-range; `ShootBow`/`ShootCrossbow` (projectile fire) use `range_base`/`range_decay` for long range.
- **Backward compatibility**: The `get_effective_range_max()` default returns `None`, so existing moves without dynamic range continue to use `mvrange[1]`.
- **Module import consistency**: Tests match moves by class name (not `isinstance()`) to work around the dual-import issue where engine code uses `import moves` while tests use `from src.moves import ...`.

https://claude.ai/code/session_01KBSbHEs4q3Qm9GsjTL1bKK