### PR TITLE
Add Slimed status type and immunity for slime enemies

### DIFF
--- a/src/combatant.py
+++ b/src/combatant.py
@@ -34,6 +34,7 @@ _DEFAULT_STATUS_RESISTANCE = {
     "generic": 1.0,  # Default status type for all states
     "stun": 1.0,  # Unable to move; typically short duration
     "poison": 1.0,  # Drains HP every combat turn/game tick; persists
+    "slimed": 1.0,  # Corrosive slime coating; drains HP and lowers finesse/protection; persists
     "enflamed": 1.0,  # Fire damage over time (matches State.statustype="enflamed")
     "sloth": 1.0,  # Drains Fatigue every combat turn
     "apathy": 1.0,  # Drains HEAT every combat turn

--- a/src/npc/_enemies.py
+++ b/src/npc/_enemies.py
@@ -210,6 +210,7 @@ class ElderSlime(NPC):
         self.resistance_base["fire"] = 1.4
         self.resistance_base["earth"] = 0.85
         self.status_resistance_base["poison"] = 1.0
+        self.status_resistance_base["slimed"] = 1.0
         self.add_move(moves.NpcAttack(self), 3)
         self.add_move(moves.SlimeVolley(self), 4)
         self.add_move(moves.Advance(self), 3)
@@ -248,6 +249,7 @@ class KingSlime(NPC):
         self.resistance_base["fire"] = 1.5
         self.resistance_base["earth"] = 0.9
         self.status_resistance_base["poison"] = 1.0
+        self.status_resistance_base["slimed"] = 1.0
         self.loot = loot.lev1
         self.add_move(moves.NpcAttack(self), 5)
         self.add_move(moves.TidalSurge(self), 3)

--- a/src/player/__init__.py
+++ b/src/player/__init__.py
@@ -117,7 +117,7 @@ class Player(
         # Default status_resistance_base is 1.0 (immune) for all types.
         # Jean is a mortal crusader — he is vulnerable to these status effects.
         # Each value of 0.0 means fully vulnerable; items/levels can raise it.
-        for _stype in ("poison", "stun", "stone", "apathy", "enraged", "disoriented"):
+        for _stype in ("poison", "slimed", "stun", "stone", "apathy", "enraged", "disoriented"):
             self.status_resistance_base[_stype] = 0.0
             self.status_resistance[_stype] = 0.0
         self.weight_tolerance = 20.00

--- a/src/states.py
+++ b/src/states.py
@@ -316,7 +316,7 @@ class Slimed(State):
             compounding=True,
             combat=True,
             world=True,
-            statustype="poison",
+            statustype="slimed",
             persistent=True,
             description="Finesse -20%, Protection -15%. Deals periodic acid damage. Worsens if reapplied.",
         )

--- a/tests/test_core_systems_tier2.py
+++ b/tests/test_core_systems_tier2.py
@@ -155,6 +155,7 @@ class TestCombatantResistances:
         assert 'stun' in obj.status_resistance
         assert 'poison' in obj.status_resistance
         assert 'stone' in obj.status_resistance
+        assert 'slimed' in obj.status_resistance
 
     def test_init_resistances_defaults_to_one_point_zero(self):
         """All resistance values should default to 1.0 (neutral)."""

--- a/tests/test_npc_systems_tier2.py
+++ b/tests/test_npc_systems_tier2.py
@@ -557,6 +557,24 @@ class TestNPCResistances:
         spider = GiantSpider()
         assert spider.status_resistance_base["poison"] == 1
 
+    def test_elder_slime_immune_to_slimed(self):
+        """ElderSlime should be immune to the Slimed status it inflicts on others."""
+        elder = ElderSlime()
+        assert elder.status_resistance_base["slimed"] == 1.0
+        assert elder.status_resistance["slimed"] == 1.0
+        status = Slimed(elder)
+        from functions import inflict
+        assert inflict(status, elder, chance=1.0) is False
+
+    def test_king_slime_immune_to_slimed(self):
+        """KingSlime should be immune to the Slimed status it inflicts on others."""
+        king = KingSlime()
+        assert king.status_resistance_base["slimed"] == 1.0
+        assert king.status_resistance["slimed"] == 1.0
+        status = Slimed(king)
+        from functions import inflict
+        assert inflict(status, king, chance=1.0) is False
+
     def test_status_dummy_zero_resistances(self):
         """Test StatusDummy has neutral damage and zero status resistances."""
         dummy = StatusDummy()

--- a/tests/test_player_core.py
+++ b/tests/test_player_core.py
@@ -40,6 +40,12 @@ class TestPlayerCore:
         assert player.level == 1
         assert player.is_alive() is True
 
+    def test_player_vulnerable_to_slimed(self, player):
+        """Jean must be vulnerable to Slimed (statustype 'slimed'), inflicted by
+        ElderSlime/KingSlime's surge moves, not just to the generic poison default."""
+        assert player.status_resistance_base["slimed"] == 0.0
+        assert player.status_resistance["slimed"] == 0.0
+
     def test_get_hp_pcnt(self, player):
         player.hp = 50
         player.maxhp = 100

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -3,7 +3,7 @@ Unit tests for states module
 """
 import pytest
 from unittest.mock import Mock, patch
-from src.states import State, Dodging, Parrying, Poisoned, Enflamed, Clean, Hawkeye, PhoenixRevive
+from src.states import State, Dodging, Parrying, Poisoned, Enflamed, Clean, Hawkeye, PhoenixRevive, Slimed
 
 
 @pytest.fixture
@@ -322,6 +322,19 @@ def test_clean_on_removal(mock_cprint, mock_target):
     state.on_removal(mock_target)
 
     assert mock_cprint.called
+
+
+def test_slimed_statustype_is_distinct():
+    """Slimed must use its own 'slimed' statustype, not 'poison', so immunity
+    granted against one doesn't silently grant immunity against the other."""
+    target = Mock()
+    target.finesse = 30
+    target.protection = 20
+    state = Slimed(target)
+
+    assert state.statustype == "slimed"
+    assert state.combat is True
+    assert state.world is True
 
 
 def test_hawkeye_initialization(mock_target):


### PR DESCRIPTION
## Summary
Introduces a distinct `"slimed"` status type to differentiate slime-based debuffs from generic poison, allowing slime enemies (ElderSlime, KingSlime) to be immune to their own sliming effects while remaining vulnerable to other status effects.

## Key Changes

- **New status type**: Added `"slimed"` to the global status resistance registry in `src/combatant.py` with default immunity (1.0)
- **Slimed state refactor**: Changed `Slimed` class in `src/states.py` to use `statustype="slimed"` instead of `"poison"`, ensuring immunity to one doesn't silently grant immunity to the other
- **Enemy immunity**: Added `status_resistance_base["slimed"] = 1.0` to ElderSlime and KingSlime in `src/npc/_enemies.py`
- **Player vulnerability**: Added `"slimed"` to Jean's vulnerable status types in `src/player/__init__.py` (alongside poison, stun, stone, apathy, enraged, disoriented)
- **Test coverage**: Added comprehensive tests verifying:
  - ElderSlime and KingSlime are immune to Slimed status
  - Slimed uses distinct `"slimed"` statustype (not poison)
  - Player is vulnerable to Slimed (0.0 resistance)
  - Status resistance registry includes the new type

## Implementation Details

The change maintains backward compatibility by treating `"slimed"` as a first-class status type in the resistance system. Slime enemies now properly resist their own debuff while remaining vulnerable to other effects, and players can be specifically targeted by slime-based surge moves without inheriting poison immunity.

https://claude.ai/code/session_01DkXRjQfgCg2P3zSftunBvy