### PR TITLE
fix(combat): call is_alive() at ~40 move sites so dead-target guards fire

### DIFF
--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1367,8 +1367,10 @@ class ApiCombatAdapter:
                 self._process_npc(enemy)
 
             # Check if enemy died (was dead before or died during turn/recoil)
-            # This check must happen regardless of whether they took a turn
-            if not enemy.is_alive():
+            # This check must happen regardless of whether they took a turn.
+            # Consult check_revive() first (mirrors the player path above) so a
+            # combatant carrying a revive state is not silently denied.
+            if not enemy.is_alive() and not enemy.check_revive():
                 enemy.die()
                 if not enemy.is_alive():
                     # Death message is handled by enemy.die() -> print() -> captured by output capture

--- a/src/combat_battlefield.py
+++ b/src/combat_battlefield.py
@@ -879,7 +879,7 @@ class CombatBattlefieldWindow:
             self.set_combatant(
                 player_name,
                 player.combat_position,
-                is_alive=(player.is_alive if hasattr(player, "is_alive") else True),
+                is_alive=(player.is_alive() if hasattr(player, "is_alive") else True),
                 is_player=True,
                 is_ally=True,
                 health_percent=health_pct,
@@ -914,7 +914,7 @@ class CombatBattlefieldWindow:
                 self.set_combatant(
                     ally_name,
                     ally.combat_position,
-                    is_alive=(ally.is_alive if hasattr(ally, "is_alive") else True),
+                    is_alive=(ally.is_alive() if hasattr(ally, "is_alive") else True),
                     is_player=False,
                     is_ally=True,
                     health_percent=health_pct,
@@ -948,7 +948,7 @@ class CombatBattlefieldWindow:
                 self.set_combatant(
                     enemy_name,
                     enemy.combat_position,
-                    is_alive=(enemy.is_alive if hasattr(enemy, "is_alive") else True),
+                    is_alive=(enemy.is_alive() if hasattr(enemy, "is_alive") else True),
                     is_player=False,
                     is_ally=False,
                     health_percent=health_pct,

--- a/src/moves/_dagger.py
+++ b/src/moves/_dagger.py
@@ -220,7 +220,7 @@ class FeintAndPivot(Move):
         ):
             return False
 
-        if not self.target or not self.target.is_alive:
+        if not self.target or not self.target.is_alive():
             return False
 
         if (
@@ -352,7 +352,7 @@ class FeintAndPivot(Move):
 
     def execute(self, user):
         """Execute stage - attack and strategically reposition."""
-        if not self.target or not self.target.is_alive:
+        if not self.target or not self.target.is_alive():
             cprint("Target is no longer available!", "red")
             return
 

--- a/src/moves/_movement.py
+++ b/src/moves/_movement.py
@@ -20,7 +20,7 @@ def _apply_sentinels_vigil(advancer, defender):
         return
     if getattr(getattr(defender, "eq_weapon", None), "subtype", None) != "Spear":
         return
-    if not getattr(advancer, "is_alive", True):
+    if hasattr(advancer, "is_alive") and not advancer.is_alive():
         return
     damage = max(1, int(defender.eq_weapon.damage * 0.3) + int(defender.strength * 0.2))
     damage = max(0, int(damage - getattr(advancer, "protection", 0)))
@@ -189,13 +189,13 @@ class Advance(Move):
 
         if self.target and self.target in self.user.combat_proximity:
             target_distance = self.user.combat_proximity[self.target]
-            if self.target.is_alive and target_distance > 1:
+            if self.target.is_alive() and target_distance > 1:
                 return True
             return False
 
         # Check for any combatant (enemy or ally) farther than adjacent
         for combatant, distance in self.user.combat_proximity.items():
-            if combatant.is_alive and distance > 1:
+            if combatant.is_alive() and distance > 1:
                 return True
         return False
 
@@ -207,12 +207,12 @@ class Advance(Move):
 
     def beat_update(self, user):
         if self.current_stage == 1:  # Execute stage
-            if not self.target or not self.target.is_alive:
+            if not self.target or not self.target.is_alive():
                 # Try to find a new target if possible
                 nearest_enemy = None
                 min_dist = float("inf")
                 for enemy in user.combat_proximity.keys():
-                    if enemy.is_alive:
+                    if enemy.is_alive():
                         dist = user.combat_proximity[enemy]
                         if dist < min_dist:
                             min_dist = dist
@@ -302,7 +302,7 @@ class Advance(Move):
             _apply_sentinels_vigil(user, self.target)
 
     def execute(self, user):
-        if self.target and self.target.is_alive:
+        if self.target and self.target.is_alive():
             cprint(
                 "{} finished advancing on {}.".format(user.name, self.target.name),
                 "green" if user.name == "Jean" else "red",
@@ -476,7 +476,7 @@ class BullCharge(Move):
 
     def beat_update(self, user):
         if self.current_stage == 1:  # Execute stage
-            if not self.target or not self.target.is_alive:
+            if not self.target or not self.target.is_alive():
                 return
 
             if self.can_use_coordinates(user):
@@ -525,7 +525,7 @@ class BullCharge(Move):
         self.target.combat_proximity[user] = user.combat_proximity[self.target]
 
     def execute(self, user):
-        if self.target and self.target.is_alive:
+        if self.target and self.target.is_alive():
             cprint(
                 f"{user.name} slammed into {self.target.name} during the charge!",
                 "green" if user.name == "Jean" else "red",
@@ -664,7 +664,7 @@ class FlankingManeuver(Move):
 
     def beat_update(self, user):
         if self.current_stage == 1:  # Execute stage
-            if not self.target or not self.target.is_alive:
+            if not self.target or not self.target.is_alive():
                 return
 
             if self.can_use_coordinates(user):
@@ -688,7 +688,7 @@ class FlankingManeuver(Move):
     def execute(self, user):
         if (
             self.target
-            and self.target.is_alive
+            and self.target.is_alive()
             and hasattr(user, "combat_position")
             and user.combat_position
         ):
@@ -710,7 +710,7 @@ class FlankingManeuver(Move):
                     f"{user.name} moved to the side of {self.target.name}!",
                     "green",
                 )
-        elif self.target and self.target.is_alive:
+        elif self.target and self.target.is_alive():
             cprint(f"{user.name} finished maneuvering.", "green")
 
 
@@ -799,7 +799,7 @@ class TacticalPositioning(Move):
 
     def beat_update(self, user):
         if self.current_stage == 1:  # Execute
-            if not self.target or not self.target.is_alive:
+            if not self.target or not self.target.is_alive():
                 return
 
             # Initialization of actual target distance with variance
@@ -877,7 +877,7 @@ class TacticalPositioning(Move):
         self.target.combat_proximity[user] = user.combat_proximity[self.target]
 
     def execute(self, user):
-        if self.target and self.target.is_alive:
+        if self.target and self.target.is_alive():
             cprint(
                 "{} finished adjusting position relative to {}.".format(
                     user.name, self.target.name

--- a/src/moves/_pick.py
+++ b/src/moves/_pick.py
@@ -127,7 +127,7 @@ class ChipAway(Move):
             else:
                 cprint(f"Strike {i + 1} missed!", "yellow")
 
-            if not self.target.is_alive:
+            if not self.target.is_alive():
                 break
 
         if hasattr(user, "eq_weapon") and user.eq_weapon:
@@ -245,14 +245,18 @@ class ExploitWeakness(Move):
                 self.parry()
             else:
                 self.hit(damage, glance)
-                if self.target and self.target.is_alive:
+                if self.target and self.target.is_alive():
                     already = any(
                         isinstance(s, states.Disoriented) for s in self.target.states
                     )
                     if not already:
                         try:
-                            self.target.states.append(states.Disoriented(self.target))
-                            cprint(f"{self.target.name} is disoriented!", "red")
+                            if functions.inflict(
+                                states.Disoriented(self.target), self.target
+                            ):
+                                cprint(
+                                    f"{self.target.name} is disoriented!", "red"
+                                )
                         except Exception:
                             pass
         else:
@@ -372,7 +376,7 @@ class Stupefy(Move):
                 self.parry()
             else:
                 self.hit(damage, glance)
-                if self.target and self.target.is_alive:
+                if self.target and self.target.is_alive():
                     # Remove existing Disoriented, apply fresh one
                     self.target.states = [
                         s

--- a/src/moves/_pick.py
+++ b/src/moves/_pick.py
@@ -251,12 +251,11 @@ class ExploitWeakness(Move):
                     )
                     if not already:
                         try:
-                            if functions.inflict(
+                            # inflict() emits the disoriented message via
+                            # Disoriented.on_application when the state lands.
+                            functions.inflict(
                                 states.Disoriented(self.target), self.target
-                            ):
-                                cprint(
-                                    f"{self.target.name} is disoriented!", "red"
-                                )
+                            )
                         except Exception:
                             pass
         else:

--- a/src/moves/_polearm.py
+++ b/src/moves/_polearm.py
@@ -136,7 +136,7 @@ class Sweep(Move):
             return False
         if not hasattr(self.user, "combat_proximity"):
             return False
-        return any(e.is_alive for e in self.user.combat_proximity)
+        return any(e.is_alive() for e in self.user.combat_proximity)
 
     def evaluate(self):
         try:
@@ -170,7 +170,7 @@ class Sweep(Move):
         arc_range = self.mvrange[1]
 
         for enemy in list(self.user.combat_proximity.keys()):
-            if not enemy.is_alive:
+            if not enemy.is_alive():
                 continue
 
             if (
@@ -326,7 +326,7 @@ class HalberdSpin(Move):
         if not hasattr(self.user, "combat_proximity"):
             return False
         return any(
-            e.is_alive and self.user.combat_proximity.get(e, 9999) <= self.mvrange[1]
+            e.is_alive() and self.user.combat_proximity.get(e, 9999) <= self.mvrange[1]
             for e in self.user.combat_proximity
         )
 
@@ -360,7 +360,7 @@ class HalberdSpin(Move):
         arc_range = self.mvrange[1]
 
         for enemy in list(self.user.combat_proximity.keys()):
-            if not enemy.is_alive:
+            if not enemy.is_alive():
                 continue
 
             if (

--- a/src/moves/_ranged.py
+++ b/src/moves/_ranged.py
@@ -906,7 +906,7 @@ class PinningBolt(Move):
                 self.parry()
             else:
                 self.hit(damage, glance)
-                if self.target and self.target.is_alive:
+                if self.target and self.target.is_alive():
                     already = any(
                         isinstance(s, states.Disoriented) for s in self.target.states
                     )

--- a/src/moves/_scythe.py
+++ b/src/moves/_scythe.py
@@ -58,7 +58,7 @@ class Reap(Move):
             return False
         if not hasattr(self.user, "combat_proximity"):
             return False
-        return any(e.is_alive for e in self.user.combat_proximity)
+        return any(e.is_alive() for e in self.user.combat_proximity)
 
     def evaluate(self):
         try:
@@ -81,7 +81,7 @@ class Reap(Move):
         arc_range = wpn_range[1]
 
         for enemy in list(self.user.combat_proximity.keys()):
-            if not enemy.is_alive:
+            if not enemy.is_alive():
                 continue
 
             # Frontal arc check when coordinates available
@@ -187,13 +187,13 @@ class ReapersMark(Move):
             return False
         if not hasattr(self.user, "combat_proximity"):
             return False
-        return any(e.is_alive for e in self.user.combat_proximity)
+        return any(e.is_alive() for e in self.user.combat_proximity)
 
     def evaluate(self):
         pass
 
     def execute(self, user):
-        if self.target and self.target.is_alive:
+        if self.target and self.target.is_alive():
             self.target._reapers_mark = True
             cprint(
                 f"{user.name} marks {self.target.name} — death follows close behind.",

--- a/src/moves/_spear.py
+++ b/src/moves/_spear.py
@@ -122,7 +122,7 @@ class KeepAway(Move):
             else:
                 self.hit(damage, glance)
                 # Push target back
-                if self.target and self.target.is_alive:
+                if self.target and self.target.is_alive():
                     self._push_target(player)
         else:
             self.miss()
@@ -244,7 +244,7 @@ class Lunge(Move):
         self.prep_colors()
 
         # Step toward target
-        if self.target and self.target.is_alive:
+        if self.target and self.target.is_alive():
             try:
                 if (
                     hasattr(player, "combat_position")

--- a/src/moves/_sword.py
+++ b/src/moves/_sword.py
@@ -518,12 +518,11 @@ class DisarmingSlash(Move):
                     )
                     if not already:
                         try:
-                            if functions.inflict(
+                            # inflict() emits the disoriented message via
+                            # Disoriented.on_application when the state lands.
+                            functions.inflict(
                                 states.Disoriented(self.target), self.target
-                            ):
-                                cprint(
-                                    f"{self.target.name} is disoriented!", "red"
-                                )
+                            )
                         except Exception:
                             pass
         else:

--- a/src/moves/_sword.py
+++ b/src/moves/_sword.py
@@ -129,7 +129,7 @@ class WhirlAttack(Move):
 
         # Check if there are enemies within range
         for enemy in self.user.combat_proximity.keys():
-            if enemy.is_alive:
+            if enemy.is_alive():
                 if (
                     hasattr(enemy, "combat_position")
                     and enemy.combat_position is not None
@@ -173,7 +173,7 @@ class WhirlAttack(Move):
 
         # Find all enemies in range
         for enemy in list(self.user.combat_proximity.keys()):
-            if not enemy.is_alive:
+            if not enemy.is_alive():
                 continue
 
             if hasattr(enemy, "combat_position") and enemy.combat_position is not None:
@@ -249,7 +249,7 @@ class VertigoSpin(Move):
         ):
             return False
 
-        if not self.target or not self.target.is_alive:
+        if not self.target or not self.target.is_alive():
             return False
 
         if (
@@ -289,7 +289,7 @@ class VertigoSpin(Move):
 
     def execute(self, user):
         """Execute stage - spin attack and apply Disoriented status."""
-        if not self.target or not self.target.is_alive:
+        if not self.target or not self.target.is_alive():
             cprint("Target is no longer available!", "red")
             return
 
@@ -512,14 +512,18 @@ class DisarmingSlash(Move):
                 self.parry()
             else:
                 self.hit(damage, glance)
-                if self.target and self.target.is_alive:
+                if self.target and self.target.is_alive():
                     already = any(
                         isinstance(s, states.Disoriented) for s in self.target.states
                     )
                     if not already:
                         try:
-                            self.target.states.append(states.Disoriented(self.target))
-                            cprint(f"{self.target.name} is disoriented!", "red")
+                            if functions.inflict(
+                                states.Disoriented(self.target), self.target
+                            ):
+                                cprint(
+                                    f"{self.target.name} is disoriented!", "red"
+                                )
                         except Exception:
                             pass
         else:

--- a/src/moves/_unarmed.py
+++ b/src/moves/_unarmed.py
@@ -167,9 +167,9 @@ class PowerStrike(Move):
                     getattr(m, "name", "") == "Heavy Handed"
                     for m in getattr(self.user, "known_moves", [])
                 ):
-                    if self.target and self.target.is_alive:
+                    if self.target and self.target.is_alive():
                         try:
-                            self.target.states.append(states.Staggered(self.target))
+                            functions.inflict(states.Staggered(self.target), self.target)
                         except Exception:
                             pass
         else:
@@ -299,9 +299,9 @@ class Jab(Move):
                     getattr(m, "name", "") == "Heavy Handed"
                     for m in getattr(self.user, "known_moves", [])
                 ):
-                    if self.target and self.target.is_alive:
+                    if self.target and self.target.is_alive():
                         try:
-                            self.target.states.append(states.Staggered(self.target))
+                            functions.inflict(states.Staggered(self.target), self.target)
                         except Exception:
                             pass
         else:

--- a/src/npc/_enemies.py
+++ b/src/npc/_enemies.py
@@ -297,7 +297,7 @@ class TalusHound(NPC):
             if (
                 npc is not self
                 and isinstance(npc, TalusHound)
-                and getattr(npc, "is_alive", True)
+                and (not hasattr(npc, "is_alive") or npc.is_alive())
             ):
                 pack_count += 1
         return pack_count

--- a/tests/test_combat_adapter_gaps2.py
+++ b/tests/test_combat_adapter_gaps2.py
@@ -107,6 +107,7 @@ def _make_enemy(name="Goblin", hp=50, maxhp=50, alive=True, speed=5, friend=Fals
     e.hp = hp
     e.maxhp = maxhp
     e.is_alive.return_value = alive
+    e.check_revive.return_value = False
     e.speed = speed
     e.friend = friend
     e.known_moves = []

--- a/tests/test_dead_flags_wiring.py
+++ b/tests/test_dead_flags_wiring.py
@@ -80,7 +80,7 @@ def _make_user(subtype, known_moves=None, **overrides):
     user.combat_list = []
     user.combat_list_allies = []
     user.combat_position = None
-    user.is_alive = True
+    user.is_alive = lambda: True
     user.resistance = dict(RESISTANCE)
     user.eq_weapon = _make_weapon(subtype)
     user.known_moves = known_moves or []
@@ -97,7 +97,7 @@ def _make_target(hp=100, finesse=0, protection=0, known_moves=None, **overrides)
     tgt.finesse = finesse
     tgt.protection = protection
     tgt.states = []
-    tgt.is_alive = True
+    tgt.is_alive = lambda: True
     tgt.combat_position = None
     tgt.combat_proximity = {}
     tgt.resistance = dict(RESISTANCE)

--- a/tests/test_movement_moves_coverage.py
+++ b/tests/test_movement_moves_coverage.py
@@ -56,7 +56,7 @@ def _make_enemy(name="Goblin", hp=50, alive=True):
     e.name = name
     e.hp = hp
     e.maxhp = 100
-    e.is_alive = alive
+    e.is_alive = lambda: alive
     e.speed = 5
     e.combat_proximity = {}
     e.friend = False

--- a/tests/test_moves_polearm.py
+++ b/tests/test_moves_polearm.py
@@ -74,7 +74,7 @@ def _make_user(subtype="Polearm", equip=True):
     user.combat_list = []
     user.combat_list_allies = []
     user.combat_position = None
-    user.is_alive = True
+    user.is_alive = lambda: True
     user.resistance = dict(RESISTANCE)
     if equip:
         user.eq_weapon = _make_weapon(subtype=subtype)
@@ -91,7 +91,7 @@ def _make_target(name="Enemy", hp=100, finesse=5, protection=0):
     tgt.finesse = finesse
     tgt.protection = protection
     tgt.states = []
-    tgt.is_alive = True
+    tgt.is_alive = lambda: True
     tgt.combat_position = None
     tgt.combat_proximity = {}
     tgt.resistance = dict(RESISTANCE)
@@ -180,7 +180,7 @@ class TestSweep:
     def test_viable_false_no_living_enemies(self):
         user = _make_user()
         tgt = _make_target()
-        tgt.is_alive = False
+        tgt.is_alive = lambda: False
         user.combat_proximity = {tgt: 3}
         move = Sweep(user)
         assert move.viable() is False
@@ -248,7 +248,7 @@ class TestSweep:
     def test_execute_skips_dead_enemies(self, monkeypatch):
         user = _make_user()
         tgt = _make_target(hp=0)
-        tgt.is_alive = False
+        tgt.is_alive = lambda: False
         user.combat_proximity = {tgt: 3}
         move = Sweep(user)
         move.power = 20
@@ -458,7 +458,7 @@ class TestHalberdSpin:
         user = _make_user()
         user.combat_position = None
         tgt = _make_target(hp=0)
-        tgt.is_alive = False
+        tgt.is_alive = lambda: False
         user.combat_proximity = {tgt: 5}
         move = HalberdSpin(user)
         move.power = 20

--- a/tests/test_moves_spear_scythe_pick.py
+++ b/tests/test_moves_spear_scythe_pick.py
@@ -97,7 +97,7 @@ def _make_user(subtype="Spear", name="Jean", equip=True):
     user.combat_list = []
     user.combat_list_allies = []
     user.combat_position = None
-    user.is_alive = True
+    user.is_alive = lambda: True
     user.resistance = dict(RESISTANCE)
     if equip:
         user.eq_weapon = _make_weapon(subtype=subtype)
@@ -114,10 +114,11 @@ def _make_target(name="Enemy", hp=100, finesse=5, protection=0):
     tgt.finesse = finesse
     tgt.protection = protection
     tgt.states = []
-    tgt.is_alive = True
+    tgt.is_alive = lambda: True
     tgt.combat_position = None
     tgt.combat_proximity = {}
     tgt.resistance = dict(RESISTANCE)
+    tgt.status_resistance = {}
     tgt.friend = False
     return tgt
 
@@ -279,7 +280,7 @@ class TestLunge:
         move.target = tgt
         move.power = 35
         move.base_damage_type = "piercing"
-        tgt.is_alive = True
+        tgt.is_alive = lambda: True
 
         monkeypatch.setattr(random, "randint", lambda a, b: 0)
         monkeypatch.setattr(random, "uniform", lambda a, b: 1.0)
@@ -295,7 +296,7 @@ class TestLunge:
         """Execute should decrease proximity when no combat_position."""
         user = _make_user("Spear")
         tgt = _make_target(finesse=0, protection=0)
-        tgt.is_alive = True
+        tgt.is_alive = lambda: True
         user.combat_position = None
         tgt.combat_position = None
         user.combat_proximity = {tgt: 10}
@@ -465,7 +466,7 @@ class TestReap:
     def test_viable_false_no_living_enemies(self):
         user = _make_user("Scythe")
         tgt = _make_target()
-        tgt.is_alive = False
+        tgt.is_alive = lambda: False
         user.combat_proximity = {tgt: 5}
         move = Reap(user)
         assert move.viable() is False
@@ -516,7 +517,7 @@ class TestReap:
         user = _make_user("Scythe")
         user.eq_weapon.wpnrange = (0, 10)
         dead_tgt = _make_target(hp=0)
-        dead_tgt.is_alive = False
+        dead_tgt.is_alive = lambda: False
         user.combat_proximity = {dead_tgt: 5}
         move = Reap(user)
         move.power = 20
@@ -570,7 +571,7 @@ class TestReapersMark:
     def test_execute_sets_mark_on_target(self):
         user = _make_user("Scythe")
         tgt = _make_target()
-        tgt.is_alive = True
+        tgt.is_alive = lambda: True
         move = ReapersMark(user)
         move.target = tgt
         move.fatigue_cost = 10
@@ -586,7 +587,7 @@ class TestReapersMark:
 
         class SimpleTarget:
             name = "Ghost"
-            is_alive = False
+            is_alive = staticmethod(lambda: False)
             hp = 0
             maxhp = 100
             states = []
@@ -728,7 +729,7 @@ class TestChipAway:
         user.eq_weapon.subtype = "Pick"
         user.combat_exp["Pick"] = 0
         tgt = _make_target(finesse=0, protection=0)
-        tgt.is_alive = True
+        tgt.is_alive = lambda: True
         move = ChipAway(user)
         move.target = tgt
         move.power = 20
@@ -756,7 +757,7 @@ class TestChipAway:
         user.eq_weapon.subtype = "Pick"
         user.combat_exp["Pick"] = 0
         tgt = _make_target(hp=1, finesse=0, protection=0)
-        tgt.is_alive = True
+        tgt.is_alive = lambda: True
         move = ChipAway(user)
         move.target = tgt
         move.power = 50
@@ -764,7 +765,7 @@ class TestChipAway:
 
         def kill_on_hit(*a, **kw):
             tgt.hp = 0
-            tgt.is_alive = False
+            tgt.is_alive = lambda: False
 
         monkeypatch.setattr(random, "randint", lambda a, b: 0)
         monkeypatch.setattr(random, "uniform", lambda a, b: 1.0)
@@ -780,7 +781,7 @@ class TestChipAway:
         user.eq_weapon.subtype = "Pick"
         user.combat_exp["Pick"] = 0
         tgt = _make_target()
-        tgt.is_alive = True
+        tgt.is_alive = lambda: True
         user.combat_proximity = {tgt: 3}
         user.fatigue = 100
         move = ChipAway(user)
@@ -815,7 +816,7 @@ class TestExploitWeakness:
         user.eq_weapon.subtype = "Pick"
         user.combat_exp["Pick"] = 0
         tgt = _make_target(finesse=0, protection=0)
-        tgt.is_alive = True
+        tgt.is_alive = lambda: True
         tgt.states = []
         move = ExploitWeakness(user)
         move.target = tgt
@@ -839,7 +840,7 @@ class TestExploitWeakness:
         user.eq_weapon.subtype = "Pick"
         user.combat_exp["Pick"] = 0
         tgt = _make_target(finesse=0, protection=0)
-        tgt.is_alive = True
+        tgt.is_alive = lambda: True
         existing = states.Disoriented(tgt)
         tgt.states = [existing]
         move = ExploitWeakness(user)
@@ -876,7 +877,7 @@ class TestStupefy:
         user.eq_weapon.subtype = "Pick"
         user.combat_exp["Pick"] = 0
         tgt = _make_target(finesse=0, protection=0)
-        tgt.is_alive = True
+        tgt.is_alive = lambda: True
         tgt.states = []
         move = Stupefy(user)
         move.target = tgt
@@ -900,7 +901,7 @@ class TestStupefy:
         user.eq_weapon.subtype = "Pick"
         user.combat_exp["Pick"] = 0
         tgt = _make_target(finesse=0, protection=0)
-        tgt.is_alive = True
+        tgt.is_alive = lambda: True
         old_dis = states.Disoriented(tgt)
         tgt.states = [old_dis]
         move = Stupefy(user)

--- a/tests/test_npc_enemies_coverage.py
+++ b/tests/test_npc_enemies_coverage.py
@@ -70,9 +70,9 @@ class TestTalusHoundCountPackMembers:
 
         hound = _make_hound()
         ally1 = TalusHound()
-        ally1.is_alive = True
+        ally1.is_alive = lambda: True
         ally2 = TalusHound()
-        ally2.is_alive = True
+        ally2.is_alive = lambda: True
         hound.combat_list = [hound, ally1, ally2]
         assert hound._count_pack_members() == 2
 
@@ -81,7 +81,7 @@ class TestTalusHoundCountPackMembers:
 
         hound = _make_hound()
         dead = TalusHound()
-        dead.is_alive = False
+        dead.is_alive = lambda: False
         hound.combat_list = [hound, dead]
         assert hound._count_pack_members() == 0
 
@@ -138,7 +138,7 @@ class TestTalusHoundSelectMoveSmallPack:
 
         hound = _make_hound()
         ally = TalusHound()
-        ally.is_alive = True
+        ally.is_alive = lambda: True
         hound.combat_list = [hound, ally]
         assert hound._count_pack_members() == 1
         hound.select_move()
@@ -153,9 +153,9 @@ class TestTalusHoundSelectMoveLargePack:
 
         hound = _make_hound()
         ally1 = TalusHound()
-        ally1.is_alive = True
+        ally1.is_alive = lambda: True
         ally2 = TalusHound()
-        ally2.is_alive = True
+        ally2.is_alive = lambda: True
         hound.combat_list = [hound, ally1, ally2]
         assert hound._count_pack_members() == 2
         hound.select_move()

--- a/tests/test_npc_friends_coverage.py
+++ b/tests/test_npc_friends_coverage.py
@@ -184,7 +184,7 @@ class TestMaraGetOptimalRange:
         m.fatigue = m.maxfatigue
 
         enemy = Mock()
-        enemy.is_alive = True
+        enemy.is_alive = lambda: True
 
         player_ref = Mock()
         player_ref.combat_list = [enemy]
@@ -286,7 +286,7 @@ class TestMaraSelectMove:
     def _make_mara_with_enemy(self, proximity_dist):
         mara = self._make_mara()
         enemy = Mock()
-        enemy.is_alive = True
+        enemy.is_alive = lambda: True
         player_ref = Mock()
         player_ref.combat_list = [enemy]
         mara.player_ref = player_ref

--- a/tests/test_phase3_advanced_moves.py
+++ b/tests/test_phase3_advanced_moves.py
@@ -41,7 +41,7 @@ class TestTurnMove:
         p.fatigue = 100
         p.combat_position = CombatPosition(x=10, y=10, facing=Direction.N)
         p.combat_proximity = {}
-        p.is_alive = True
+        p.is_alive = lambda: True
         return p
 
     @pytest.fixture
@@ -135,7 +135,7 @@ class TestWhirlAttackMove:
         p.strength = 10
         p.finesse = 5
         p.combat_proximity = {}
-        p.is_alive = True
+        p.is_alive = lambda: True
         return p
 
     @pytest.fixture
@@ -256,7 +256,7 @@ class TestFeintAndPivotMove:
         p.strength = 12
         p.finesse = 4
         p.combat_proximity = {}
-        p.is_alive = True
+        p.is_alive = lambda: True
         return p
 
     @pytest.fixture
@@ -310,7 +310,7 @@ class TestFeintAndPivotMove:
 
     def test_feint_not_viable_with_dead_target(self, player, target_enemy):
         """Test FeintAndPivot not viable if target is dead"""
-        target_enemy.is_alive = False
+        target_enemy.is_alive = lambda: False
         feint = FeintAndPivot(player)
         feint.target = target_enemy
         assert not feint.viable()
@@ -375,7 +375,7 @@ class TestVertigoSpinMove:
         p.strength = 14
         p.finesse = 3
         p.combat_proximity = {}
-        p.is_alive = True
+        p.is_alive = lambda: True
         return p
 
     @pytest.fixture
@@ -496,7 +496,7 @@ class TestPhase3MovesIntegration:
         player.protection = 3
         player.speed = 8
         player.combat_proximity = {}
-        player.is_alive = True
+        player.is_alive = lambda: True
         player.states = []
 
         enemies = []

--- a/tests/test_ranged_moves_coverage.py
+++ b/tests/test_ranged_moves_coverage.py
@@ -115,7 +115,7 @@ def _make_enemy(finesse=8, protection=2, resistance=None):
     enemy.finesse = finesse
     enemy.protection = protection
     enemy.states = []
-    enemy.is_alive = True
+    enemy.is_alive = lambda: True
     if resistance is None:
         enemy.resistance = {"piercing": 1.0, "blunt": 1.0, "slashing": 1.0}
     else:


### PR DESCRIPTION
Combatant.is_alive is a method, but across the move package and a few
adjacent sites it was referenced without parentheses, evaluating the
always-truthy bound method instead of calling it. Every dead-target guard,
viable() proximity check, and AoE liveness filter written that way was dead
code — moves proceeded against corpses and stayed viable against all-dead
proximity dicts.

- Append () to all attribute-style is_alive references in moves/* and
  combat_battlefield.py (snapshot now records true liveness).
- Convert the two getattr(x, "is_alive", True) forms (_movement.py,
  npc/_enemies.py) to hasattr-guarded calls.
- Route HeavyHanded Staggered and ExploitWeakness/DisarmingSlash Disoriented
  through functions.inflict() so status_resistance and stacking are honored;
  gate the disoriented message on successful application. Stupefy keeps its
  direct append (applies regardless of resistance, by design).
- Consult enemy.check_revive() before enemy.die() in the combat adapter,
  mirroring the player path so a revive-carrying combatant is not denied.
- Update test fixtures that had encoded the bug (is_alive/check_revive set as
  bools) to expose them as callables.

Closes #258

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gwgxxbg28bYCp9RsX1hpbv