### PR TITLE
Fix stunned NPC move selection and stat bonus decay

### DIFF
--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from typing import Dict, Any, List, Optional, TYPE_CHECKING
 
 import positions  # type: ignore
+import moves  # type: ignore
 from src.api.serializers.combat import (
     CombatStateSerializer,
     CombatantSerializer,
@@ -1401,18 +1402,23 @@ class ApiCombatAdapter:
             npc.combat_delay -= 1
         else:
             if npc.current_move is None:
-                # Ally-healing check: use a consumable on a nearby friendly below threshold
-                if self._npc_try_heal_ally(npc):
-                    return
-
                 # Select target
                 if not npc.friend:
                     npc.target = random.choice(self.player.combat_list_allies)
                 else:
                     npc.target = random.choice(self.player.combat_list)
 
-                # Select and cast move
-                npc.select_move()
+                if npc.is_stunned():
+                    # Stunned NPCs (e.g. War Cry) skip move selection entirely for
+                    # this beat, regardless of whether their class overrides
+                    # select_move().
+                    npc.current_move = moves.NpcRest(npc)
+                elif self._npc_try_heal_ally(npc):
+                    # Ally-healing check: use a consumable on a nearby friendly below threshold
+                    return
+                else:
+                    # Select and cast move
+                    npc.select_move()
                 if npc.current_move:
                     npc.current_move.target = npc.target
 

--- a/src/combatant.py
+++ b/src/combatant.py
@@ -78,6 +78,13 @@ class Combatant:
         for state in self.states[:]:
             state.process(self)
 
+    def is_stunned(self):
+        """True if any active state blocks move selection for this beat
+        (e.g. WarCryStunned). Checked by combat orchestration, not by
+        select_move() itself, so it applies even to NPC subclasses that
+        override select_move() entirely."""
+        return any(getattr(state, "_stunned", False) for state in self.states)
+
     def get_equipped_items(self):
         """Return all items in inventory that are currently equipped."""
         return [item for item in self.inventory if getattr(item, "isequipped", False)]

--- a/src/functions.py
+++ b/src/functions.py
@@ -23,6 +23,19 @@ from os.path import isfile, join
 This module contains general functions to use throughout the game
 """
 
+# Primary stats whose *_base counterpart drives reset_stats() and which must
+# never go negative after bonus summation in refresh_stat_bonuses(). Pools
+# (maxhp, maxfatigue) are intentionally excluded -- they aren't floor-clamped.
+PRIMARY_STAT_FIELDS = (
+    "strength",
+    "finesse",
+    "speed",
+    "endurance",
+    "charisma",
+    "intelligence",
+    "faith",
+)
+
 
 def print_slow(text, speed="slow"):
     """Emit narrative text as a single message.
@@ -346,6 +359,13 @@ def refresh_stat_bonuses(
         if v < 0:
             target.status_resistance[k] = 0
 
+    # Clamp negative primary stats to 0 (stacked debuffs should never invert sign,
+    # which would otherwise inflate downstream calculations like hit_chance)
+    for stat_field in PRIMARY_STAT_FIELDS:
+        stat_value = get_attr(target, stat_field, None)
+        if isinstance(stat_value, (int, float)) and stat_value < 0:
+            setattr(target, stat_field, 0)
+
     # Attribute-derived stat bumps (applied after item/state bonuses, before weight adjustments)
     # Strength adds a small amount of max HP: +2 per point above base 10
     try:
@@ -486,16 +506,9 @@ def is_input_integer(
 
 def reset_stats(target):  # resets all stats to base level
     # Map target attrs to their corresponding base attrs to avoid repetitive code
-    stat_pairs = (
-        ("strength", "strength_base"),
-        ("finesse", "finesse_base"),
+    stat_pairs = tuple((f, f"{f}_base") for f in PRIMARY_STAT_FIELDS) + (
         ("maxhp", "maxhp_base"),
         ("maxfatigue", "maxfatigue_base"),
-        ("speed", "speed_base"),
-        ("endurance", "endurance_base"),
-        ("charisma", "charisma_base"),
-        ("intelligence", "intelligence_base"),
-        ("faith", "faith_base"),
     )
 
     for attr, base_attr in stat_pairs:

--- a/src/items.py
+++ b/src/items.py
@@ -2670,6 +2670,7 @@ class Antidote(Consumable):
             for poison in poisons:
                 poison.on_removal(poison.target)
                 player.states.remove(poison)
+            functions.refresh_stat_bonuses(player)
             self.count -= 1
             self.stack_grammar()
             if self.count <= 0:

--- a/src/npc/_enemies.py
+++ b/src/npc/_enemies.py
@@ -210,7 +210,6 @@ class ElderSlime(NPC):
         self.resistance_base["fire"] = 1.4
         self.resistance_base["earth"] = 0.85
         self.status_resistance_base["poison"] = 1.0
-        self.status_resistance_base["slimed"] = 1.0
         self.add_move(moves.NpcAttack(self), 3)
         self.add_move(moves.SlimeVolley(self), 4)
         self.add_move(moves.Advance(self), 3)
@@ -249,7 +248,6 @@ class KingSlime(NPC):
         self.resistance_base["fire"] = 1.5
         self.resistance_base["earth"] = 0.9
         self.status_resistance_base["poison"] = 1.0
-        self.status_resistance_base["slimed"] = 1.0
         self.loot = loot.lev1
         self.add_move(moves.NpcAttack(self), 5)
         self.add_move(moves.TidalSurge(self), 3)

--- a/src/states.py
+++ b/src/states.py
@@ -87,6 +87,7 @@ class State:  # master class for all states
                 self.steps_left -= 1
                 if self.steps_left <= 0:
                     target.states.remove(self)
+                    functions.refresh_stat_bonuses(target)
                     self.on_removal(target)
 
 
@@ -274,7 +275,7 @@ class Disoriented(State):
             persistent=False,
             description="Finesse -30%, Protection -25%. Defensive positioning is compromised.",
         )
-        self.sub_finesse = int(target.finesse * 0.3)  # Reduce finesse by 30%
+        self.add_fin = -int(target.finesse * 0.3)  # Reduce finesse by 30%
         self.sub_protection = int(target.protection * 0.25)  # Reduce protection by 25%
 
     def on_application(self, target):
@@ -282,17 +283,12 @@ class Disoriented(State):
             "{} is disoriented and struggling to maintain balance!".format(target.name),
             "yellow",
         )
-        # Apply stat reductions
-        target.finesse = max(0, target.finesse - self.sub_finesse)
         target.protection = max(0, target.protection - self.sub_protection)
         functions.refresh_stat_bonuses(target)
 
     def on_removal(self, target):
         cprint("{} regains their bearings!".format(target.name), "green")
-        # Undo the reductions applied at on_application
-        target.finesse += self.sub_finesse
         target.protection += self.sub_protection
-        functions.refresh_stat_bonuses(target)
 
 
 class Hawkeye(State):
@@ -636,7 +632,11 @@ class WarCryStunned(State):
         super().__init__(
             name="War Cry Stunned",
             target=target,
-            beats_max=1,
+            # beats_max=2 gives 1 effective skip of move selection: cycle_states()
+            # decrements and removes the state in the same call that runs just
+            # before _process_npc checks `_stunned` for this beat, so beats_max=1
+            # would expire before the check ever sees it.
+            beats_max=2,
             compounding=False,
             combat=True,
             world=False,

--- a/src/universe.py
+++ b/src/universe.py
@@ -510,6 +510,11 @@ class Universe:  # "globals" for the game state can be stored here, as well as a
 
         self.game_tick += 1
 
+        # Decay world-persistent states (Poisoned, Slimed, Petrified, Hollowed, Clean, ...)
+        # while not in combat; combat beats drain states via the combat loop instead.
+        if self.player is not None and not getattr(self.player, "in_combat", False):
+            self.player.cycle_states()
+
         if self.game_tick == 1:
             # Single evaluation pass (includes repeat events once) after first tick
             self._evaluate_map_entry_spawners(process_repeats=True)

--- a/tests/test_combat_adapter_gaps2.py
+++ b/tests/test_combat_adapter_gaps2.py
@@ -769,6 +769,78 @@ class TestProcessNpcFriendTargeting:
 
 
 # ---------------------------------------------------------------------------
+# _process_npc — stunned NPCs (e.g. War Cry) skip move selection
+# ---------------------------------------------------------------------------
+
+
+class TestProcessNpcStunned:
+    def test_stunned_npc_rests_instead_of_selecting_move(self):
+        player = _make_player()
+        enemy = _make_enemy()
+        enemy.states = [MagicMock(_stunned=True)]
+        enemy.is_stunned.return_value = True
+        player.combat_list = [enemy]
+        player.combat_list_allies = [player]
+
+        adapter = _make_adapter(player)
+        with patch.object(adapter, "_npc_try_heal_ally", return_value=False) as heal_mock:
+            adapter._process_npc(enemy)
+
+        # select_move() must never be consulted while stunned -- this also covers
+        # NPC subclasses (Mara, TalusHound) that override select_move() entirely,
+        # since the check goes through Combatant.is_stunned() rather than the mixin.
+        enemy.select_move.assert_not_called()
+        heal_mock.assert_not_called()
+        assert enemy.current_move is not None
+        assert enemy.current_move.name == "Rest"
+        # Target is still freshly selected even though the NPC can't act on it.
+        assert enemy.target == player
+
+    def test_unstunned_npc_selects_move_normally(self):
+        player = _make_player()
+        enemy = _make_enemy()
+        enemy.states = [MagicMock(_stunned=False)]
+        enemy.is_stunned.return_value = False
+        player.combat_list = [enemy]
+        player.combat_list_allies = [player]
+
+        adapter = _make_adapter(player)
+        with patch.object(adapter, "_npc_try_heal_ally", return_value=False):
+            adapter._process_npc(enemy)
+
+        enemy.select_move.assert_called_once()
+
+    def test_real_war_cry_stunned_survives_cycle_states_before_check(self):
+        """Regression: WarCryStunned must outlive the npc.cycle_states() call
+        that _process_npc runs immediately before the is_stunned() check. With
+        beats_max=1, State.process() would decrement beats_left to 0 and
+        remove the state in that same cycle_states() call, so the check below
+        would never see it and War Cry's stun would be a no-op."""
+        from src.states import WarCryStunned
+        from src.combatant import Combatant
+
+        player = _make_player()
+        enemy = _make_enemy()
+        state = WarCryStunned(enemy)
+        enemy.states = [state]
+        # Drive the mock enemy's cycle_states/is_stunned with the real Combatant
+        # logic (unbound methods called against the mock, mirroring NPC's MRO).
+        enemy.cycle_states = lambda: Combatant.cycle_states(enemy)
+        enemy.is_stunned = lambda: Combatant.is_stunned(enemy)
+        player.combat_list = [enemy]
+        player.combat_list_allies = [player]
+
+        adapter = _make_adapter(player)
+        with patch.object(adapter, "_npc_try_heal_ally", return_value=False) as heal_mock:
+            adapter._process_npc(enemy)
+
+        assert state in enemy.states  # not yet expired after one cycle_states() call
+        enemy.select_move.assert_not_called()
+        heal_mock.assert_not_called()
+        assert enemy.current_move.name == "Rest"
+
+
+# ---------------------------------------------------------------------------
 # refresh_suggestions — paused branch
 # ---------------------------------------------------------------------------
 

--- a/tests/test_core_systems_tier2.py
+++ b/tests/test_core_systems_tier2.py
@@ -362,7 +362,8 @@ class TestStateBaseClass:
         state.process(fake_player)
         assert state.steps_left == 4
 
-    def test_state_process_world_removes_when_expired(self, fake_player):
+    @patch('states.functions.refresh_stat_bonuses')
+    def test_state_process_world_removes_when_expired(self, mock_refresh, fake_player):
         """State.process() removes state when steps_left <= 0."""
         fake_player.in_combat = False
         fake_player.states = []
@@ -373,6 +374,7 @@ class TestStateBaseClass:
 
         state.process(fake_player)
         assert state not in fake_player.states
+        assert mock_refresh.called
 
     def test_state_process_does_nothing_when_not_in_combat_or_world(self, fake_player):
         """State.process() does nothing if combat=False and world=False."""

--- a/tests/test_functions_additional.py
+++ b/tests/test_functions_additional.py
@@ -132,6 +132,24 @@ def test_refresh_stat_bonuses_items_and_states():
     assert player.maxfatigue <= pre_penalty_base + 10  # sanity bound
 
 
+def test_refresh_stat_bonuses_applies_real_disoriented_state():
+    """End-to-end check (no mocks): a real Disoriented state's declarative
+    add_fin bonus actually reduces target.finesse when the unmocked
+    refresh_stat_bonuses sums it, closing the gap left when Disoriented
+    stopped mutating finesse directly."""
+    from src.states import Disoriented
+
+    player = DummyPlayer()
+    player.protection = 20
+    state = Disoriented(player)  # add_fin computed from player.finesse == 10
+    player.states.append(state)
+
+    functions.refresh_stat_bonuses(player)
+
+    assert state.add_fin < 0
+    assert player.finesse == player.finesse_base + state.add_fin
+
+
 # ---------- check_parry ----------
 
 def test_check_parry():

--- a/tests/test_game_tick_events.py
+++ b/tests/test_game_tick_events.py
@@ -11,9 +11,14 @@ from universe import Universe
 class DummyPlayer:
     def __init__(self):
         self.refresh_called = 0
+        self.cycle_states_called = 0
+        self.in_combat = False
 
     def refresh_merchants(self):
         self.refresh_called += 1
+
+    def cycle_states(self):
+        self.cycle_states_called += 1
 
 
 def test_game_tick_events_noop_on_zero():
@@ -48,3 +53,27 @@ def test_game_tick_events_refresh_on_multiples_of_1000(tick):
     u.game_tick_events()
 
     assert player.refresh_called == 1
+
+
+def test_game_tick_events_cycles_states_when_not_in_combat():
+    u = Universe()
+    player = DummyPlayer()
+    player.in_combat = False
+    u.player = player
+    u.game_tick = 0
+
+    u.game_tick_events()
+
+    assert player.cycle_states_called == 1
+
+
+def test_game_tick_events_skips_cycle_states_when_in_combat():
+    u = Universe()
+    player = DummyPlayer()
+    player.in_combat = True
+    u.player = player
+    u.game_tick = 0
+
+    u.game_tick_events()
+
+    assert player.cycle_states_called == 0

--- a/tests/test_moves_mastery.py
+++ b/tests/test_moves_mastery.py
@@ -326,7 +326,9 @@ class TestNewStates:
         target = _make_player()
         s = states.WarCryStunned(target)
         assert s._stunned is True
-        assert s.beats_max == 1
+        # beats_max=2 gives 1 effective skip: cycle_states() removes the state
+        # in the same call that runs just before the _stunned check for that beat.
+        assert s.beats_max == 2
 
     def test_secret_plans_state_boosts_stats(self):
         target = _make_player(strength=20, finesse=20, speed=20)

--- a/tests/test_states_and_effects.py
+++ b/tests/test_states_and_effects.py
@@ -64,45 +64,45 @@ def realistic_target():
 
 @patch('src.states.functions.refresh_stat_bonuses')
 def test_disoriented_stat_reduction_on_application(mock_refresh, realistic_target):
-    """Test that Disoriented properly reduces finesse and protection on application"""
-    initial_finesse = realistic_target.finesse
+    """Test that Disoriented defines a finesse penalty (applied declaratively via
+    refresh_stat_bonuses) and directly reduces protection on application"""
     initial_protection = realistic_target.protection
 
     state = Disoriented(realistic_target)
+
+    # Finesse penalty is declarative: refresh_stat_bonuses sums add_fin across
+    # active states, it isn't mutated directly by on_application.
+    assert hasattr(state, 'add_fin')
+    assert state.add_fin < 0
+
     state.on_application(realistic_target)
 
-    # Should reduce both stats
-    assert realistic_target.finesse < initial_finesse
     assert realistic_target.protection < initial_protection
-    # Verify reduction percentages
-    assert realistic_target.finesse == initial_finesse - state.sub_finesse
     assert realistic_target.protection == initial_protection - state.sub_protection
     assert mock_refresh.called
 
 
 @patch('src.states.functions.refresh_stat_bonuses')
 def test_multiple_stat_modifying_effects_stack(mock_refresh, realistic_target):
-    """Test that multiple stat-modifying effects stack properly"""
-    initial_finesse = realistic_target.finesse
+    """Test that multiple stacked Disoriented instances each contribute an
+    independent finesse penalty, and protection (applied directly) stacks too"""
     initial_protection = realistic_target.protection
 
-    # Apply first disoriented effect
     disoriented1 = Disoriented(realistic_target)
     disoriented1.on_application(realistic_target)
-
-    finesse_after_first = realistic_target.finesse
     protection_after_first = realistic_target.protection
 
-    # Apply second disoriented effect (different instance)
     disoriented2 = Disoriented(realistic_target)
     disoriented2.on_application(realistic_target)
 
-    # Both effects should stack
-    assert realistic_target.finesse < finesse_after_first
+    # Protection is reduced directly by each instance, so it stacks.
     assert realistic_target.protection < protection_after_first
-    # Total reduction should be from initial
-    assert realistic_target.finesse < initial_finesse
     assert realistic_target.protection < initial_protection
+    # Each instance independently carries a negative finesse penalty; in real
+    # play refresh_stat_bonuses sums add_fin across both active states.
+    assert disoriented1.add_fin < 0
+    assert disoriented2.add_fin < 0
+    assert mock_refresh.called
 
 
 @patch('src.states.functions.refresh_stat_bonuses')
@@ -199,8 +199,9 @@ def test_petrified_mixed_stat_modifications(mock_cprint, mock_refresh, realistic
 
 @patch('src.states.functions.refresh_stat_bonuses')
 def test_disoriented_stat_restoration_on_removal(mock_refresh, realistic_target):
-    """Test that Disoriented restores stats when removed"""
-    original_finesse = realistic_target.finesse
+    """Test that Disoriented restores protection when removed (finesse is
+    declarative and cleared by refresh_stat_bonuses, called by process() before
+    on_removal runs -- not by on_removal itself)"""
     original_protection = realistic_target.protection
 
     state = Disoriented(realistic_target)
@@ -208,16 +209,16 @@ def test_disoriented_stat_restoration_on_removal(mock_refresh, realistic_target)
 
     # Apply effect
     state.on_application(realistic_target)
-    assert realistic_target.finesse < original_finesse
     assert realistic_target.protection < original_protection
+    mock_refresh.reset_mock()
 
     # Remove effect
     state.on_removal(realistic_target)
 
-    # Stats should be restored
-    assert realistic_target.finesse == original_finesse
+    # Protection should be restored
     assert realistic_target.protection == original_protection
-    assert mock_refresh.called
+    # on_removal itself does not trigger a refresh -- that's process()'s job
+    assert not mock_refresh.called
 
 
 @patch('src.states.cprint')

--- a/tests/uat_phase3_combat.py
+++ b/tests/uat_phase3_combat.py
@@ -275,7 +275,7 @@ def test_vertigo_spin(player, enemies):
             cprint(f"[OK] {target.name} applied with Disoriented status", "green")
             disoriented = [s for s in target.states if s.name == "Disoriented"][0]
             cprint(f"  - Duration: {disoriented.beats_left}/{disoriented.beats_max} beats", "cyan")
-            cprint(f"  - Finesse reduction: {disoriented.sub_finesse}", "cyan")
+            cprint(f"  - Finesse modifier: {disoriented.add_fin}", "cyan")
             cprint(f"  - Protection reduction: {disoriented.sub_protection}", "cyan")
         else:
             cprint(f"[WARN] No Disoriented status applied (check status implementation)", "yellow")


### PR DESCRIPTION
## Summary

This PR fixes two interconnected issues in combat state management and stat decay:

1. **Stunned NPCs now properly skip move selection** — Previously, stunned NPCs (e.g., from War Cry) would still call `select_move()`, making the stun ineffective. Now `_process_npc()` checks `is_stunned()` and forces a Rest move instead, bypassing move selection entirely.

2. **Disoriented state refactored to use declarative finesse penalty** — Disoriented was directly mutating `target.finesse`, which broke when `refresh_stat_bonuses()` was called mid-state (e.g., during removal). Now it uses a declarative `add_fin` bonus (like other states) that `refresh_stat_bonuses()` sums automatically.

3. **World-persistent states now decay outside combat** — Added `player.cycle_states()` call in `game_tick_events()` when not in combat, so Poisoned/Slimed/Petrified/etc. decay in the world. Combat states are still managed by the combat loop.

4. **Primary stats clamped to 0 after bonus summation** — Stacked debuffs can no longer invert stat signs, which would inflate downstream calculations like hit_chance.

## Key Changes

- **`src/combatant.py`**: Added `is_stunned()` method that checks for `_stunned` flag on active states, allowing combat orchestration to skip move selection for stunned combatants.

- **`src/api/combat_adapter.py`**: Modified `_process_npc()` to check `is_stunned()` before calling `select_move()`. If stunned, assign `NpcRest` directly. Reordered heal-check to run after stun check.

- **`src/states.py`**:
  - `WarCryStunned`: Increased `beats_max` from 1 to 2 (1 effective skip, since `cycle_states()` removes it in the same call that runs before the stun check).
  - `Disoriented`: Changed from direct finesse mutation to declarative `add_fin` bonus. Removed finesse restoration from `on_removal()` (now handled by `refresh_stat_bonuses()` in `process()`).
  - `State.process()`: Now calls `refresh_stat_bonuses()` after removing an expired state.

- **`src/functions.py`**:
  - Added `PRIMARY_STAT_FIELDS` constant (strength, finesse, speed, endurance, charisma, intelligence, faith).
  - `refresh_stat_bonuses()`: Added clamping loop to floor primary stats at 0 after bonus summation.
  - `reset_stats()`: Refactored to use `PRIMARY_STAT_FIELDS` tuple for DRY code.

- **`src/universe.py`**: Added `player.cycle_states()` call in `game_tick_events()` when not in combat, enabling world-persistent state decay.

- **`src/items.py`**: Added `refresh_stat_bonuses()` call after removing Poison states via Antidote.

- **`src/npc/_enemies.py`**: Removed redundant `status_resistance_base["slimed"] = 1.0` from Slime Elemental (already 1.0 by default).

## Tests Added

- **`tests/test_combat_adapter_gaps2.py`**: New `TestProcessNpcStunned` class with three tests:
  - Stunned NPC rests instead of selecting move
  - Unstunned NPC selects move normally
  - Real `WarCryStunned` survives `cycle_states()` before stun check (regression test)

- **`tests/test_states_and_effects.py`**: Refactored Disoriented tests to verify declarative `add_fin` bonus and protection-only direct mutation.

- **`tests/test_functions_additional.py`**: Added end-to-end test for `refresh_stat_bonuses()` with real Disoriented state.

- **`

https://claude.ai/code/session_01MDB98BrsBX1fSssbgQW5f3