### PR TITLE
fix(states): make protection debuffs/buffs declarative so they survive refresh_stat_bonuses

### DIFF
--- a/src/api/services/session_manager.py
+++ b/src/api/services/session_manager.py
@@ -692,8 +692,6 @@ class SessionManager:
                 except ImportError:
                     from src import functions as _functions
                 _functions.refresh_stat_bonuses(player)
-                if hasattr(player, "refresh_protection_rating"):
-                    player.refresh_protection_rating()
             except Exception as e:
                 print(
                     f"[SessionManager] [ERROR] Error refreshing stats after starting equipment: {e}",

--- a/src/functions.py
+++ b/src/functions.py
@@ -261,7 +261,7 @@ def refresh_stat_bonuses(
          one recognized bonus attribute are collected.
       3. Supported bonus attributes:
            add_str, add_fin, add_maxhp, add_maxfatigue, add_speed, add_endurance,
-           add_charisma, add_intelligence, add_faith, add_weight_tolerance,
+           add_charisma, add_intelligence, add_faith, add_weight_tolerance, add_protection,
            add_resistance (dict), add_status_resistance (dict)
       4. Resistance & status resistance bonuses merge only for keys present in the target's
          base dictionaries. Status resistance cannot drop below 0.
@@ -290,6 +290,7 @@ def refresh_stat_bonuses(
         "add_intelligence": "intelligence",
         "add_faith": "faith",
         "add_weight_tolerance": "weight_tolerance",
+        "add_protection": "protection",
         "add_resistance": "_resistance_dict",  # sentinel: dict merge
         "add_status_resistance": "_status_resistance_dict",  # sentinel: dict merge
     }
@@ -424,13 +425,6 @@ def refresh_stat_bonuses(
             except Exception:
                 pass
 
-    # Refresh protection rating if applicable
-    if hasattr(target, "refresh_protection_rating"):
-        try:
-            target.refresh_protection_rating()
-        except Exception:
-            pass
-
     # Ensure all fatigue values are rounded up to the nearest integer and clamped
     if hasattr(target, "fatigue") and hasattr(target, "maxfatigue"):
         target.maxfatigue = int(math.ceil(target.maxfatigue))
@@ -544,6 +538,20 @@ def reset_stats(target):  # resets all stats to base level
     if hasattr(target, "weight_tolerance") and hasattr(target, "weight_tolerance_base"):
         try:
             target.weight_tolerance = getattr(target, "weight_tolerance_base")
+        except Exception:
+            pass
+
+    # Reset protection to its true base before bonuses (add_protection from states/
+    # items) are summed on top. Player recomputes protection dynamically from gear;
+    # NPCs fall back to the fixed value captured at construction.
+    if hasattr(target, "refresh_protection_rating"):
+        try:
+            target.refresh_protection_rating()
+        except Exception:
+            pass
+    elif hasattr(target, "protection_base"):
+        try:
+            target.protection = target.protection_base
         except Exception:
             pass
 

--- a/src/functions.py
+++ b/src/functions.py
@@ -320,10 +320,14 @@ def refresh_stat_bonuses(
                 adder_group.append(state)
                 break
 
-    # Apply bonuses
+    # Apply bonuses. add_protection is deferred to its own pass below: Player's
+    # refresh_protection_rating() (called after this loop) recomputes protection
+    # from strength/finesse via equipped str_mod/fin_mod, so it must run only
+    # after those stats have been fully bonused -- otherwise it would read their
+    # pre-bonus values.
     for adder in adder_group:
         # Precompute which bonus attributes this adder actually supplies
-        present = [b for b in bonuses_map if hasattr(adder, b)]
+        present = [b for b in bonuses_map if b != "add_protection" and hasattr(adder, b)]
         for bonus_attr in present:
             target_field = bonuses_map[bonus_attr]
             bonus_value = get_attr(adder, bonus_attr)
@@ -424,6 +428,25 @@ def refresh_stat_bonuses(
                         target.maxfatigue = 0
             except Exception:
                 pass
+
+    # Recompute Player's gear-based protection now that strength/finesse/endurance
+    # bonuses above are fully applied (str_mod/fin_mod on equipped armor read the
+    # current, post-bonus values). NPCs already had protection reset to
+    # protection_base in reset_stats and need no further recompute here.
+    if hasattr(target, "refresh_protection_rating"):
+        try:
+            target.refresh_protection_rating()
+        except Exception:
+            pass
+
+    # Sum declarative add_protection bonuses (states/items) on top of the
+    # freshly-established base.
+    for adder in adder_group:
+        if hasattr(adder, "add_protection"):
+            try:
+                target.protection = target.protection + get_attr(adder, "add_protection")
+            except Exception:
+                continue
 
     # Ensure all fatigue values are rounded up to the nearest integer and clamped
     if hasattr(target, "fatigue") and hasattr(target, "maxfatigue"):
@@ -541,15 +564,13 @@ def reset_stats(target):  # resets all stats to base level
         except Exception:
             pass
 
-    # Reset protection to its true base before bonuses (add_protection from states/
-    # items) are summed on top. Player recomputes protection dynamically from gear;
-    # NPCs fall back to the fixed value captured at construction.
-    if hasattr(target, "refresh_protection_rating"):
-        try:
-            target.refresh_protection_rating()
-        except Exception:
-            pass
-    elif hasattr(target, "protection_base"):
+    # Reset protection to its true base before add_protection bonuses (from states/
+    # items) are summed on top. NPCs fall back to the fixed value captured at
+    # construction. Player's protection is recomputed dynamically from gear via
+    # refresh_protection_rating(), but that depends on strength/finesse, which
+    # haven't been re-bonused yet at this point -- so for Player that recompute
+    # happens later in refresh_stat_bonuses, after those bonuses are summed.
+    if hasattr(target, "protection_base"):
         try:
             target.protection = target.protection_base
         except Exception:

--- a/src/items.py
+++ b/src/items.py
@@ -195,7 +195,6 @@ class Item:
                 if "equip" not in self.interactions:
                     self.interactions.append("equip")
                 functions.refresh_stat_bonuses(player)
-                player.refresh_protection_rating()
             except Exception:
                 # If anything goes wrong here, fail gracefully without breaking the equip flow
                 pass
@@ -264,7 +263,6 @@ class Item:
                     if issubclass(self.__class__, Weapon):
                         player.eq_weapon = player.fists
         functions.refresh_stat_bonuses(player)
-        player.refresh_protection_rating()
 
     def take(self, player: "Player", quantity: Optional[int] = None) -> None:
         """Take the item from the ground."""
@@ -408,7 +406,6 @@ class Item:
             self.interactions.remove("unequip")
             self.interactions.append("equip")
             functions.refresh_stat_bonuses(player)
-            player.refresh_protection_rating()
 
 
 class Gold(Item):

--- a/src/player/_inventory.py
+++ b/src/player/_inventory.py
@@ -218,7 +218,6 @@ class PlayerInventoryMixin:
                                 else:
                                     self.skill_exp[target_item.subtype] = 9999
                     functions.refresh_stat_bonuses(self)
-                    self.refresh_protection_rating()
 
     def use_item(self, phrase="", target=None):
         """Use a consumable or special item by phrase match.

--- a/src/player/_ui.py
+++ b/src/player/_ui.py
@@ -123,7 +123,6 @@ class PlayerUIMixin:
     def print_status(self):
         """Print Jean's full status: stats, protection, resistances, and susceptibilities."""
         functions.refresh_stat_bonuses(self)
-        self.refresh_protection_rating()
         cprint("=====\nStatus\n=====\n" "{}".format(self.name_long), "cyan")
         output_grid_data = [
             "Health: {} / {} ({})".format(self.hp, self.maxhp, self.maxhp_base),

--- a/src/states.py
+++ b/src/states.py
@@ -276,19 +276,17 @@ class Disoriented(State):
             description="Finesse -30%, Protection -25%. Defensive positioning is compromised.",
         )
         self.add_fin = -int(target.finesse * 0.3)  # Reduce finesse by 30%
-        self.sub_protection = int(target.protection * 0.25)  # Reduce protection by 25%
+        self.add_protection = -int(target.protection * 0.25)  # Reduce protection by 25%
 
     def on_application(self, target):
         cprint(
             "{} is disoriented and struggling to maintain balance!".format(target.name),
             "yellow",
         )
-        target.protection = max(0, target.protection - self.sub_protection)
         functions.refresh_stat_bonuses(target)
 
     def on_removal(self, target):
         cprint("{} regains their bearings!".format(target.name), "green")
-        target.protection += self.sub_protection
 
 
 class Hawkeye(State):
@@ -323,15 +321,13 @@ class Slimed(State):
         self.tick = 0
         self.execute_on = 6
         self.add_fin = -int(target.finesse * 0.20)
-        self.sub_protection = int(target.protection * 0.15)
+        self.add_protection = -int(target.protection * 0.15)
 
     def on_application(self, target):
-        target.protection = max(0, target.protection - self.sub_protection)
         functions.refresh_stat_bonuses(target)
         cprint("{} is coated in corrosive slime!".format(target.name), "cyan")
 
     def on_removal(self, target):
-        target.protection += self.sub_protection
         cprint("The corrosive slime finally sloughs away from {}.".format(target.name), "white")
 
     def effect(self, target):
@@ -430,10 +426,9 @@ class Petrified(State):
         self.execute_on = 6
         self.add_fin = -int(target.finesse * 0.20)
         self.add_speed = -int(target.speed * 0.35)
-        self.prot_bonus = int(target.protection * 0.25)
+        self.add_protection = int(target.protection * 0.25)
 
     def on_application(self, target):
-        target.protection += self.prot_bonus
         functions.refresh_stat_bonuses(target)
         cprint(
             "Mineral sediment from the pools settles into {}'s joints.".format(target.name),
@@ -441,7 +436,6 @@ class Petrified(State):
         )
 
     def on_removal(self, target):
-        target.protection = max(0, target.protection - self.prot_bonus)
         cprint(
             "The mineral crust cracks and falls away from {}.".format(target.name),
             "white",

--- a/src/states.py
+++ b/src/states.py
@@ -343,6 +343,7 @@ class Slimed(State):
     def compound(self, target):
         cprint("The slime coating on {} thickens!".format(target.name), "cyan")
         self.add_fin -= int(target.finesse * 0.05)
+        self.add_protection -= int(target.protection * 0.05)
         self.beats_max = int(self.beats_max * 1.1)
         self.beats_left = min(self.beats_max, self.beats_left + int(self.beats_max / 4))
         self.steps_max = int(self.steps_max * 1.1)
@@ -461,6 +462,7 @@ class Petrified(State):
         )
         self.add_fin -= int(target.finesse * 0.10)
         self.add_speed -= int(target.speed * 0.10)
+        self.add_protection += int(target.protection * 0.10)
         self.beats_max = int(self.beats_max * 1.1)
         self.beats_left = min(self.beats_max, self.beats_left + int(self.beats_max / 4))
         self.steps_max = int(self.steps_max * 1.1)

--- a/tests/test_functions_additional.py
+++ b/tests/test_functions_additional.py
@@ -223,6 +223,43 @@ def test_refresh_stat_bonuses_real_npc_petrified_protection_bonus():
     assert npc.protection == baseline_protection
 
 
+def test_refresh_stat_bonuses_protection_recompute_sees_buffed_strength():
+    """Player.refresh_protection_rating() scales equipped armor's str_mod/fin_mod
+    bonus by self.strength/self.finesse. That recompute must run *after*
+    add_str/add_fin bonuses from states/items are summed -- otherwise armor
+    bonuses silently ignore active strength/finesse buffs (the bug introduced
+    by originally moving the protection-base reset into reset_stats() ahead of
+    the bonus-summing loop)."""
+    from src.player import Player
+
+    player = Player()
+
+    class StrScalingShield:
+        isequipped = True
+        protection = 5
+        str_mod = 1.0
+
+    player.inventory.append(StrScalingShield())
+    functions.refresh_stat_bonuses(player)
+    baseline_protection = player.protection
+
+    total_str_mod = sum(
+        getattr(item, "str_mod", 0) or 0
+        for item in player.inventory
+        if getattr(item, "isequipped", False)
+    )
+
+    class StrengthBuff:
+        add_str = 20
+
+    player.states.append(StrengthBuff())
+    functions.refresh_stat_bonuses(player)
+
+    assert player.strength == player.strength_base + 20
+    expected_extra = 20 * total_str_mod
+    assert player.protection == baseline_protection + expected_extra
+
+
 # ---------- check_parry ----------
 
 def test_check_parry():

--- a/tests/test_functions_additional.py
+++ b/tests/test_functions_additional.py
@@ -134,20 +134,93 @@ def test_refresh_stat_bonuses_items_and_states():
 
 def test_refresh_stat_bonuses_applies_real_disoriented_state():
     """End-to-end check (no mocks): a real Disoriented state's declarative
-    add_fin bonus actually reduces target.finesse when the unmocked
-    refresh_stat_bonuses sums it, closing the gap left when Disoriented
-    stopped mutating finesse directly."""
+    add_fin/add_protection bonuses actually reduce target.finesse/protection
+    when the unmocked refresh_stat_bonuses sums them, closing the gap left
+    when Disoriented stopped mutating finesse/protection directly (issue #259)."""
     from src.states import Disoriented
 
     player = DummyPlayer()
     player.protection = 20
-    state = Disoriented(player)  # add_fin computed from player.finesse == 10
+    player.protection_base = 20  # lacks refresh_protection_rating; reset_stats
+    # falls back to the protection_base path (mirrors a real NPC's fixed value)
+    state = Disoriented(player)  # add_fin/add_protection computed from current stats
     player.states.append(state)
 
     functions.refresh_stat_bonuses(player)
 
     assert state.add_fin < 0
     assert player.finesse == player.finesse_base + state.add_fin
+    assert state.add_protection < 0
+    assert player.protection == player.protection_base + state.add_protection
+
+    # Idempotency: repeated refreshes while the state remains active must not
+    # keep stacking the penalty (reset_stats restores protection_base first).
+    functions.refresh_stat_bonuses(player)
+    assert player.protection == player.protection_base + state.add_protection
+
+    # Removal: once the state is gone, refresh_stat_bonuses must restore
+    # protection to its true base -- no double-restore, no residual penalty.
+    player.states.remove(state)
+    functions.refresh_stat_bonuses(player)
+    assert player.protection == player.protection_base
+
+
+def test_refresh_stat_bonuses_real_player_protection_survives_recompute():
+    """Reproduces the exact GitHub issue #259 scenario end-to-end with a real
+    Player: Disoriented's protection penalty must not be silently wiped by
+    Player.refresh_protection_rating() recomputing protection from gear, and
+    must not double-restore (inflate) protection when the state expires."""
+    from src.player import Player
+    from src.states import Disoriented
+
+    player = Player()
+    functions.refresh_stat_bonuses(player)
+    baseline_protection = player.protection
+
+    state = Disoriented(player)
+    player.states.append(state)
+    functions.refresh_stat_bonuses(player)
+
+    assert state.add_protection < 0
+    assert player.protection == baseline_protection + state.add_protection
+
+    # Calling refresh_stat_bonuses again (e.g. from an equip/rest path) while
+    # the debuff is still active must not re-stack or wipe the penalty.
+    functions.refresh_stat_bonuses(player)
+    assert player.protection == baseline_protection + state.add_protection
+
+    # Removal restores the original value exactly -- no double-restore.
+    player.states.remove(state)
+    functions.refresh_stat_bonuses(player)
+    assert player.protection == baseline_protection
+
+
+def test_refresh_stat_bonuses_real_npc_petrified_protection_bonus():
+    """Same regression as above but for a real NPC and the Petrified buff
+    (positive add_protection). NPCs have no refresh_protection_rating, so this
+    exercises the protection_base fallback branch in reset_stats()."""
+    from src.npc import NPC
+    from src.states import Petrified
+
+    npc = NPC(name="RockRumbler", description="A lumbering creature", damage=8, aggro=70, exp_award=50, protection=30)
+    functions.refresh_stat_bonuses(npc)
+    baseline_protection = npc.protection
+
+    state = Petrified(npc)
+    npc.states.append(state)
+    functions.refresh_stat_bonuses(npc)
+
+    assert state.add_protection > 0
+    assert npc.protection == baseline_protection + state.add_protection
+
+    # Repeated refresh while active must not keep stacking the bonus.
+    functions.refresh_stat_bonuses(npc)
+    assert npc.protection == baseline_protection + state.add_protection
+
+    # Removal restores the original value exactly -- no double-restore.
+    npc.states.remove(state)
+    functions.refresh_stat_bonuses(npc)
+    assert npc.protection == baseline_protection
 
 
 # ---------- check_parry ----------

--- a/tests/test_states_and_effects.py
+++ b/tests/test_states_and_effects.py
@@ -64,44 +64,50 @@ def realistic_target():
 
 @patch('src.states.functions.refresh_stat_bonuses')
 def test_disoriented_stat_reduction_on_application(mock_refresh, realistic_target):
-    """Test that Disoriented defines a finesse penalty (applied declaratively via
-    refresh_stat_bonuses) and directly reduces protection on application"""
+    """Test that Disoriented defines both finesse and protection penalties
+    declaratively (summed by refresh_stat_bonuses) rather than mutating the
+    target directly -- on_application's only job is to trigger the refresh."""
     initial_protection = realistic_target.protection
 
     state = Disoriented(realistic_target)
 
-    # Finesse penalty is declarative: refresh_stat_bonuses sums add_fin across
-    # active states, it isn't mutated directly by on_application.
+    # Both penalties are declarative: refresh_stat_bonuses sums add_fin/add_protection
+    # across active states; on_application never mutates the target directly.
     assert hasattr(state, 'add_fin')
     assert state.add_fin < 0
+    assert hasattr(state, 'add_protection')
+    assert state.add_protection < 0
+    assert state.add_protection == -int(initial_protection * 0.25)
 
     state.on_application(realistic_target)
 
-    assert realistic_target.protection < initial_protection
-    assert realistic_target.protection == initial_protection - state.sub_protection
+    # on_application defers all stat mutation to refresh_stat_bonuses (mocked here).
+    assert realistic_target.protection == initial_protection
     assert mock_refresh.called
 
 
 @patch('src.states.functions.refresh_stat_bonuses')
 def test_multiple_stat_modifying_effects_stack(mock_refresh, realistic_target):
     """Test that multiple stacked Disoriented instances each contribute an
-    independent finesse penalty, and protection (applied directly) stacks too"""
+    independent finesse and protection penalty (summed later by refresh_stat_bonuses,
+    not applied directly by on_application)"""
     initial_protection = realistic_target.protection
 
     disoriented1 = Disoriented(realistic_target)
     disoriented1.on_application(realistic_target)
-    protection_after_first = realistic_target.protection
 
     disoriented2 = Disoriented(realistic_target)
     disoriented2.on_application(realistic_target)
 
-    # Protection is reduced directly by each instance, so it stacks.
-    assert realistic_target.protection < protection_after_first
-    assert realistic_target.protection < initial_protection
-    # Each instance independently carries a negative finesse penalty; in real
-    # play refresh_stat_bonuses sums add_fin across both active states.
+    # on_application never mutates protection directly -- it stays untouched here
+    # because refresh_stat_bonuses (the actual stacking mechanism) is mocked.
+    assert realistic_target.protection == initial_protection
+    # Each instance independently carries negative finesse/protection penalties; in
+    # real play refresh_stat_bonuses sums add_fin/add_protection across both states.
     assert disoriented1.add_fin < 0
     assert disoriented2.add_fin < 0
+    assert disoriented1.add_protection < 0
+    assert disoriented2.add_protection < 0
     assert mock_refresh.called
 
 
@@ -137,9 +143,9 @@ def test_slimed_stat_modifications_persist_during_effect(mock_cprint, mock_refre
 
     state = Slimed(realistic_target)
 
-    # Verify state has the protection penalty defined
-    assert hasattr(state, 'sub_protection')
-    assert state.sub_protection > 0
+    # Verify state has the protection penalty defined (declarative, negative)
+    assert hasattr(state, 'add_protection')
+    assert state.add_protection < 0
 
     # Verify state applies stat penalties on application
     state.on_application(realistic_target)
@@ -181,12 +187,12 @@ def test_petrified_mixed_stat_modifications(mock_cprint, mock_refresh, realistic
     # Verify state defines the mixed modifications
     assert hasattr(state, 'add_fin')
     assert hasattr(state, 'add_speed')
-    assert hasattr(state, 'prot_bonus')
+    assert hasattr(state, 'add_protection')
 
     # Negative values mean penalties
     assert state.add_fin < 0  # Reduced finesse
     assert state.add_speed < 0  # Reduced speed
-    assert state.prot_bonus > 0  # Increased protection
+    assert state.add_protection > 0  # Increased protection
 
     # Application should trigger stat refresh
     state.on_application(realistic_target)
@@ -199,48 +205,49 @@ def test_petrified_mixed_stat_modifications(mock_cprint, mock_refresh, realistic
 
 @patch('src.states.functions.refresh_stat_bonuses')
 def test_disoriented_stat_restoration_on_removal(mock_refresh, realistic_target):
-    """Test that Disoriented restores protection when removed (finesse is
-    declarative and cleared by refresh_stat_bonuses, called by process() before
-    on_removal runs -- not by on_removal itself)"""
+    """Test that Disoriented's protection penalty is purely declarative: neither
+    on_application nor on_removal mutate target.protection directly. Restoration
+    on removal happens because refresh_stat_bonuses (called by process(), not by
+    on_removal) stops summing this state's add_protection once it's gone."""
     original_protection = realistic_target.protection
 
     state = Disoriented(realistic_target)
     realistic_target.states.append(state)
 
-    # Apply effect
+    # Apply effect -- defers to refresh_stat_bonuses (mocked), no direct mutation
     state.on_application(realistic_target)
-    assert realistic_target.protection < original_protection
+    assert realistic_target.protection == original_protection
     mock_refresh.reset_mock()
 
     # Remove effect
     state.on_removal(realistic_target)
 
-    # Protection should be restored
+    # on_removal does not mutate protection directly, and does not trigger a
+    # refresh itself -- that's process()'s job (called before on_removal runs)
     assert realistic_target.protection == original_protection
-    # on_removal itself does not trigger a refresh -- that's process()'s job
     assert not mock_refresh.called
 
 
 @patch('src.states.cprint')
 @patch('src.states.functions.refresh_stat_bonuses')
 def test_petrified_protection_bonus_cleanup_on_removal(mock_refresh, mock_cprint, realistic_target):
-    """Test that Petrified removes its protection bonus when effect expires"""
+    """Test that Petrified's protection bonus is purely declarative: neither
+    on_application nor on_removal mutate target.protection directly -- the bonus
+    is summed/dropped by refresh_stat_bonuses based on whether the state is active."""
     initial_protection = realistic_target.protection
 
     state = Petrified(realistic_target)
     state.on_application(realistic_target)
-    boosted_protection = realistic_target.protection
 
-    # Verify protection was increased
-    assert boosted_protection > initial_protection
+    # on_application defers all stat mutation to refresh_stat_bonuses (mocked here)
+    assert realistic_target.protection == initial_protection
+    assert state.add_protection > 0
 
     # Remove the effect
     state.on_removal(realistic_target)
-    final_protection = realistic_target.protection
 
-    # Protection bonus should be removed
-    assert final_protection == initial_protection
-    assert final_protection < boosted_protection
+    # on_removal does not mutate protection directly either
+    assert realistic_target.protection == initial_protection
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_states_coverage.py
+++ b/tests/test_states_coverage.py
@@ -86,17 +86,18 @@ def test_enflamed_compound_steps_left_cap():
 # Slimed.on_removal() — lines 337-339
 # ---------------------------------------------------------------------------
 def test_slimed_on_removal():
+    """on_removal only announces; the protection penalty is declarative
+    (add_protection summed by refresh_stat_bonuses) and is never mutated
+    directly by on_removal."""
     target = FakeTarget()
     state = Slimed(target)
     original_protection = target.protection
-    # Manually apply the on_application effect so protection is reduced
-    target.protection = max(0, target.protection - state.sub_protection)
 
-    with patch('states.cprint'):
+    with patch('states.cprint') as mock_cprint:
         state.on_removal(target)
 
-    # protection should be restored
     assert target.protection == original_protection
+    assert mock_cprint.called
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_states_coverage.py
+++ b/tests/test_states_coverage.py
@@ -111,12 +111,16 @@ def test_slimed_compound():
     state.steps_max = 20
     state.steps_left = 20
     original_add_fin = state.add_fin
+    original_add_protection = state.add_protection
 
     with patch('states.cprint'):
         state.compound(target)
 
     # add_fin should decrease
     assert state.add_fin < original_add_fin
+    # add_protection should also deepen (issue #259 follow-up: compound() must
+    # worsen every declarative penalty the state carries, not just add_fin)
+    assert state.add_protection < original_add_protection
     # beats_max *= 1.1
     assert state.beats_max == int(50 * 1.1)
 
@@ -179,6 +183,7 @@ def test_petrified_compound():
     state.steps_left = 20
     original_add_fin = state.add_fin
     original_add_speed = state.add_speed
+    original_add_protection = state.add_protection
 
     with patch('states.cprint'):
         state.compound(target)
@@ -186,6 +191,10 @@ def test_petrified_compound():
     # Both stat penalties deepen
     assert state.add_fin < original_add_fin
     assert state.add_speed < original_add_speed
+    # add_protection is a buff for Petrified, so it should grow more positive
+    # on reapplication (issue #259 follow-up: compound() must worsen/deepen
+    # every declarative bonus, not just add_fin/add_speed)
+    assert state.add_protection > original_add_protection
     assert state.beats_max == int(30 * 1.1)
 
 

--- a/tests/uat_phase3_combat.py
+++ b/tests/uat_phase3_combat.py
@@ -276,7 +276,7 @@ def test_vertigo_spin(player, enemies):
             disoriented = [s for s in target.states if s.name == "Disoriented"][0]
             cprint(f"  - Duration: {disoriented.beats_left}/{disoriented.beats_max} beats", "cyan")
             cprint(f"  - Finesse modifier: {disoriented.add_fin}", "cyan")
-            cprint(f"  - Protection reduction: {disoriented.sub_protection}", "cyan")
+            cprint(f"  - Protection modifier: {disoriented.add_protection}", "cyan")
         else:
             cprint(f"[WARN] No Disoriented status applied (check status implementation)", "yellow")
     else:


### PR DESCRIPTION
Disoriented, Slimed, and Petrified mutated target.protection directly via
+=/-= in on_application/on_removal. For Player this got silently wiped
almost immediately because refresh_stat_bonuses (called right after,
within the same on_application) invokes Player.refresh_protection_rating(),
which fully recomputes protection from endurance + gear and discards the
manual mutation.

Convert the penalty/bonus to a declarative add_protection attribute summed
by refresh_stat_bonuses/reset_stats, mirroring the existing add_fin pattern
from issue #240. reset_stats now restores protection to its true base
(via refresh_protection_rating for Player, or protection_base for NPCs)
before bonuses are summed on top, so the effect is idempotent and survives
recomputation.

Also removes now-redundant/harmful refresh_protection_rating() calls in
items.py, session_manager.py, player/_inventory.py, and player/_ui.py that
each immediately followed refresh_stat_bonuses and could otherwise wipe or
double-restore the declarative bonus.

Fixes #259

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V9krRJnAZ556VbBbE9jiPi