### PR TITLE
refactor(backend): route equip/drop/use through GameService; drop dead code

### DIFF
--- a/frontend/src/components/ItemDetailDialog.jsx
+++ b/frontend/src/components/ItemDetailDialog.jsx
@@ -141,16 +141,14 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
         const isNowEquipped = !item.is_equipped
         setActionMessage(isNowEquipped ? '✓ Item equipped!' : '✗ Item unequipped!')
 
-        // Show success dialog, including any flavor narration from the engine
-        // (slot swaps, on-equip effects) surfaced via the backend `messages`.
+        // Prefer the engine's flavor narration (slot swaps, on-equip effects)
+        // as the single source of truth; fall back to a hardcoded line only
+        // when the backend returned no narration.
         setActionResult({
-          message: (
-            <>
-              {isNowEquipped
-                ? <><strong>{player?.name || 'Player'}</strong> equipped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.</>
-                : <><strong>{player?.name || 'Player'}</strong> unequipped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.</>}
-              {renderNarration(data.messages)}
-            </>
+          message: renderNarration(data.messages) || (
+            isNowEquipped
+              ? <><strong>{player?.name || 'Player'}</strong> equipped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.</>
+              : <><strong>{player?.name || 'Player'}</strong> unequipped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.</>
           )
         })
 
@@ -251,14 +249,12 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
       const data = response.data || response
       if (data.success) {
         setActionMessage('✓ Item dropped!')
-        // Show success dialog, including any flavor narration from the engine
-        // (e.g. unequip-before-drop) surfaced via the backend `messages`.
+        // Prefer the engine's drop narration (incl. any unequip-before-drop)
+        // as the single source of truth; fall back to a hardcoded line only
+        // when the backend returned no narration.
         setActionResult({
-          message: (
-            <>
-              <strong>{player?.name || 'Player'}</strong> dropped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.
-              {renderNarration(data.messages)}
-            </>
+          message: renderNarration(data.messages) || (
+            <><strong>{player?.name || 'Player'}</strong> dropped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.</>
           )
         })
 

--- a/frontend/src/components/ItemDetailDialog.jsx
+++ b/frontend/src/components/ItemDetailDialog.jsx
@@ -26,6 +26,24 @@ const capitalize = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s)
 const formatSigned = (value) => `${value >= 0 ? '+' : ''}${value}`
 const formatSignedPercent = (value) => `${value >= 0 ? '+' : ''}${Math.round(value * 100)}%`
 
+// Render engine flavor narration (the backend `messages` array) below an action
+// result. Returns null when there is nothing to show.
+const renderNarration = (messages) => {
+  if (!Array.isArray(messages) || messages.length === 0) return null
+  return (
+    <div style={{
+      whiteSpace: 'pre-wrap',
+      color: '#00ffff',
+      fontSize: '13px',
+      fontFamily: 'monospace',
+      marginTop: '12px',
+      textAlign: 'left',
+    }}>
+      {messages.join('\n')}
+    </div>
+  )
+}
+
 // Describes a single consumable effect descriptor (see inventory.py's
 // _CONSUMABLE_EFFECTS) without per-target context, for the main item panel.
 function describeEffect(effect) {
@@ -123,11 +141,17 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
         const isNowEquipped = !item.is_equipped
         setActionMessage(isNowEquipped ? '✓ Item equipped!' : '✗ Item unequipped!')
 
-        // Show success dialog
+        // Show success dialog, including any flavor narration from the engine
+        // (slot swaps, on-equip effects) surfaced via the backend `messages`.
         setActionResult({
-          message: isNowEquipped
-            ? <><strong>{player?.name || 'Player'}</strong> equipped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.</>
-            : <><strong>{player?.name || 'Player'}</strong> unequipped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.</>
+          message: (
+            <>
+              {isNowEquipped
+                ? <><strong>{player?.name || 'Player'}</strong> equipped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.</>
+                : <><strong>{player?.name || 'Player'}</strong> unequipped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.</>}
+              {renderNarration(data.messages)}
+            </>
+          )
         })
 
         // Update item's equipped state locally
@@ -227,9 +251,15 @@ export default function ItemDetailDialog({ item, player, onClose, onBack, onRefe
       const data = response.data || response
       if (data.success) {
         setActionMessage('✓ Item dropped!')
-        // Show success dialog
+        // Show success dialog, including any flavor narration from the engine
+        // (e.g. unequip-before-drop) surfaced via the backend `messages`.
         setActionResult({
-          message: <><strong>{player?.name || 'Player'}</strong> dropped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.</>
+          message: (
+            <>
+              <strong>{player?.name || 'Player'}</strong> dropped <br /><span style={{ color: '#ffff00', fontSize: '18px' }}>{item.name}</span>.
+              {renderNarration(data.messages)}
+            </>
+          )
         })
 
         // Call onItemRemoved to update inventory client-side

--- a/frontend/src/components/ItemDetailDialog.test.jsx
+++ b/frontend/src/components/ItemDetailDialog.test.jsx
@@ -88,6 +88,34 @@ describe('ItemDetailDialog', () => {
     expect(mockOnBack).toHaveBeenCalled();
   });
 
+  it('renders engine flavor narration from the equip response', async () => {
+    apiClient.post.mockResolvedValue({
+      data: {
+        success: true,
+        messages: ['Jean put the Rusty Dagger back into his bag.'],
+      },
+    });
+
+    render(
+      <ItemDetailDialog
+        item={mockItem}
+        player={mockPlayer}
+        onClose={mockOnClose}
+        onBack={mockOnBack}
+        onItemUpdated={mockOnItemUpdated}
+        onRefetch={mockOnRefetch}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/Equip/i));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/back into his bag/i)
+      ).toBeDefined();
+    });
+  });
+
   it('handles use action successfully', async () => {
     const consumableItem = {
       ...mockItem,

--- a/src/api/routes/combat.py
+++ b/src/api/routes/combat.py
@@ -198,47 +198,16 @@ def toggle_suggestions_pause():
         if error:
             return error
 
+        from flask import current_app
+
         data = request.get_json() or {}
         paused = bool(data.get("paused", False))
-        player.suggestions_paused = paused
-        if not paused:
-            # Clear stale data so the next status poll triggers a fresh fetch
-            player.suggested_moves = []
-            player.suggestions_loading = False
+        current_app.game_service.set_suggestions_paused(player, paused)
         return jsonify({"success": True, "paused": paused}), 200
 
     except Exception:
         logger.exception("Unhandled error in toggle_suggestions_pause")
         return jsonify({"success": False, "error": "An internal error occurred"}), 500
-
-
-@combat_bp.route("/log", methods=["GET"])
-def get_combat_log():
-    """Get full combat log.
-
-    Headers:
-        Authorization: Bearer <session_id>
-
-    Returns:
-        {
-            "success": bool,
-            "log": [...]
-        }
-    """
-    try:
-        session_manager, session, player, error = get_session_and_player()
-        if error:
-            return error
-
-        log = getattr(player, "combat_log", [])
-        return jsonify({"success": True, "log": log}), 200
-
-    except Exception:
-        logger.exception("Unhandled error in get_combat_log")
-        return (
-            jsonify({"success": False, "error": "An internal error occurred"}),
-            500,
-        )
 
 
 @combat_bp.route("/collect-loot", methods=["POST"])

--- a/src/api/routes/inventory.py
+++ b/src/api/routes/inventory.py
@@ -9,6 +9,7 @@ Provides endpoints for:
 
 import contextlib
 import io
+import logging
 import re
 from unittest.mock import patch
 
@@ -29,6 +30,8 @@ from src.api.middleware.auth import get_session_and_player
 
 # Create blueprint
 inventory_bp = Blueprint("inventory", __name__)
+
+logger = logging.getLogger(__name__)
 
 
 def get_item_and_index(player, item_id=None, item_index=None):
@@ -96,8 +99,9 @@ def get_inventory():
             jsonify({"success": True, "inventory": inventory_data}),
             200,
         )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        logger.exception("Unhandled error in inventory route")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
 
 @inventory_bp.route("/inventory/examine", methods=["GET"])
@@ -137,8 +141,9 @@ def examine_item():
             jsonify({"success": True, "item": item_data}),
             200,
         )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        logger.exception("Unhandled error in inventory route")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
 
 @inventory_bp.route("/inventory/drop", methods=["POST"])
@@ -189,13 +194,15 @@ def drop_item():
                 {
                     "success": True,
                     "message": "Item dropped",
+                    "messages": result.get("messages", []),
                     "inventory": inventory_data,
                 }
             ),
             200,
         )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        logger.exception("Unhandled error in inventory route")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
 
 @inventory_bp.route("/equipment", methods=["GET"])
@@ -215,8 +222,9 @@ def get_equipment():
             jsonify({"success": True, "equipment": equipment_data}),
             200,
         )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        logger.exception("Unhandled error in inventory route")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
 
 @inventory_bp.route("/inventory/equip", methods=["POST"])
@@ -268,14 +276,16 @@ def equip_item():
                 {
                     "success": True,
                     "message": result["message"],
+                    "messages": result.get("messages", []),
                     "equipment": equipment_data,
                     "inventory": inventory_data,
                 }
             ),
             200,
         )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        logger.exception("Unhandled error in inventory route")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
 
 @inventory_bp.route("/inventory/use", methods=["POST"])
@@ -446,8 +456,9 @@ def use_item():
             jsonify(response_data),
             200,
         )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        logger.exception("Unhandled error in inventory route")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
 
 @inventory_bp.route("/inventory/unequip", methods=["POST"])
@@ -498,14 +509,16 @@ def unequip_item():
                 {
                     "success": True,
                     "message": result["message"],
+                    "messages": result.get("messages", []),
                     "equipment": equipment_data,
                     "inventory": inventory_data,
                 }
             ),
             200,
         )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        logger.exception("Unhandled error in inventory route")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
 
 @inventory_bp.route("/inventory/compare", methods=["GET"])
@@ -565,8 +578,9 @@ def compare_items():
             jsonify({"success": True, "comparison": comparison_data}),
             200,
         )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        logger.exception("Unhandled error in inventory route")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
 
 @inventory_bp.route("/inventory/stats", methods=["GET"])
@@ -586,8 +600,9 @@ def get_stats():
     try:
         stats = current_app.game_service.get_player_stats(player)
         return jsonify({"success": True, "stats": stats}), 200
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        logger.exception("Unhandled error in inventory route")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
 
 @inventory_bp.route("/inventory/currency", methods=["GET"])
@@ -611,5 +626,6 @@ def get_currency():
             jsonify({"success": True, "currency": currency}),
             200,
         )
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        logger.exception("Unhandled error in inventory route")
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500

--- a/src/api/routes/inventory.py
+++ b/src/api/routes/inventory.py
@@ -170,43 +170,17 @@ def drop_item():
             )
 
         # Find the item
-        item_to_drop, actual_index = get_item_and_index(player, item_id, item_index)
+        item_to_drop, _actual_index = get_item_and_index(player, item_id, item_index)
         if item_to_drop is None:
             return (
                 jsonify({"success": False, "error": "Item not found in inventory"}),
                 400,
             )
 
-        # Get player's current position
-        player_x = getattr(player, "location_x", 0)
-        player_y = getattr(player, "location_y", 0)
-
-        # Get the tile at player's current position
-        tile = player.universe.get_tile(player_x, player_y)
-        if not tile:
-            return jsonify({"success": False, "error": "Current tile not found"}), 400
-
-        # If equipped, unequip cleanly before dropping
-        if getattr(item_to_drop, "isequipped", False):
-            item_to_drop.isequipped = False
-            if hasattr(item_to_drop, "on_unequip"):
-                item_to_drop.on_unequip(player)
-            if getattr(item_to_drop, "maintype", None) == "Weapon":
-                player.eq_weapon = getattr(player, "fists", None)
-            from src import functions
-
-            functions.refresh_stat_bonuses(player)
-
-        # Remove item from inventory and add to tile
-        inventory_list = getattr(player, "inventory_list", None) or getattr(
-            player, "inventory", []
-        )
-        inventory_list.pop(actual_index)
-        items_here = getattr(tile, "items_here", [])
-        items_here.append(item_to_drop)
-        # Update item description if it's stackable
-        if hasattr(item_to_drop, "stack_grammar"):
-            item_to_drop.stack_grammar()
+        # Delegate the drop (and any unequip-before-drop) to the engine layer.
+        result = current_app.game_service.drop_item(player, item_to_drop)
+        if "error" in result:
+            return jsonify({"success": False, "error": result["error"]}), 400
 
         # Return updated inventory
         inventory_data = InventorySerializer.serialize(player)
@@ -274,96 +248,17 @@ def equip_item():
             )
 
         # Find the item
-        item, actual_index = get_item_and_index(player, item_id, item_index)
+        item, _actual_index = get_item_and_index(player, item_id, item_index)
         if item is None:
             return (
                 jsonify({"success": False, "error": "Item not found in inventory"}),
                 400,
             )
 
-        # Check if equippable
-        if not hasattr(item, "isequipped"):
-            return (
-                jsonify(
-                    {
-                        "success": False,
-                        "error": f"{getattr(item, 'name', 'Item')} cannot be equipped",
-                    }
-                ),
-                400,
-            )
-
-        # Check if already equipped
-        if getattr(item, "isequipped", False):
-            # Unequip it
-            item.isequipped = False
-            if hasattr(item, "on_unequip"):
-                item.on_unequip(player)
-            if getattr(item, "maintype", None) == "Weapon":
-                player.eq_weapon = getattr(player, "fists", None)
-            from src import functions
-
-            functions.refresh_stat_bonuses(player)
-            message = f"{item.name} unequipped"
-        else:
-            # Check if merchandise - can't equip until purchased
-            if getattr(item, "merchandise", False):
-                return (
-                    jsonify(
-                        {
-                            "success": False,
-                            "error": f"You must purchase {item.name} before equipping it",
-                        }
-                    ),
-                    400,
-                )
-
-            # Unequip other items of same maintype if needed
-            inventory_list = getattr(player, "inventory_list", None) or getattr(
-                player, "inventory", []
-            )
-            maintype = getattr(item, "maintype", None)
-            if maintype:
-                for other_item in inventory_list:
-                    if other_item != item and getattr(other_item, "isequipped", False):
-                        other_maintype = getattr(other_item, "maintype", None)
-                        # For accessories, only replace same subtype (except multiple jewelry)
-                        if maintype == "Accessory" and other_maintype == "Accessory":
-                            other_subtype = getattr(other_item, "subtype", None)
-                            item_subtype = getattr(item, "subtype", None)
-                            if item_subtype == other_subtype:
-                                # Check if it's a type that allows multiples (Ring, Bracelet, Earring)
-                                if item_subtype in ["Ring", "Bracelet", "Earring"]:
-                                    # Don't auto-unequip for these; let player manage multiples
-                                    continue
-                                # For single-slot accessories, replace
-                                other_item.isequipped = False
-                                if hasattr(other_item, "on_unequip"):
-                                    other_item.on_unequip(player)
-                        elif maintype == other_maintype:
-                            # For non-accessories, replace the old one
-                            other_item.isequipped = False
-                            if hasattr(other_item, "on_unequip"):
-                                other_item.on_unequip(player)
-
-            # Equip the item
-            item.isequipped = True
-            if hasattr(item, "on_equip"):
-                item.on_equip(player)
-
-            # Update weapon reference if applicable
-            if maintype == "Weapon":
-                player.eq_weapon = item
-
-            # Refresh stat bonuses
-            from src import functions
-
-            functions.refresh_stat_bonuses(player)
-
-            message = f"{item.name} equipped"
-
-        # Get updated equipment data
-        from src.api.serializers.inventory import EquipmentSerializer
+        # Delegate the equip/unequip toggle to the engine layer.
+        result = current_app.game_service.equip_item(player, item)
+        if "error" in result:
+            return jsonify({"success": False, "error": result["error"]}), 400
 
         equipment_data = EquipmentSerializer.serialize(player)
         inventory_data = InventorySerializer.serialize(player)
@@ -372,7 +267,7 @@ def equip_item():
             jsonify(
                 {
                     "success": True,
-                    "message": message,
+                    "message": result["message"],
                     "equipment": equipment_data,
                     "inventory": inventory_data,
                 }
@@ -583,41 +478,17 @@ def unequip_item():
             )
 
         # Find the item
-        item, actual_index = get_item_and_index(player, item_id, item_index)
+        item, _actual_index = get_item_and_index(player, item_id, item_index)
         if item is None:
             return (
                 jsonify({"success": False, "error": "Item not found in inventory"}),
                 400,
             )
 
-        if not hasattr(item, "isequipped"):
-            return (
-                jsonify(
-                    {
-                        "success": False,
-                        "error": f"{getattr(item, 'name', 'Item')} cannot be unequipped",
-                    }
-                ),
-                400,
-            )
-
-        if not getattr(item, "isequipped", False):
-            return (
-                jsonify(
-                    {"success": False, "error": f"{item.name} is not equipped"}
-                ),
-                400,
-            )
-
-        item.isequipped = False
-        if hasattr(item, "on_unequip"):
-            item.on_unequip(player)
-        if getattr(item, "maintype", None) == "Weapon":
-            player.eq_weapon = getattr(player, "fists", None)
-
-        from src import functions
-
-        functions.refresh_stat_bonuses(player)
+        # Delegate the unequip to the engine layer.
+        result = current_app.game_service.unequip_item(player, item)
+        if "error" in result:
+            return jsonify({"success": False, "error": result["error"]}), 400
 
         equipment_data = EquipmentSerializer.serialize(player)
         inventory_data = InventorySerializer.serialize(player)
@@ -626,7 +497,7 @@ def unequip_item():
             jsonify(
                 {
                     "success": True,
-                    "message": f"{item.name} unequipped",
+                    "message": result["message"],
                     "equipment": equipment_data,
                     "inventory": inventory_data,
                 }

--- a/src/api/routes/world.py
+++ b/src/api/routes/world.py
@@ -5,6 +5,7 @@ import logging
 from flask import Blueprint, request, jsonify
 
 from src.api.middleware.auth import get_session_and_player
+from src.api.services.validators import validate_direction
 
 world_bp = Blueprint("world", __name__)
 _log = logging.getLogger(__name__)
@@ -112,6 +113,10 @@ def move_player():
             )
 
         direction = data["direction"].lower()
+
+        is_valid, direction_error = validate_direction(direction)
+        if not is_valid:
+            return jsonify({"success": False, "error": direction_error}), 400
 
         from flask import current_app
 
@@ -227,7 +232,7 @@ def submit_event_input():
             return jsonify(result), 400
 
         # Detect player death caused by event processing
-        if getattr(player, "hp", 1) <= 0:
+        if game_service.is_player_dead(player):
             result["is_game_over"] = True
             result["is_death_scene"] = True
 
@@ -679,7 +684,7 @@ def trigger_room_events():
             )
 
         # Get current tile
-        tile = player.universe.get_tile(player.location_x, player.location_y)
+        tile = game_service.get_current_tile_object(player)
         if not tile:
             return (
                 jsonify({"success": False, "error": "Current tile not found"}),

--- a/src/api/services/__init__.py
+++ b/src/api/services/__init__.py
@@ -5,14 +5,7 @@ from .game_service import GameService
 from .validators import (
     validate_required_fields,
     validate_direction,
-    validate_coordinates,
-    validate_item_slot,
-    validate_combat_action,
     validate_item_index,
-    validate_save_name,
-    validate_string_field,
-    validate_positive_integer,
-    validate_range,
     validate_npc_id,
 )
 
@@ -22,13 +15,6 @@ __all__ = [
     "GameService",
     "validate_required_fields",
     "validate_direction",
-    "validate_coordinates",
-    "validate_item_slot",
-    "validate_combat_action",
     "validate_item_index",
-    "validate_save_name",
-    "validate_string_field",
-    "validate_positive_integer",
-    "validate_range",
     "validate_npc_id",
 ]

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -3991,8 +3991,13 @@ class GameService:
         if getattr(item, "merchandise", False):
             return {"error": f"You must purchase {item.name} before equipping it"}
 
-        player.equip_item(item_object=item)
-        return {"success": True, "message": f"{item.name} equipped"}
+        with capture_narration() as _msgs:
+            player.equip_item(item_object=item)
+        return {
+            "success": True,
+            "message": f"{item.name} equipped",
+            "messages": [m.get("text", "") for m in _msgs if m.get("text")],
+        }
 
     def unequip_item(self, player: "player_module.Player", item) -> Dict[str, Any]:
         """Unequip a currently-equipped inventory item via the engine.
@@ -4009,8 +4014,13 @@ class GameService:
         if not item.isequipped:
             return {"error": f"{item.name} is not equipped"}
 
-        player.unequip_item(item_object=item)
-        return {"success": True, "message": f"{item.name} unequipped"}
+        with capture_narration() as _msgs:
+            player.unequip_item(item_object=item)
+        return {
+            "success": True,
+            "message": f"{item.name} unequipped",
+            "messages": [m.get("text", "") for m in _msgs if m.get("text")],
+        }
 
     def drop_item(self, player: "player_module.Player", item) -> Dict[str, Any]:
         """Drop an inventory item onto the player's current tile.
@@ -4029,21 +4039,23 @@ class GameService:
         if not tile or not hasattr(tile, "items_here"):
             return {"error": "Cannot drop item: invalid current location"}
 
-        if getattr(item, "isequipped", False):
-            player.unequip_item(item_object=item)
+        with capture_narration() as _msgs:
+            if getattr(item, "isequipped", False):
+                player.unequip_item(item_object=item)
 
-        try:
-            player.inventory.remove(item)
-        except (ValueError, AttributeError):
-            return {"error": "Item not found in inventory"}
+            try:
+                player.inventory.remove(item)
+            except (ValueError, AttributeError):
+                return {"error": "Item not found in inventory"}
 
-        tile.items_here.append(item)
-        if hasattr(item, "stack_grammar"):
-            item.stack_grammar()
+            tile.items_here.append(item)
+            if hasattr(item, "stack_grammar"):
+                item.stack_grammar()
 
         return {
             "success": True,
             "message": f"Dropped {getattr(item, 'name', 'item')}",
+            "messages": [m.get("text", "") for m in _msgs if m.get("text")],
             "item_name": getattr(item, "name", None),
         }
 

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -4051,6 +4051,9 @@ class GameService:
             tile.items_here.append(item)
             if hasattr(item, "stack_grammar"):
                 item.stack_grammar()
+            # Narrate the drop so `messages` is the single source of truth for
+            # the dialog (the engine has no drop verb; mirrors the take action).
+            narrate(f"{getattr(player, 'name', 'Jean')} drops {getattr(item, 'name', 'the item')}.")
 
         return {
             "success": True,

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -3934,81 +3934,117 @@ class GameService:
             "objects": ObjectSerializer.serialize_list(getattr(tile, "objects_here", [])),
         }
 
-    def use_item(self, player: "player_module.Player", item_index: int) -> Dict[str, Any]:
-        """Use an item from the player's inventory.
+    def get_current_tile_object(self, player: "player_module.Player"):
+        """Return the raw tile object the player currently stands on, or None.
 
-        Args:
-            player: The Player instance
-            item_index: Index of the item to use
-
-        Returns:
-            Dictionary with use result
+        Distinct from ``get_tile``, which returns serialized tile data. Routes
+        that need the live tile (to mutate it or pass it to another engine call)
+        should use this instead of reaching into ``player.universe`` directly.
         """
-        if not isinstance(player.inventory, list):
-            return {"error": "Inventory not accessible"}
-
-        if item_index < 0 or item_index >= len(player.inventory):
-            return {"error": "Invalid item index"}
-
-        item = player.inventory[item_index]
-
-        # FIX 2: Add type validation to ensure item is an object with expected attributes
-        if isinstance(item, (str, dict, int, float)):
-            return {"error": f"Invalid inventory item: corrupted data type {type(item).__name__}"}
-
-        if not hasattr(item, "name"):
-            return {"error": "Invalid inventory item: missing name attribute"}
-
-        # Try to use the item if it has a use method
-        if hasattr(item, "use") and callable(item.use):
-            try:
-                item.use(player)
-                return {"success": True, "message": f"Used {item.name}"}
-            except Exception as e:
-                return {"success": False, "error": str(e)}
-
-        return {"success": False, "error": f"{item.name} cannot be used"}
-
-    def drop_item(self, player: "player_module.Player", item_index: int) -> Dict[str, Any]:
-        """Drop an item from the player's inventory.
-
-        Args:
-            player: The Player instance
-            item_index: Index of the item to drop
-
-        Returns:
-            Dictionary with drop result
-        """
-        if not isinstance(player.inventory, list):
-            return {"error": "Inventory not accessible"}
-
-        if item_index < 0 or item_index >= len(player.inventory):
-            return {"error": "Invalid item index"}
-
-        # FIX 1: Add defensive checks for universe and tile BEFORE modifying inventory
         if not hasattr(player, "universe") or player.universe is None:
-            return {"error": "Cannot drop item: player universe not accessible"}
+            return None
+        return player.universe.get_tile(player.location_x, player.location_y)
 
-        # Get the tile and validate it exists before popping from inventory
-        tile = player.universe.get_tile(player.location_x, player.location_y)
+    def is_player_dead(self, player: "player_module.Player") -> bool:
+        """Return True if the player's HP has dropped to zero or below.
+
+        Centralises the death-state derivation so routes don't compute it from
+        ``player.hp`` inline.
+        """
+        return getattr(player, "hp", 1) <= 0
+
+    def set_suggestions_paused(
+        self, player: "player_module.Player", paused: bool
+    ) -> None:
+        """Pause or resume Tactical Advisor suggestion generation.
+
+        When resuming, clears stale suggestion data so the next status poll
+        triggers a fresh fetch.
+        """
+        player.suggestions_paused = paused
+        if not paused:
+            player.suggested_moves = []
+            player.suggestions_loading = False
+
+    def equip_item(self, player: "player_module.Player", item) -> Dict[str, Any]:
+        """Equip an inventory item, delegating core mechanics to the engine.
+
+        Acts as a toggle to match the web client, which uses this single path
+        for both equip and unequip: if the item is already equipped it is
+        unequipped. Otherwise merchandise is rejected and the engine's
+        ``Player.equip_item`` performs the equip (slot-swap rules, weapon
+        reference, exp-category setup, stat refresh).
+
+        Args:
+            player: The Player instance
+            item: The inventory item object to equip/unequip
+
+        Returns:
+            Dictionary with ``success``/``message`` or ``error``
+        """
+        if not hasattr(item, "isequipped"):
+            return {"error": f"{getattr(item, 'name', 'Item')} cannot be equipped"}
+
+        if item.isequipped:
+            return self.unequip_item(player, item)
+
+        if getattr(item, "merchandise", False):
+            return {"error": f"You must purchase {item.name} before equipping it"}
+
+        player.equip_item(item_object=item)
+        return {"success": True, "message": f"{item.name} equipped"}
+
+    def unequip_item(self, player: "player_module.Player", item) -> Dict[str, Any]:
+        """Unequip a currently-equipped inventory item via the engine.
+
+        Args:
+            player: The Player instance
+            item: The inventory item object to unequip
+
+        Returns:
+            Dictionary with ``success``/``message`` or ``error``
+        """
+        if not hasattr(item, "isequipped"):
+            return {"error": f"{getattr(item, 'name', 'Item')} cannot be unequipped"}
+        if not item.isequipped:
+            return {"error": f"{item.name} is not equipped"}
+
+        player.unequip_item(item_object=item)
+        return {"success": True, "message": f"{item.name} unequipped"}
+
+    def drop_item(self, player: "player_module.Player", item) -> Dict[str, Any]:
+        """Drop an inventory item onto the player's current tile.
+
+        Unequips the item first if it is equipped, then moves it from the
+        inventory to the tile.
+
+        Args:
+            player: The Player instance
+            item: The inventory item object to drop
+
+        Returns:
+            Dictionary with drop result or ``error``
+        """
+        tile = self.get_current_tile_object(player)
         if not tile or not hasattr(tile, "items_here"):
             return {"error": "Cannot drop item: invalid current location"}
 
-        # FIX 2: Add type validation for inventory items
-        item = player.inventory[item_index]
-        if not hasattr(item, "name"):
-            return {"error": "Cannot drop item: corrupted inventory item"}
+        if getattr(item, "isequipped", False):
+            player.unequip_item(item_object=item)
 
-        # Now it's safe to remove from inventory
-        player.inventory.pop(item_index)
+        try:
+            player.inventory.remove(item)
+        except (ValueError, AttributeError):
+            return {"error": "Item not found in inventory"}
 
-        # Add item to the current tile
         tile.items_here.append(item)
+        if hasattr(item, "stack_grammar"):
+            item.stack_grammar()
 
         return {
             "success": True,
-            "message": f"Dropped {item.name}",
-            "item_name": item.name,
+            "message": f"Dropped {getattr(item, 'name', 'item')}",
+            "item_name": getattr(item, "name", None),
         }
 
     def get_combat_state(self, player: "player_module.Player") -> Dict[str, Any]:

--- a/src/api/services/game_service.py
+++ b/src/api/services/game_service.py
@@ -3966,6 +3966,11 @@ class GameService:
             player.suggested_moves = []
             player.suggestions_loading = False
 
+    @staticmethod
+    def _narration_texts(messages) -> List[str]:
+        """Extract the non-empty ``text`` fields from captured narration entries."""
+        return [m.get("text", "") for m in messages if m.get("text")]
+
     def equip_item(self, player: "player_module.Player", item) -> Dict[str, Any]:
         """Equip an inventory item, delegating core mechanics to the engine.
 
@@ -3996,7 +4001,7 @@ class GameService:
         return {
             "success": True,
             "message": f"{item.name} equipped",
-            "messages": [m.get("text", "") for m in _msgs if m.get("text")],
+            "messages": self._narration_texts(_msgs),
         }
 
     def unequip_item(self, player: "player_module.Player", item) -> Dict[str, Any]:
@@ -4019,7 +4024,7 @@ class GameService:
         return {
             "success": True,
             "message": f"{item.name} unequipped",
-            "messages": [m.get("text", "") for m in _msgs if m.get("text")],
+            "messages": self._narration_texts(_msgs),
         }
 
     def drop_item(self, player: "player_module.Player", item) -> Dict[str, Any]:
@@ -4058,7 +4063,7 @@ class GameService:
         return {
             "success": True,
             "message": f"Dropped {getattr(item, 'name', 'item')}",
-            "messages": [m.get("text", "") for m in _msgs if m.get("text")],
+            "messages": self._narration_texts(_msgs),
             "item_name": getattr(item, "name", None),
         }
 

--- a/src/api/services/validators.py
+++ b/src/api/services/validators.py
@@ -1,6 +1,6 @@
 """Input validation helpers for API routes."""
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def validate_required_fields(
@@ -28,177 +28,31 @@ def validate_required_fields(
 def validate_direction(direction: str) -> Tuple[bool, Optional[str]]:
     """Validate movement direction.
 
+    Accepts the eight directions the engine's ``GameService.move_player``
+    supports (cardinal plus diagonal).
+
     Args:
         direction: Direction string
 
     Returns:
         Tuple of (is_valid, error_message)
     """
-    valid_directions = ["north", "south", "east", "west"]
+    valid_directions = [
+        "north",
+        "south",
+        "east",
+        "west",
+        "northeast",
+        "northwest",
+        "southeast",
+        "southwest",
+    ]
     if direction.lower() not in valid_directions:
         return (
             False,
             f"Invalid direction '{direction}'. Must be one of: {', '.join(valid_directions)}",
         )
     return True, None
-
-
-def validate_coordinates(x: Any, y: Any) -> Tuple[bool, Optional[str]]:
-    """Validate tile coordinates.
-
-    Args:
-        x: X coordinate
-        y: Y coordinate
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    try:
-        x_int = int(x)
-        y_int = int(y)
-        if x_int < -100 or x_int > 100 or y_int < -100 or y_int > 100:
-            return False, "Coordinates must be between -100 and 100"
-        return True, None
-    except (ValueError, TypeError):
-        return False, "Coordinates must be valid integers"
-
-
-def validate_item_slot(slot: str) -> Tuple[bool, Optional[str]]:
-    """Validate equipment slot name.
-
-    Args:
-        slot: Equipment slot name
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    valid_slots = [
-        "head",
-        "chest",
-        "hands",
-        "legs",
-        "feet",
-        "main_hand",
-        "off_hand",
-        "accessory1",
-        "accessory2",
-    ]
-    if slot.lower() not in valid_slots:
-        return (
-            False,
-            f"Invalid slot '{slot}'. Must be one of: {', '.join(valid_slots)}",
-        )
-    return True, None
-
-
-def validate_combat_action(action: str) -> Tuple[bool, Optional[str]]:
-    """Validate combat action type.
-
-    Args:
-        action: Combat action name
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    valid_actions = ["attack", "defend", "cast", "item", "flee"]
-    if action.lower() not in valid_actions:
-        return (
-            False,
-            f"Invalid action '{action}'. Must be one of: {', '.join(valid_actions)}",
-        )
-    return True, None
-
-
-def validate_save_name(name: str) -> Tuple[bool, Optional[str]]:
-    """Validate save file name.
-
-    Args:
-        name: Save file name
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    if not name or not isinstance(name, str):
-        return False, "Save name must be a non-empty string"
-    if len(name) > 50:
-        return False, "Save name must be 50 characters or less"
-    if any(c in name for c in ["/", "\\", ":", "*", "?", '"', "<", ">", "|"]):
-        return False, "Save name contains invalid characters"
-    return True, None
-
-
-def validate_string_field(
-    field_name: str, value: Any, max_length: int = 1000, min_length: int = 1
-) -> Tuple[bool, Optional[str]]:
-    """Validate a string field with length constraints.
-
-    Args:
-        field_name: Name of the field (for error messages)
-        value: The value to validate
-        max_length: Maximum allowed length
-        min_length: Minimum allowed length
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    if not isinstance(value, str):
-        return False, f"{field_name} must be a string"
-    if len(value) < min_length:
-        return False, f"{field_name} must be at least {min_length} characters"
-    if len(value) > max_length:
-        return False, f"{field_name} must be at most {max_length} characters"
-    return True, None
-
-
-def validate_positive_integer(
-    field_name: str, value: Any, min_value: int = 1
-) -> Tuple[bool, Optional[str]]:
-    """Validate a positive integer field.
-
-    Args:
-        field_name: Name of the field (for error messages)
-        value: The value to validate
-        min_value: Minimum allowed value
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    try:
-        num = int(value)
-        if num < min_value:
-            return False, f"{field_name} must be at least {min_value}"
-        return True, None
-    except (ValueError, TypeError):
-        return False, f"{field_name} must be a valid integer"
-
-
-def validate_range(
-    field_name: str,
-    value: Any,
-    min_value: Union[int, float],
-    max_value: Union[int, float],
-) -> Tuple[bool, Optional[str]]:
-    """Validate a numeric value within a range.
-
-    Args:
-        field_name: Name of the field (for error messages)
-        value: The value to validate
-        min_value: Minimum allowed value
-        max_value: Maximum allowed value
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    try:
-        num = float(value)
-        if num < min_value or num > max_value:
-            return (
-                False,
-                f"{field_name} must be between {min_value} and {max_value}",
-            )
-        return True, None
-    except (ValueError, TypeError):
-        return False, f"{field_name} must be a valid number"
 
 
 def validate_item_index(item_index: Any, max_items: int) -> Tuple[bool, Optional[str]]:
@@ -221,74 +75,6 @@ def validate_item_index(item_index: Any, max_items: int) -> Tuple[bool, Optional
         return True, None
     except (ValueError, TypeError):
         return False, "Item index must be a valid integer"
-
-
-def validate_equipment_slot(slot_name: str) -> Tuple[bool, Optional[str]]:
-    """Validate equipment slot name.
-
-    Args:
-        slot_name: Equipment slot name
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    valid_slots = [
-        "weapon",
-        "shield",
-        "head",
-        "body",
-        "legs",
-        "hands",
-        "feet",
-        "accessory_1",
-        "accessory_2",
-    ]
-    if slot_name not in valid_slots:
-        return (
-            False,
-            f"Invalid slot '{slot_name}'. Must be one of: {', '.join(valid_slots)}",
-        )
-    return True, None
-
-
-def validate_weight_limit(
-    current_weight: float, item_weight: float, limit: float
-) -> Tuple[bool, Optional[str]]:
-    """Validate that adding item won't exceed weight limit.
-
-    Args:
-        current_weight: Current inventory weight
-        item_weight: Weight of item to add
-        limit: Weight limit
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    total = current_weight + item_weight
-    if total > limit:
-        return (False, f"Weight limit exceeded: {total:.1f} > {limit:.1f}")
-    return True, None
-
-
-def validate_currency_amount(amount: Any, available: int) -> Tuple[bool, Optional[str]]:
-    """Validate currency amount.
-
-    Args:
-        amount: Amount to validate
-        available: Available currency
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    try:
-        amt = int(amount)
-        if amt <= 0:
-            return False, "Amount must be positive"
-        if amt > available:
-            return False, f"Insufficient funds: need {amt}, have {available}"
-        return True, None
-    except (ValueError, TypeError):
-        return False, "Amount must be a valid integer"
 
 
 def validate_npc_id(npc_id: str) -> Tuple[bool, Optional[str]]:

--- a/src/player/_inventory.py
+++ b/src/player/_inventory.py
@@ -219,6 +219,33 @@ class PlayerInventoryMixin:
                                     self.skill_exp[target_item.subtype] = 9999
                     functions.refresh_stat_bonuses(self)
 
+    def unequip_item(self, item_object):
+        """Unequip a currently-equipped item.
+
+        Canonical counterpart to ``equip_item``: mirrors the unequip half of the
+        equip swap logic so the engine remains the single source of truth for
+        equip/unequip mechanics. No-op if the item isn't equippable or isn't
+        currently equipped. Narration flows through the narration sink.
+        """
+        if item_object is None or not hasattr(item_object, "isequipped"):
+            return
+        if not item_object.isequipped:
+            return
+        item_object.isequipped = False
+        cprint("Jean put {} back into his bag.".format(item_object.name), "cyan")
+        item_object.on_unequip(self)
+        if hasattr(item_object, "interactions"):
+            if "unequip" in item_object.interactions:
+                item_object.interactions.remove("unequip")
+            if "equip" not in item_object.interactions:
+                item_object.interactions.append("equip")
+        if (
+            hasattr(item_object, "maintype")
+            and item_object.maintype == "Weapon"
+        ):
+            self.eq_weapon = getattr(self, "fists", None)
+        functions.refresh_stat_bonuses(self)
+
     def use_item(self, phrase="", target=None):
         """Use a consumable or special item by phrase match.
 

--- a/tests/api/test_routes_critical.py
+++ b/tests/api/test_routes_critical.py
@@ -169,14 +169,6 @@ class TestCombatRoutes:
                              headers={'Authorization': f'Bearer {session_id}'})
         assert response.status_code in [200, 400, 404]
 
-    def test_get_combat_log(self, client, authenticated_session):
-        """Test getting combat log."""
-        session_id, player, session_manager = authenticated_session
-
-        response = client.get('/api/combat/log',
-                            headers={'Authorization': f'Bearer {session_id}'})
-        assert response.status_code in [200, 404]
-
 
 class TestInventoryRoutes:
     """Test inventory and item management routes."""

--- a/tests/api/test_validators.py
+++ b/tests/api/test_validators.py
@@ -12,14 +12,8 @@ if str(SRC_DIR) not in sys.path:
 from src.api.services.validators import (
     validate_required_fields,
     validate_direction,
-    validate_coordinates,
-    validate_item_slot,
-    validate_combat_action,
     validate_item_index,
-    validate_save_name,
-    validate_string_field,
-    validate_positive_integer,
-    validate_range,
+    validate_npc_id,
 )
 
 
@@ -49,8 +43,17 @@ def test_validate_required_fields_non_dict():
 
 
 def test_validate_direction_valid():
-    """Test valid directions."""
-    for direction in ["north", "south", "east", "west", "NORTH", "South"]:
+    """Test valid directions, including diagonals."""
+    for direction in [
+        "north",
+        "south",
+        "east",
+        "west",
+        "northeast",
+        "southwest",
+        "NORTH",
+        "South",
+    ]:
         is_valid, error = validate_direction(direction)
         assert is_valid is True
         assert error is None
@@ -58,74 +61,9 @@ def test_validate_direction_valid():
 
 def test_validate_direction_invalid():
     """Test invalid direction."""
-    is_valid, error = validate_direction("northeast")
+    is_valid, error = validate_direction("up")
     assert is_valid is False
     assert "Invalid direction" in error
-
-
-def test_validate_coordinates_valid():
-    """Test valid coordinates."""
-    is_valid, error = validate_coordinates(0, 0)
-    assert is_valid is True
-    assert error is None
-
-    is_valid, error = validate_coordinates("50", "-50")
-    assert is_valid is True
-    assert error is None
-
-
-def test_validate_coordinates_out_of_range():
-    """Test out-of-range coordinates."""
-    is_valid, error = validate_coordinates(200, 0)
-    assert is_valid is False
-    assert "must be between -100 and 100" in error
-
-
-def test_validate_coordinates_invalid():
-    """Test invalid coordinate types."""
-    is_valid, error = validate_coordinates("abc", 0)
-    assert is_valid is False
-    assert "must be valid integers" in error
-
-
-def test_validate_item_slot_valid():
-    """Test valid item slots."""
-    for slot in [
-        "head",
-        "chest",
-        "hands",
-        "legs",
-        "feet",
-        "main_hand",
-        "off_hand",
-        "accessory1",
-        "accessory2",
-    ]:
-        is_valid, error = validate_item_slot(slot)
-        assert is_valid is True
-        assert error is None
-
-
-def test_validate_item_slot_invalid():
-    """Test invalid item slot."""
-    is_valid, error = validate_item_slot("armor")
-    assert is_valid is False
-    assert "Invalid slot" in error
-
-
-def test_validate_combat_action_valid():
-    """Test valid combat actions."""
-    for action in ["attack", "defend", "cast", "item", "flee"]:
-        is_valid, error = validate_combat_action(action)
-        assert is_valid is True
-        assert error is None
-
-
-def test_validate_combat_action_invalid():
-    """Test invalid combat action."""
-    is_valid, error = validate_combat_action("spell")
-    assert is_valid is False
-    assert "Invalid action" in error
 
 
 def test_validate_item_index_valid():
@@ -146,107 +84,21 @@ def test_validate_item_index_out_of_range():
     assert "Invalid item index" in error or "must be between" in error
 
 
-def test_validate_save_name_valid():
-    """Test valid save names."""
-    is_valid, error = validate_save_name("My Save")
+def test_validate_npc_id_valid():
+    """Test a valid NPC id."""
+    is_valid, error = validate_npc_id("gorran_01")
     assert is_valid is True
     assert error is None
 
 
-def test_validate_save_name_empty():
-    """Test empty save name."""
-    is_valid, error = validate_save_name("")
+def test_validate_npc_id_empty():
+    """Test an empty NPC id."""
+    is_valid, error = validate_npc_id("")
     assert is_valid is False
-    assert "non-empty string" in error
 
 
-def test_validate_save_name_too_long():
-    """Test save name too long."""
-    is_valid, error = validate_save_name("x" * 51)
+def test_validate_npc_id_non_string():
+    """Test a non-string NPC id."""
+    is_valid, error = validate_npc_id(42)
     assert is_valid is False
-    assert "50 characters" in error
-
-
-def test_validate_save_name_invalid_chars():
-    """Test save name with invalid characters."""
-    is_valid, error = validate_save_name("My/Save")
-    assert is_valid is False
-    assert "invalid characters" in error
-
-
-def test_validate_string_field_valid():
-    """Test valid string field."""
-    is_valid, error = validate_string_field("name", "Player", max_length=10)
-    assert is_valid is True
-    assert error is None
-
-
-def test_validate_string_field_non_string():
-    """Test non-string value."""
-    is_valid, error = validate_string_field("name", 123)
-    assert is_valid is False
-    assert "must be a string" in error
-
-
-def test_validate_string_field_too_short():
-    """Test string too short."""
-    is_valid, error = validate_string_field("name", "a", min_length=3)
-    assert is_valid is False
-    assert "at least 3 characters" in error
-
-
-def test_validate_string_field_too_long():
-    """Test string too long."""
-    is_valid, error = validate_string_field("name", "x" * 11, max_length=10)
-    assert is_valid is False
-    assert "at most 10 characters" in error
-
-
-def test_validate_positive_integer_valid():
-    """Test valid positive integer."""
-    is_valid, error = validate_positive_integer("level", 5)
-    assert is_valid is True
-    assert error is None
-
-    is_valid, error = validate_positive_integer("level", "10")
-    assert is_valid is True
-    assert error is None
-
-
-def test_validate_positive_integer_invalid():
-    """Test invalid positive integer."""
-    is_valid, error = validate_positive_integer("level", "abc")
-    assert is_valid is False
-    assert "must be a valid integer" in error
-
-
-def test_validate_positive_integer_too_small():
-    """Test positive integer too small."""
-    is_valid, error = validate_positive_integer("level", 0, min_value=1)
-    assert is_valid is False
-    assert "at least 1" in error
-
-
-def test_validate_range_valid():
-    """Test valid range."""
-    is_valid, error = validate_range("health", 50, 0, 100)
-    assert is_valid is True
-    assert error is None
-
-    is_valid, error = validate_range("temperature", "98.6", 95.0, 105.0)
-    assert is_valid is True
-    assert error is None
-
-
-def test_validate_range_invalid():
-    """Test invalid range."""
-    is_valid, error = validate_range("health", 150, 0, 100)
-    assert is_valid is False
-    assert "must be between 0 and 100" in error
-
-
-def test_validate_range_non_numeric():
-    """Test non-numeric value in range."""
-    is_valid, error = validate_range("health", "abc", 0, 100)
-    assert is_valid is False
-    assert "must be a valid number" in error
+    assert "string" in error

--- a/tests/test_api_final_tier3.py
+++ b/tests/test_api_final_tier3.py
@@ -216,22 +216,6 @@ class TestValidatorsMethods:
             # Expected to raise
             pass
 
-    def test_validate_player_stats_valid(self):
-        """Test validate_coordinates with valid coordinates."""
-        from src.api.services.validators import validate_coordinates
-
-        is_valid, error = validate_coordinates(5, 10)
-        # Should be valid
-        assert is_valid or error is None
-
-    def test_validate_player_stats_negative(self):
-        """Test validate_coordinates with negative values."""
-        from src.api.services.validators import validate_coordinates
-
-        is_valid, error = validate_coordinates(-1, 10)
-        # May or may not reject negative coords
-        pass
-
     def test_validate_inventory_item_valid(self):
         """Test validate_required_fields with item data."""
         from src.api.services.validators import validate_required_fields
@@ -1000,7 +984,7 @@ class TestValidatorIntegration:
         validation_functions = [
             'validate_required_fields',
             'validate_direction',
-            'validate_coordinates',
+            'validate_item_index',
         ]
 
         for func_name in validation_functions:

--- a/tests/test_api_routes_and_serializers.py
+++ b/tests/test_api_routes_and_serializers.py
@@ -1122,13 +1122,6 @@ class TestCombatRoutes:
         assert rv.status_code == 200
         assert rv.get_json()["paused"] is False
 
-    def test_get_combat_log(self, client):
-        c, _ = client
-        rv = c.get("/api/combat/log", headers=AUTH_HEADER)
-        assert rv.status_code == 200
-        assert rv.get_json()["success"] is True
-        assert isinstance(rv.get_json()["log"], list)
-
     def test_collect_loot_success(self, client):
         c, _ = client
         rv = c.post(

--- a/tests/test_api_services_tier4_final.py
+++ b/tests/test_api_services_tier4_final.py
@@ -185,64 +185,9 @@ class TestValidators:
         result = validate_direction("invalid_dir")
         assert isinstance(result, tuple)
 
-    def test_validate_coordinates(self):
-        """Test validate_coordinates"""
-        result = validate_coordinates(5, 5)
-        assert isinstance(result, tuple)
-
-    def test_validate_coordinates_negative(self):
-        """Test validate_coordinates with negative values"""
-        result = validate_coordinates(-1, -1)
-        assert isinstance(result, tuple)
-
-    def test_validate_item_slot(self):
-        """Test validate_item_slot"""
-        result = validate_item_slot("right_hand")
-        assert isinstance(result, tuple)
-
-    def test_validate_combat_action(self):
-        """Test validate_combat_action"""
-        result = validate_combat_action("attack")
-        assert isinstance(result, tuple)
-
-    def test_validate_save_name(self):
-        """Test validate_save_name"""
-        result = validate_save_name("my_save_1")
-        assert isinstance(result, tuple)
-
-    def test_validate_string_field(self):
-        """Test validate_string_field"""
-        result = validate_string_field("test_string", "test", min_length=1, max_length=100)
-        assert isinstance(result, tuple)
-
-    def test_validate_positive_integer(self):
-        """Test validate_positive_integer"""
-        result = validate_positive_integer(42, "count")
-        assert isinstance(result, tuple)
-
-    def test_validate_range(self):
-        """Test validate_range"""
-        result = validate_range(50, 0, 100, "value")
-        assert isinstance(result, tuple)
-
     def test_validate_item_index(self):
         """Test validate_item_index"""
         result = validate_item_index(0, 5)
-        assert isinstance(result, tuple)
-
-    def test_validate_equipment_slot(self):
-        """Test validate_equipment_slot"""
-        result = validate_equipment_slot("head")
-        assert isinstance(result, tuple)
-
-    def test_validate_weight_limit(self):
-        """Test validate_weight_limit"""
-        result = validate_weight_limit(50, 10, 100)
-        assert isinstance(result, tuple)
-
-    def test_validate_currency_amount(self):
-        """Test validate_currency_amount"""
-        result = validate_currency_amount(100, 500)
         assert isinstance(result, tuple)
 
     def test_validate_npc_id(self):
@@ -259,49 +204,9 @@ class TestValidatorsEdgeCases:
         result = validate_direction("north@#$")
         assert isinstance(result, tuple)
 
-    def test_validate_coordinates_with_strings(self):
-        """Test coordinates with non-numeric input"""
-        result = validate_coordinates("abc", "def")
-        assert isinstance(result, tuple)
-
-    def test_validate_empty_string_fields(self):
-        """Test string validators with empty strings"""
-        result = validate_string_field("", "field")
-        assert isinstance(result, tuple)
-
-    def test_validate_negative_integers(self):
-        """Test positive integer validator with negative"""
-        result = validate_positive_integer(-5, "count")
-        assert isinstance(result, tuple)
-
-    def test_validate_range_boundary_min(self):
-        """Test range validator at minimum boundary"""
-        result = validate_range(0, 0, 100, "value")
-        assert isinstance(result, tuple)
-
-    def test_validate_range_boundary_max(self):
-        """Test range validator at maximum boundary"""
-        result = validate_range(100, 0, 100, "value")
-        assert isinstance(result, tuple)
-
-    def test_validate_range_exceeds_max(self):
-        """Test range validator exceeding maximum"""
-        result = validate_range(150, 0, 100, "value")
-        assert isinstance(result, tuple)
-
     def test_validate_item_index_out_of_bounds(self):
         """Test item index exceeding max"""
         result = validate_item_index(10, 5)
-        assert isinstance(result, tuple)
-
-    def test_validate_zero_weight(self):
-        """Test weight limit with zero"""
-        result = validate_weight_limit(0, 10, 100)
-        assert isinstance(result, tuple)
-
-    def test_validate_negative_currency(self):
-        """Test currency with negative amount"""
-        result = validate_currency_amount(-10, 100)
         assert isinstance(result, tuple)
 
     def test_validate_required_fields_missing(self):
@@ -344,12 +249,6 @@ class TestServiceIntegration:
         is_valid, error_msg = result
         if not is_valid:
             assert error_msg is not None
-
-    def test_coordinates_validation_integration(self):
-        """Test coordinates used in position checking"""
-        result = validate_coordinates(10, 20)
-        assert isinstance(result, tuple)
-        is_valid, error_msg = result
 
 
 if __name__ == "__main__":

--- a/tests/test_game_service_coverage.py
+++ b/tests/test_game_service_coverage.py
@@ -206,29 +206,13 @@ class TestGameServiceInventory:
         assert result is not None
         assert len(result) >= 0
     
-    def test_use_item_valid(self, game_service, mock_player):
-        """Test using item from inventory."""
-        mock_item = MagicMock()
-        mock_item.use = MagicMock(return_value=True)
-        mock_player.inventory = [mock_item]
-        
-        result = game_service.use_item(mock_player, 0)
-        assert result is not None
-    
-    def test_use_item_invalid_index(self, game_service, mock_player):
-        """Test using item with invalid index."""
-        mock_player.inventory = []
-        
-        result = game_service.use_item(mock_player, 99)
-        # Should return error
-        assert result is not None
-    
     def test_drop_item_valid(self, game_service, mock_player):
         """Test dropping item from inventory."""
         mock_item = MagicMock()
+        mock_item.isequipped = False
         mock_player.inventory = [mock_item]
-        
-        result = game_service.drop_item(mock_player, 0)
+
+        result = game_service.drop_item(mock_player, mock_item)
         assert result is not None
 
 

--- a/tests/test_game_service_equip_unequip.py
+++ b/tests/test_game_service_equip_unequip.py
@@ -1,0 +1,242 @@
+"""Characterization tests for the canonical equip/unequip/drop path.
+
+These exercise the *real* engine mechanics (``Player.equip_item`` /
+``Player.unequip_item``) through ``GameService`` with a real ``Player`` and
+realistic item stand-ins, locking in the behavior of the hybrid delegation
+introduced for issue #260:
+
+- ``GameService.equip_item`` is a toggle (equip / unequip) plus a merchandise
+  guard, delegating the core mechanics to the engine.
+- ``GameService.unequip_item`` delegates to the new engine
+  ``Player.unequip_item``.
+- ``GameService.drop_item`` unequips an equipped item before moving it to the
+  current tile.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_player():
+    """Return a real Player with a minimal tile/universe for inventory methods."""
+    from src.player import Player
+
+    p = Player()
+    p.weight_tolerance = 100.0
+    p.weight_current = 0.0
+    p.combat_exp = {}
+    p.skill_exp = {}
+    p.testing_mode = False
+    tile = MagicMock()
+    tile.items_here = []
+    p.current_room = tile
+    p.tile = tile
+    return p
+
+
+def _make_equippable(maintype="Weapon", subtype="Sword", name="TestSword"):
+    """Return an equippable item stand-in with real interaction/state fields."""
+    item = MagicMock()
+    item.name = name
+    item.announce = name.lower()
+    item.maintype = maintype
+    item.subtype = subtype
+    item.isequipped = False
+    item.merchandise = False
+    item.gives_exp = False
+    item.weight = 1.0
+    item.interactions = ["equip"]
+    item.on_equip = MagicMock()
+    item.on_unequip = MagicMock()
+    return item
+
+
+@pytest.fixture
+def game_service():
+    from src.api.services.game_service import GameService
+
+    return GameService()
+
+
+# ---------------------------------------------------------------------------
+# Engine: Player.unequip_item
+# ---------------------------------------------------------------------------
+
+
+def test_engine_unequip_weapon_resets_to_fists():
+    p = _make_player()
+    item = _make_equippable(maintype="Weapon")
+    item.isequipped = True
+    item.interactions = ["unequip"]
+    p.inventory = [item]
+    p.eq_weapon = item
+
+    with (
+        patch("player._inventory.functions.refresh_stat_bonuses") as mock_refresh,
+        patch("player._inventory.cprint"),
+    ):
+        p.unequip_item(item_object=item)
+
+    assert item.isequipped is False
+    item.on_unequip.assert_called_once_with(p)
+    assert "unequip" not in item.interactions
+    assert "equip" in item.interactions
+    assert p.eq_weapon is getattr(p, "fists", None)
+    mock_refresh.assert_called_once_with(p)
+
+
+def test_engine_unequip_not_equipped_is_noop():
+    p = _make_player()
+    item = _make_equippable(maintype="Armor")
+    item.isequipped = False
+    p.inventory = [item]
+
+    with patch("player._inventory.functions.refresh_stat_bonuses") as mock_refresh:
+        p.unequip_item(item_object=item)
+
+    assert item.isequipped is False
+    item.on_unequip.assert_not_called()
+    mock_refresh.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# GameService.equip_item (toggle + merchandise guard + delegation)
+# ---------------------------------------------------------------------------
+
+
+def test_service_equip_equips_weapon(game_service):
+    p = _make_player()
+    item = _make_equippable(maintype="Weapon")
+    p.inventory = [item]
+
+    with (
+        patch("player._inventory.functions.refresh_stat_bonuses"),
+        patch("player._inventory.cprint"),
+    ):
+        result = game_service.equip_item(p, item)
+
+    assert result["success"] is True
+    assert "equipped" in result["message"]
+    assert item.isequipped is True
+    assert p.eq_weapon is item
+
+
+def test_service_equip_toggles_unequip_when_equipped(game_service):
+    p = _make_player()
+    item = _make_equippable(maintype="Armor")
+    item.isequipped = True
+    item.interactions = ["unequip"]
+    p.inventory = [item]
+
+    with (
+        patch("player._inventory.functions.refresh_stat_bonuses"),
+        patch("player._inventory.cprint"),
+    ):
+        result = game_service.equip_item(p, item)
+
+    assert result["success"] is True
+    assert "unequipped" in result["message"]
+    assert item.isequipped is False
+
+
+def test_service_equip_rejects_merchandise(game_service):
+    p = _make_player()
+    item = _make_equippable()
+    item.merchandise = True
+    p.inventory = [item]
+
+    result = game_service.equip_item(p, item)
+
+    assert "error" in result
+    assert "purchase" in result["error"].lower()
+    assert item.isequipped is False
+
+
+def test_service_equip_rejects_non_equippable(game_service):
+    p = _make_player()
+    item = MagicMock(spec=["name"])
+    item.name = "Herb"
+
+    result = game_service.equip_item(p, item)
+
+    assert "error" in result
+    assert "cannot be equipped" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# GameService.unequip_item
+# ---------------------------------------------------------------------------
+
+
+def test_service_unequip_success(game_service):
+    p = _make_player()
+    item = _make_equippable(maintype="Armor")
+    item.isequipped = True
+    item.interactions = ["unequip"]
+    p.inventory = [item]
+
+    with (
+        patch("player._inventory.functions.refresh_stat_bonuses"),
+        patch("player._inventory.cprint"),
+    ):
+        result = game_service.unequip_item(p, item)
+
+    assert result["success"] is True
+    assert "unequipped" in result["message"]
+    assert item.isequipped is False
+
+
+def test_service_unequip_not_equipped_errors(game_service):
+    p = _make_player()
+    item = _make_equippable(maintype="Armor")
+    item.isequipped = False
+    p.inventory = [item]
+
+    result = game_service.unequip_item(p, item)
+
+    assert "error" in result
+    assert "not equipped" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# GameService.drop_item (unequips equipped item, moves to tile)
+# ---------------------------------------------------------------------------
+
+
+def test_service_drop_equipped_item_unequips_then_drops(game_service):
+    p = _make_player()
+    item = _make_equippable(maintype="Weapon")
+    item.isequipped = True
+    item.interactions = ["unequip"]
+    p.inventory = [item]
+    p.eq_weapon = item
+
+    tile = MagicMock()
+    tile.items_here = []
+    p.universe = MagicMock()
+    p.universe.get_tile.return_value = tile
+
+    with (
+        patch("player._inventory.functions.refresh_stat_bonuses"),
+        patch("player._inventory.cprint"),
+    ):
+        result = game_service.drop_item(p, item)
+
+    assert result["success"] is True
+    assert item.isequipped is False
+    assert item in tile.items_here
+    assert item not in p.inventory
+    assert p.eq_weapon is getattr(p, "fists", None)

--- a/tests/test_game_service_equip_unequip.py
+++ b/tests/test_game_service_equip_unequip.py
@@ -240,3 +240,43 @@ def test_service_drop_equipped_item_unequips_then_drops(game_service):
     assert item in tile.items_here
     assert item not in p.inventory
     assert p.eq_weapon is getattr(p, "fists", None)
+
+
+# ---------------------------------------------------------------------------
+# Narration capture — engine flavor is surfaced via the `messages` field
+# ---------------------------------------------------------------------------
+
+
+def test_service_equip_returns_engine_narration(game_service):
+    """cprint flavor from the engine equip is captured into `messages`."""
+    p = _make_player()
+    item = _make_equippable(maintype="Weapon", name="TestSword")
+    p.inventory = [item]
+
+    # Note: cprint is NOT patched here so real narration flows into the sink.
+    with patch("player._inventory.functions.refresh_stat_bonuses"):
+        result = game_service.equip_item(p, item)
+
+    assert result["success"] is True
+    assert any("equipped" in m.lower() for m in result["messages"])
+
+
+def test_service_drop_equipped_returns_unequip_narration(game_service):
+    """The unequip-before-drop flavor is captured into `messages`."""
+    p = _make_player()
+    item = _make_equippable(maintype="Weapon", name="TestSword")
+    item.isequipped = True
+    item.interactions = ["unequip"]
+    p.inventory = [item]
+    p.eq_weapon = item
+
+    tile = MagicMock()
+    tile.items_here = []
+    p.universe = MagicMock()
+    p.universe.get_tile.return_value = tile
+
+    with patch("player._inventory.functions.refresh_stat_bonuses"):
+        result = game_service.drop_item(p, item)
+
+    assert result["success"] is True
+    assert any("back into his bag" in m.lower() for m in result["messages"])

--- a/tests/test_game_service_equip_unequip.py
+++ b/tests/test_game_service_equip_unequip.py
@@ -261,6 +261,24 @@ def test_service_equip_returns_engine_narration(game_service):
     assert any("equipped" in m.lower() for m in result["messages"])
 
 
+def test_service_drop_returns_drop_narration(game_service):
+    """A plain drop narrates the drop itself into `messages`."""
+    p = _make_player()
+    item = _make_equippable(name="TestSword")
+    item.isequipped = False
+    p.inventory = [item]
+
+    tile = MagicMock()
+    tile.items_here = []
+    p.universe = MagicMock()
+    p.universe.get_tile.return_value = tile
+
+    result = game_service.drop_item(p, item)
+
+    assert result["success"] is True
+    assert any("drops" in m.lower() for m in result["messages"])
+
+
 def test_service_drop_equipped_returns_unequip_narration(game_service):
     """The unequip-before-drop flavor is captured into `messages`."""
     p = _make_player()

--- a/tests/test_game_service_errors.py
+++ b/tests/test_game_service_errors.py
@@ -12,7 +12,6 @@ Target: 50-70 error scenario tests covering all exception paths.
 
 import pytest
 from unittest.mock import MagicMock, Mock, patch
-import logging
 from src.api.services.game_service import GameService
 
 
@@ -76,117 +75,76 @@ def mock_tile():
     return tile
 
 
-class TestUseItemErrors:
-    """Test error handling in use_item method."""
-
-    def test_use_item_inventory_not_list(self, game_service, mock_player):
-        """Test use_item when inventory is not a list."""
-        mock_player.inventory = None
-        result = game_service.use_item(mock_player, 0)
-        assert result["error"] == "Inventory not accessible"
-
-    def test_use_item_negative_index(self, game_service, mock_player):
-        """Test use_item with negative index."""
-        mock_player.inventory = []
-        result = game_service.use_item(mock_player, -1)
-        assert result["error"] == "Invalid item index"
-
-    def test_use_item_index_out_of_bounds(self, game_service, mock_player):
-        """Test use_item with index beyond inventory length."""
-        mock_player.inventory = []
-        result = game_service.use_item(mock_player, 5)
-        assert result["error"] == "Invalid item index"
-
-    def test_use_item_no_use_method(self, game_service, mock_player):
-        """Test use_item on item without use method."""
-        item = MagicMock(spec=[])  # No 'use' attribute
-        item.name = "Unusable"
-        mock_player.inventory = [item]
-
-        result = game_service.use_item(mock_player, 0)
-        assert result["success"] is False
-        assert "cannot be used" in result["error"]
-
-    def test_use_item_exception_in_use_method(self, game_service, mock_player):
-        """Test exception handling when item.use() fails."""
-        item = MagicMock()
-        item.name = "Broken Potion"
-        item.use = MagicMock(side_effect=Exception("Use failed"))
-        mock_player.inventory = [item]
-
-        result = game_service.use_item(mock_player, 0)
-        assert result["success"] is False
-        assert "error" in result
-
-    def test_use_item_success(self, game_service, mock_player):
-        """Test successful item use."""
-        item = MagicMock()
-        item.name = "Potion"
-        item.use = MagicMock(return_value={"healed": 20})
-        mock_player.inventory = [item]
-
-        result = game_service.use_item(mock_player, 0)
-        assert result["success"] is True
-        assert "Used" in result["message"]
-
-
 class TestDropItemErrors:
-    """Test error handling in drop_item method."""
-
-    def test_drop_item_inventory_not_list(self, game_service, mock_player):
-        """Test drop_item when inventory is not a list."""
-        mock_player.inventory = None
-        result = game_service.drop_item(mock_player, 0)
-        assert result["error"] == "Inventory not accessible"
-
-    def test_drop_item_negative_index(self, game_service, mock_player):
-        """Test drop_item with negative index."""
-        mock_player.inventory = []
-        result = game_service.drop_item(mock_player, -1)
-        assert result["error"] == "Invalid item index"
-
-    def test_drop_item_index_out_of_bounds(self, game_service, mock_player):
-        """Test drop_item with index beyond inventory."""
-        mock_player.inventory = []
-        result = game_service.drop_item(mock_player, 5)
-        assert result["error"] == "Invalid item index"
+    """Test error handling in the object-based drop_item method."""
 
     def test_drop_item_no_universe(self, game_service, mock_player):
-        """Test drop_item when universe is None - now returns error gracefully."""
+        """Test drop_item when universe is None - returns error gracefully."""
         item = MagicMock()
         item.name = "Item"
+        item.isequipped = False
         mock_player.inventory = [item]
         mock_player.universe = None
 
-        # FIX 1: Now returns error instead of raising AttributeError
-        result = game_service.drop_item(mock_player, 0)
+        result = game_service.drop_item(mock_player, item)
         assert "error" in result
-        assert "universe" in result["error"].lower()
+        assert "location" in result["error"].lower()
+        # Item not removed from inventory
+        assert item in mock_player.inventory
 
     def test_drop_item_no_tile_found(self, game_service, mock_player, mock_tile):
-        """Test drop_item when get_tile returns None - now returns error gracefully."""
+        """Test drop_item when get_tile returns None - returns error gracefully."""
         item = MagicMock()
         item.name = "Item"
+        item.isequipped = False
         mock_player.inventory = [item]
         mock_player.universe.get_tile = MagicMock(return_value=None)
 
-        # FIX 1: Now returns error to prevent item loss
-        result = game_service.drop_item(mock_player, 0)
+        result = game_service.drop_item(mock_player, item)
         assert "error" in result
         assert "location" in result["error"].lower()
         # Verify item was not removed from inventory
         assert item in mock_player.inventory
 
+    def test_drop_item_not_in_inventory(self, game_service, mock_player, mock_tile):
+        """Test drop_item when the item isn't in the inventory."""
+        item = MagicMock()
+        item.name = "Ghost"
+        item.isequipped = False
+        mock_player.inventory = []
+        mock_tile.items_here = []
+        mock_player.universe.get_tile = MagicMock(return_value=mock_tile)
+
+        result = game_service.drop_item(mock_player, item)
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
     def test_drop_item_success(self, game_service, mock_player, mock_tile):
-        """Test successful item drop."""
+        """Test successful item drop by object."""
         item = MagicMock()
         item.name = "Item"
+        item.isequipped = False
         mock_player.inventory = [item]
         mock_tile.items_here = []
         mock_player.universe.get_tile = MagicMock(return_value=mock_tile)
 
-        result = game_service.drop_item(mock_player, 0)
+        result = game_service.drop_item(mock_player, item)
         assert result["success"] is True
+        assert item in mock_tile.items_here
+        assert item not in mock_player.inventory
+
+    def test_drop_item_unequips_equipped(self, game_service, mock_player, mock_tile):
+        """Test drop_item unequips an equipped item first."""
+        item = MagicMock()
+        item.name = "Sword"
+        item.isequipped = True
+        mock_player.inventory = [item]
+        mock_tile.items_here = []
+        mock_player.universe.get_tile = MagicMock(return_value=mock_tile)
+
+        result = game_service.drop_item(mock_player, item)
+        assert result["success"] is True
+        mock_player.unequip_item.assert_called_once_with(item_object=item)
         assert item in mock_tile.items_here
 
 
@@ -572,49 +530,24 @@ class TestStateRecovery:
         """Test that drop_item maintains inventory consistency after error."""
         item = MagicMock()
         item.name = "Item"
+        item.isequipped = False
         mock_player.inventory = [item]
 
         # Try to drop with no universe
         mock_player.universe = None
         initial_count = len(mock_player.inventory)
 
-        # FIX 1: Now checks universe BEFORE popping item
-        result = game_service.drop_item(mock_player, 0)
+        # Universe missing -> no tile -> error before removing the item
+        result = game_service.drop_item(mock_player, item)
         assert "error" in result
 
-        # After error, item is still in inventory (GOOD - fixed)
-        # FIX 1 ensures item is not lost if universe is missing
+        # After error, item is still in inventory (not lost)
         assert len(mock_player.inventory) == initial_count
         assert item in mock_player.inventory
-
-class TestErrorLogging:
-    """Test that errors are properly logged."""
-
-    def test_use_item_error_logged(self, game_service, mock_player, caplog):
-        """Test that use_item exceptions are logged."""
-        item = MagicMock()
-        item.name = "Broken"
-        item.use = MagicMock(side_effect=Exception("Test error"))
-        mock_player.inventory = [item]
-
-        with caplog.at_level(logging.DEBUG):
-            result = game_service.use_item(mock_player, 0)
-
-        assert result["success"] is False
 
 
 class TestBoundaryConditions:
     """Test boundary conditions and edge cases."""
-
-    def test_use_item_index_zero(self, game_service, mock_player):
-        """Test use_item with index 0 (first item)."""
-        item = MagicMock()
-        item.name = "Potion"
-        item.use = MagicMock(return_value={})
-        mock_player.inventory = [item]
-
-        result = game_service.use_item(mock_player, 0)
-        assert result["success"] is True
 
     def test_shop_buy_quantity_one(self, game_service, mock_player, mock_tile):
         """Test shop_buy with quantity = 1 (minimum)."""
@@ -653,29 +586,18 @@ class TestBoundaryConditions:
         """Test drop_item when dropping last item from inventory."""
         item = MagicMock()
         item.name = "Last Item"
+        item.isequipped = False
         mock_player.inventory = [item]
         mock_tile.items_here = []
         mock_player.universe.get_tile = MagicMock(return_value=mock_tile)
 
-        result = game_service.drop_item(mock_player, 0)
+        result = game_service.drop_item(mock_player, item)
         assert result["success"] is True
         assert len(mock_player.inventory) == 0
 
 
 class TestTypeValidation:
     """Test type validation across methods."""
-
-    def test_use_item_string_index(self, game_service, mock_player):
-        """Test use_item with string index - raises TypeError."""
-        # String comparison with int raises TypeError
-        with pytest.raises(TypeError):
-            result = game_service.use_item(mock_player, "0")
-
-    def test_drop_item_dict_index(self, game_service, mock_player):
-        """Test drop_item with dict instead of int - raises TypeError."""
-        # Dict comparison with int raises TypeError
-        with pytest.raises(TypeError):
-            result = game_service.drop_item(mock_player, {})
 
     def test_shop_buy_invalid_quantity_type(self, game_service, mock_player, mock_tile):
         """Test shop_buy with invalid quantity type."""
@@ -692,25 +614,15 @@ class TestTypeValidation:
 class TestNullableAttributes:
     """Test handling of None/missing attributes."""
 
-    def test_use_item_null_name(self, game_service, mock_player):
-        """Test use_item with None item name."""
-        item = MagicMock()
-        item.name = None
-        item.use = MagicMock(return_value={})
-        mock_player.inventory = [item]
-
-        result = game_service.use_item(mock_player, 0)
-        # Should handle None name
-        assert result is not None
-
     def test_drop_item_null_name(self, game_service, mock_player, mock_tile):
         """Test drop_item with None item name."""
         item = MagicMock()
         item.name = None
+        item.isequipped = False
         mock_player.inventory = [item]
         mock_tile.items_here = []
         mock_player.universe.get_tile = MagicMock(return_value=mock_tile)
 
-        result = game_service.drop_item(mock_player, 0)
+        result = game_service.drop_item(mock_player, item)
         # Should handle None name
         assert result is not None

--- a/tests/test_game_service_tier2.py
+++ b/tests/test_game_service_tier2.py
@@ -220,37 +220,22 @@ class TestInventoryManagement:
         """Test dropping an item from inventory."""
         item = MagicMock()
         item.name = "Sword"
+        item.isequipped = False
         mock_player.inventory = [item]
 
-        result = game_service.drop_item(mock_player, 0)
+        result = game_service.drop_item(mock_player, item)
         assert result["success"] is True
         assert len(mock_player.inventory) == 0
 
-    def test_drop_item_invalid_index(self, game_service, mock_player):
-        """Test dropping item with invalid index."""
-        mock_player.inventory = []
-
-        result = game_service.drop_item(mock_player, 5)
-        assert result is not None  # Method handles gracefully
-
-    def test_use_item_success(self, game_service, mock_player):
-        """Test using an item from inventory."""
+    def test_drop_item_not_in_inventory(self, game_service, mock_player):
+        """Test dropping an item that isn't in the inventory."""
         item = MagicMock()
-        item.name = "Health Potion"
-        item.use = MagicMock()
-        mock_player.inventory = [item]
-        mock_player.hp = 50
-        mock_player.maxhp = 100
-
-        result = game_service.use_item(mock_player, 0)
-        assert result is not None
-
-    def test_use_item_invalid_index(self, game_service, mock_player):
-        """Test using item with invalid index."""
+        item.name = "Ghost"
+        item.isequipped = False
         mock_player.inventory = []
 
-        result = game_service.use_item(mock_player, 5)
-        assert result is not None  # Method handles gracefully
+        result = game_service.drop_item(mock_player, item)
+        assert "error" in result  # Method handles gracefully
 
     def test_collect_combat_loot(self, game_service, mock_player):
         """Test collecting loot from combat."""

--- a/tests/test_hardening_fixes.py
+++ b/tests/test_hardening_fixes.py
@@ -12,7 +12,7 @@ from src import player as player_module
 
 
 class TestDropItemHardening:
-    """Test FIX 1 & 2: drop_item() defensive checks and type validation."""
+    """Test drop_item() defensive checks on the object-based signature."""
 
     def test_drop_item_success_basic(self):
         """Test successful drop_item with valid state."""
@@ -21,6 +21,7 @@ class TestDropItemHardening:
         # Create a mock player with valid state
         item = Mock()
         item.name = "Test Item"
+        item.isequipped = False
         player = Mock()
         player.inventory = [item]
         player.universe = Mock()
@@ -28,7 +29,7 @@ class TestDropItemHardening:
         tile.items_here = []
         player.universe.get_tile = Mock(return_value=tile)
 
-        result = game_service.drop_item(player, 0)
+        result = game_service.drop_item(player, item)
 
         assert result["success"] is True
         assert result["item_name"] == "Test Item"
@@ -36,49 +37,52 @@ class TestDropItemHardening:
         assert item not in player.inventory
 
     def test_drop_item_universe_none(self):
-        """FIX 1: Test that drop_item returns error when universe is None."""
+        """Test that drop_item returns error when universe is None."""
         game_service = GameService()
 
         item = Mock()
         item.name = "Test Item"
+        item.isequipped = False
         player = Mock()
         player.inventory = [item]
         player.universe = None
 
-        result = game_service.drop_item(player, 0)
+        result = game_service.drop_item(player, item)
 
         assert "error" in result
-        assert "universe" in result["error"].lower()
+        assert "location" in result["error"].lower()
         # Verify item was not removed from inventory
         assert item in player.inventory
 
     def test_drop_item_no_universe_attr(self):
-        """FIX 1: Test that drop_item returns error when universe attribute missing."""
+        """Test that drop_item returns error when universe attribute missing."""
         game_service = GameService()
 
         item = Mock()
         item.name = "Test Item"
-        player = Mock(spec=[])  # No universe attribute
+        item.isequipped = False
+        player = Mock(spec=["inventory"])  # No universe attribute
         player.inventory = [item]
 
-        result = game_service.drop_item(player, 0)
+        result = game_service.drop_item(player, item)
 
         assert "error" in result
-        assert "universe" in result["error"].lower()
+        assert "location" in result["error"].lower()
         assert item in player.inventory
 
     def test_drop_item_tile_none(self):
-        """FIX 1: Test that drop_item returns error when tile is None."""
+        """Test that drop_item returns error when tile is None."""
         game_service = GameService()
 
         item = Mock()
         item.name = "Test Item"
+        item.isequipped = False
         player = Mock()
         player.inventory = [item]
         player.universe = Mock()
         player.universe.get_tile = Mock(return_value=None)
 
-        result = game_service.drop_item(player, 0)
+        result = game_service.drop_item(player, item)
 
         assert "error" in result
         assert "location" in result["error"].lower()
@@ -86,29 +90,51 @@ class TestDropItemHardening:
         assert item in player.inventory
 
     def test_drop_item_tile_missing_items_here(self):
-        """FIX 1: Test that drop_item returns error when tile lacks items_here."""
+        """Test that drop_item returns error when tile lacks items_here."""
         game_service = GameService()
 
         item = Mock()
         item.name = "Test Item"
+        item.isequipped = False
         player = Mock()
         player.inventory = [item]
         player.universe = Mock()
         tile = Mock(spec=[])  # No items_here attribute
         player.universe.get_tile = Mock(return_value=tile)
 
-        result = game_service.drop_item(player, 0)
+        result = game_service.drop_item(player, item)
 
         assert "error" in result
         assert "location" in result["error"].lower()
         # Verify item was not removed from inventory
         assert item in player.inventory
 
-    def test_drop_item_corrupted_inventory_item_no_name(self):
-        """FIX 2: Test that drop_item rejects items without name attribute."""
+    def test_drop_item_not_in_inventory(self):
+        """Test that drop_item errors when the item isn't in inventory."""
         game_service = GameService()
 
-        item = Mock(spec=[])  # No name attribute
+        item = Mock()
+        item.name = "Ghost"
+        item.isequipped = False
+        player = Mock()
+        player.inventory = []
+        player.universe = Mock()
+        tile = Mock()
+        tile.items_here = []
+        player.universe.get_tile = Mock(return_value=tile)
+
+        result = game_service.drop_item(player, item)
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_drop_item_unequips_equipped(self):
+        """Test that drop_item unequips an equipped item before dropping it."""
+        game_service = GameService()
+
+        item = Mock()
+        item.name = "Sword"
+        item.isequipped = True
         player = Mock()
         player.inventory = [item]
         player.universe = Mock()
@@ -116,118 +142,11 @@ class TestDropItemHardening:
         tile.items_here = []
         player.universe.get_tile = Mock(return_value=tile)
 
-        result = game_service.drop_item(player, 0)
-
-        assert "error" in result
-        assert "corrupted" in result["error"].lower()
-        assert item in player.inventory  # Not removed
-
-    def test_drop_item_invalid_index(self):
-        """Test that drop_item rejects invalid index."""
-        game_service = GameService()
-
-        player = Mock()
-        player.inventory = []
-
-        result = game_service.drop_item(player, 0)
-
-        assert "error" in result
-        assert "index" in result["error"].lower()
-
-    def test_drop_item_negative_index(self):
-        """Test that drop_item rejects negative index."""
-        game_service = GameService()
-
-        player = Mock()
-        player.inventory = [Mock(name="Item")]
-
-        result = game_service.drop_item(player, -1)
-
-        assert "error" in result
-        assert "index" in result["error"].lower()
-
-
-class TestUseItemHardening:
-    """Test FIX 2: use_item() type validation."""
-
-    def test_use_item_success_basic(self):
-        """Test successful use_item with valid item."""
-        game_service = GameService()
-
-        item = Mock()
-        item.name = "Test Potion"
-        item.use = Mock(return_value={"success": True})
-        player = Mock()
-        player.inventory = [item]
-
-        result = game_service.use_item(player, 0)
+        result = game_service.drop_item(player, item)
 
         assert result["success"] is True
-        assert "Used" in result["message"]
-
-    def test_use_item_string_in_inventory(self):
-        """FIX 2: Test that use_item rejects string in inventory."""
-        game_service = GameService()
-
-        player = Mock()
-        player.inventory = ["not_an_item"]
-
-        result = game_service.use_item(player, 0)
-
-        assert "error" in result
-        assert "corrupted" in result["error"].lower()
-
-    def test_use_item_dict_in_inventory(self):
-        """FIX 2: Test that use_item rejects dict in inventory."""
-        game_service = GameService()
-
-        player = Mock()
-        player.inventory = [{"name": "Item"}]
-
-        result = game_service.use_item(player, 0)
-
-        assert "error" in result
-        assert "corrupted" in result["error"].lower()
-
-    def test_use_item_int_in_inventory(self):
-        """FIX 2: Test that use_item rejects int in inventory."""
-        game_service = GameService()
-
-        player = Mock()
-        player.inventory = [42]
-
-        result = game_service.use_item(player, 0)
-
-        assert "error" in result
-        assert "corrupted" in result["error"].lower()
-
-    def test_use_item_missing_name_attribute(self):
-        """FIX 2: Test that use_item rejects item missing name."""
-        game_service = GameService()
-
-        item = Mock(spec=[])  # No name attribute
-        player = Mock()
-        player.inventory = [item]
-
-        result = game_service.use_item(player, 0)
-
-        assert "error" in result
-        assert "name" in result["error"].lower()
-
-    def test_use_item_no_use_method(self):
-        """Test that use_item rejects item without use method."""
-        game_service = GameService()
-
-        item = Mock()
-        item.name = "Decoration"
-        item.use = None  # Not callable
-        player = Mock()
-        player.inventory = [item]
-
-        result = game_service.use_item(player, 0)
-
-        assert result["success"] is False
-        assert "cannot be used" in result["error"]
+        player.unequip_item.assert_called_once_with(item_object=item)
+        assert item in tile.items_here
 
 
 class TestCollectCombatLootHardening:
@@ -763,10 +682,12 @@ class TestRegressionScenarios:
         sword = Mock()
         sword.name = "Iron Sword"
         sword.weight = 5.0
+        sword.isequipped = False
 
         potion = Mock()
         potion.name = "Health Potion"
         potion.use = Mock(return_value={"healed": 10})
+        potion.isequipped = False
 
         player = Mock()
         player.inventory = [sword, potion]
@@ -776,13 +697,10 @@ class TestRegressionScenarios:
         player.universe.get_tile = Mock(return_value=tile)
 
         # Test drop
-        result = game_service.drop_item(player, 0)
+        result = game_service.drop_item(player, sword)
         assert result["success"] is True
         assert len(player.inventory) == 1
-
-        # Test use
-        result = game_service.use_item(player, 0)
-        assert result["success"] is True
+        assert sword in tile.items_here
 
     def test_loot_collection_flow(self):
         """Ensure normal loot collection still works."""

--- a/tests/test_inventory_routes_coverage.py
+++ b/tests/test_inventory_routes_coverage.py
@@ -239,11 +239,13 @@ class TestDropItem:
             )
         assert resp.status_code == 400
 
-    def test_tile_not_found_returns_400(self):
+    def test_service_error_returns_400(self):
         item = _make_item()
         player = _make_player(items=[item])
-        player.universe.get_tile.return_value = None
         app, _, _, _ = _make_app(player=player)
+        app.game_service.drop_item.return_value = {
+            "error": "Cannot drop item: invalid current location"
+        }
         with patch("src.api.routes.inventory.InventorySerializer") as mock_ser:
             mock_ser.serialize.return_value = {}
             with app.test_client() as c:
@@ -254,10 +256,14 @@ class TestDropItem:
                 )
         assert resp.status_code == 400
 
-    def test_drop_unequipped_item_success(self):
+    def test_drop_success_delegates_to_service(self):
         item = _make_item(isequipped=False)
         player = _make_player(items=[item])
         app, _, _, _ = _make_app(player=player)
+        app.game_service.drop_item.return_value = {
+            "success": True,
+            "message": "Dropped Iron Sword",
+        }
         with patch("src.api.routes.inventory.InventorySerializer") as mock_ser:
             mock_ser.serialize.return_value = {"items": []}
             with app.test_client() as c:
@@ -268,31 +274,17 @@ class TestDropItem:
                 )
         assert resp.status_code == 200
         assert resp.get_json()["success"] is True
-
-    def test_drop_equipped_weapon_unequips_first(self):
-        item = _make_item(isequipped=True, maintype="Weapon")
-        player = _make_player(items=[item])
-        app, _, _, _ = _make_app(player=player)
-        with (
-            patch("src.api.routes.inventory.InventorySerializer") as mock_ser,
-            patch("src.functions.refresh_stat_bonuses"),
-        ):
-            mock_ser.serialize.return_value = {}
-            with app.test_client() as c:
-                resp = c.post(
-                    "/inventory/drop",
-                    json={"item_index": 0},
-                    headers={"Authorization": AUTH},
-                )
-        # Item should have been unequipped
-        assert item.isequipped is False
-        assert resp.status_code == 200
+        app.game_service.drop_item.assert_called_once_with(player, item)
 
     def test_drop_by_item_id(self):
         item = _make_item(isequipped=False)
         player = _make_player(items=[item])
         item_id = str(id(item))
         app, _, _, _ = _make_app(player=player)
+        app.game_service.drop_item.return_value = {
+            "success": True,
+            "message": "Dropped Iron Sword",
+        }
         with patch("src.api.routes.inventory.InventorySerializer") as mock_ser:
             mock_ser.serialize.return_value = {}
             with app.test_client() as c:
@@ -302,21 +294,7 @@ class TestDropItem:
                     headers={"Authorization": AUTH},
                 )
         assert resp.status_code == 200
-
-    def test_item_with_stack_grammar_called(self):
-        item = _make_item(isequipped=False)
-        item.stack_grammar = MagicMock()
-        player = _make_player(items=[item])
-        app, _, _, _ = _make_app(player=player)
-        with patch("src.api.routes.inventory.InventorySerializer") as mock_ser:
-            mock_ser.serialize.return_value = {}
-            with app.test_client() as c:
-                c.post(
-                    "/inventory/drop",
-                    json={"item_index": 0},
-                    headers={"Authorization": AUTH},
-                )
-        item.stack_grammar.assert_called_once()
+        app.game_service.drop_item.assert_called_once_with(player, item)
 
 
 # ---------------------------------------------------------------------------
@@ -369,12 +347,15 @@ class TestEquipItem:
             )
         assert resp.status_code == 400
 
-    def test_item_not_equippable_returns_400(self):
+    def test_service_error_returns_400(self):
         item = MagicMock(spec=["name", "merchandise"])
         item.name = "Herb"
         item.merchandise = False
         player = _make_player(items=[item])
         app, _, _, _ = _make_app(player=player)
+        app.game_service.equip_item.return_value = {
+            "error": "Herb cannot be equipped"
+        }
         with app.test_client() as c:
             resp = c.post(
                 "/inventory/equip",
@@ -387,6 +368,9 @@ class TestEquipItem:
         item = _make_item(merchandise=True)
         player = _make_player(items=[item])
         app, _, _, _ = _make_app(player=player)
+        app.game_service.equip_item.return_value = {
+            "error": "You must purchase Iron Sword before equipping it"
+        }
         with app.test_client() as c:
             resp = c.post(
                 "/inventory/equip",
@@ -395,14 +379,17 @@ class TestEquipItem:
             )
         assert resp.status_code == 400
 
-    def test_equip_item_success(self):
+    def test_equip_success_delegates_to_service(self):
         item = _make_item(isequipped=False, maintype="Armor")
         player = _make_player(items=[item])
         app, _, _, _ = _make_app(player=player)
+        app.game_service.equip_item.return_value = {
+            "success": True,
+            "message": "Iron Sword equipped",
+        }
         with (
             patch("src.api.routes.inventory.EquipmentSerializer") as mock_eq,
             patch("src.api.routes.inventory.InventorySerializer") as mock_inv,
-            patch("src.functions.refresh_stat_bonuses"),
         ):
             mock_eq.serialize.return_value = {}
             mock_inv.serialize.return_value = {}
@@ -413,17 +400,23 @@ class TestEquipItem:
                     headers={"Authorization": AUTH},
                 )
         assert resp.status_code == 200
-        assert resp.get_json()["success"] is True
-        assert item.isequipped is True
+        body = resp.get_json()
+        assert body["success"] is True
+        assert body["message"] == "Iron Sword equipped"
+        app.game_service.equip_item.assert_called_once_with(player, item)
 
-    def test_unequip_already_equipped_item(self):
+    def test_equip_toggle_unequip_message(self):
+        """An already-equipped item returns the service's unequip message."""
         item = _make_item(isequipped=True, maintype="Armor")
         player = _make_player(items=[item])
         app, _, _, _ = _make_app(player=player)
+        app.game_service.equip_item.return_value = {
+            "success": True,
+            "message": "Iron Sword unequipped",
+        }
         with (
             patch("src.api.routes.inventory.EquipmentSerializer") as mock_eq,
             patch("src.api.routes.inventory.InventorySerializer") as mock_inv,
-            patch("src.functions.refresh_stat_bonuses"),
         ):
             mock_eq.serialize.return_value = {}
             mock_inv.serialize.return_value = {}
@@ -434,97 +427,7 @@ class TestEquipItem:
                     headers={"Authorization": AUTH},
                 )
         assert resp.status_code == 200
-        assert item.isequipped is False
-
-    def test_equip_weapon_sets_eq_weapon(self):
-        item = _make_item(isequipped=False, maintype="Weapon")
-        player = _make_player(items=[item])
-        app, _, _, _ = _make_app(player=player)
-        with (
-            patch("src.api.routes.inventory.EquipmentSerializer") as mock_eq,
-            patch("src.api.routes.inventory.InventorySerializer") as mock_inv,
-            patch("src.functions.refresh_stat_bonuses"),
-        ):
-            mock_eq.serialize.return_value = {}
-            mock_inv.serialize.return_value = {}
-            with app.test_client() as c:
-                c.post(
-                    "/inventory/equip",
-                    json={"item_index": 0},
-                    headers={"Authorization": AUTH},
-                )
-        assert player.eq_weapon is item
-
-    def test_equip_replaces_same_maintype(self):
-        item_old = _make_item("Old Sword", isequipped=True, maintype="Weapon")
-        item_new = _make_item("New Sword", isequipped=False, maintype="Weapon")
-        player = _make_player(items=[item_old, item_new])
-        app, _, _, _ = _make_app(player=player)
-        with (
-            patch("src.api.routes.inventory.EquipmentSerializer") as mock_eq,
-            patch("src.api.routes.inventory.InventorySerializer") as mock_inv,
-            patch("src.functions.refresh_stat_bonuses"),
-        ):
-            mock_eq.serialize.return_value = {}
-            mock_inv.serialize.return_value = {}
-            with app.test_client() as c:
-                c.post(
-                    "/inventory/equip",
-                    json={"item_index": 1},
-                    headers={"Authorization": AUTH},
-                )
-        # Old sword should be unequipped
-        assert item_old.isequipped is False
-        assert item_new.isequipped is True
-
-    def test_accessory_single_slot_replaces(self):
-        item_old = _make_item(
-            "Amulet", isequipped=True, maintype="Accessory", subtype="Amulet"
-        )
-        item_new = _make_item(
-            "Amulet2", isequipped=False, maintype="Accessory", subtype="Amulet"
-        )
-        player = _make_player(items=[item_old, item_new])
-        app, _, _, _ = _make_app(player=player)
-        with (
-            patch("src.api.routes.inventory.EquipmentSerializer") as mock_eq,
-            patch("src.api.routes.inventory.InventorySerializer") as mock_inv,
-            patch("src.functions.refresh_stat_bonuses"),
-        ):
-            mock_eq.serialize.return_value = {}
-            mock_inv.serialize.return_value = {}
-            with app.test_client() as c:
-                c.post(
-                    "/inventory/equip",
-                    json={"item_index": 1},
-                    headers={"Authorization": AUTH},
-                )
-        assert item_old.isequipped is False
-
-    def test_ring_allows_multiple_equipped(self):
-        item_old = _make_item(
-            "Ring1", isequipped=True, maintype="Accessory", subtype="Ring"
-        )
-        item_new = _make_item(
-            "Ring2", isequipped=False, maintype="Accessory", subtype="Ring"
-        )
-        player = _make_player(items=[item_old, item_new])
-        app, _, _, _ = _make_app(player=player)
-        with (
-            patch("src.api.routes.inventory.EquipmentSerializer") as mock_eq,
-            patch("src.api.routes.inventory.InventorySerializer") as mock_inv,
-            patch("src.functions.refresh_stat_bonuses"),
-        ):
-            mock_eq.serialize.return_value = {}
-            mock_inv.serialize.return_value = {}
-            with app.test_client() as c:
-                c.post(
-                    "/inventory/equip",
-                    json={"item_index": 1},
-                    headers={"Authorization": AUTH},
-                )
-        # Ring1 should remain equipped (rings allow multiples)
-        assert item_old.isequipped is True
+        assert resp.get_json()["message"] == "Iron Sword unequipped"
 
 
 # ---------------------------------------------------------------------------
@@ -756,24 +659,13 @@ class TestUnequipItem:
             )
         assert resp.status_code == 400
 
-    def test_item_not_equippable_returns_400(self):
-        item = MagicMock(spec=["name", "merchandise"])
-        item.name = "Herb"
-        item.merchandise = False
-        player = _make_player(items=[item])
-        app, _, _, _ = _make_app(player=player)
-        with app.test_client() as c:
-            resp = c.post(
-                "/inventory/unequip",
-                json={"item_index": 0},
-                headers={"Authorization": AUTH},
-            )
-        assert resp.status_code == 400
-
-    def test_not_currently_equipped_returns_400(self):
+    def test_service_error_returns_400(self):
         item = _make_item("Helmet", isequipped=False, maintype="Armor")
         player = _make_player(items=[item])
         app, _, _, _ = _make_app(player=player)
+        app.game_service.unequip_item.return_value = {
+            "error": "Helmet is not equipped"
+        }
         with app.test_client() as c:
             resp = c.post(
                 "/inventory/unequip",
@@ -782,14 +674,17 @@ class TestUnequipItem:
             )
         assert resp.status_code == 400
 
-    def test_unequip_success_clears_slot_and_refreshes_stats(self):
+    def test_unequip_success_delegates_to_service(self):
         item = _make_item("Helmet", isequipped=True, maintype="Armor")
         player = _make_player(items=[item])
         app, _, _, _ = _make_app(player=player)
+        app.game_service.unequip_item.return_value = {
+            "success": True,
+            "message": "Helmet unequipped",
+        }
         with (
             patch("src.api.routes.inventory.EquipmentSerializer") as mock_eq,
             patch("src.api.routes.inventory.InventorySerializer") as mock_inv,
-            patch("src.functions.refresh_stat_bonuses") as mock_refresh,
         ):
             mock_eq.serialize.return_value = {}
             mock_inv.serialize.return_value = {}
@@ -800,34 +695,10 @@ class TestUnequipItem:
                     headers={"Authorization": AUTH},
                 )
         assert resp.status_code == 200
-        assert resp.get_json()["success"] is True
-        # The actual bug being fixed: the slot must clear and on_unequip/
-        # refresh_stat_bonuses must be called — not just validated and ignored.
-        assert item.isequipped is False
-        item.on_unequip.assert_called_once_with(player)
-        mock_refresh.assert_called_once_with(player)
-
-    def test_unequip_weapon_resets_to_fists(self):
-        item = _make_item("Iron Sword", isequipped=True, maintype="Weapon")
-        player = _make_player(items=[item])
-        player.eq_weapon = item
-        app, _, _, _ = _make_app(player=player)
-        with (
-            patch("src.api.routes.inventory.EquipmentSerializer") as mock_eq,
-            patch("src.api.routes.inventory.InventorySerializer") as mock_inv,
-            patch("src.functions.refresh_stat_bonuses"),
-        ):
-            mock_eq.serialize.return_value = {}
-            mock_inv.serialize.return_value = {}
-            with app.test_client() as c:
-                resp = c.post(
-                    "/inventory/unequip",
-                    json={"item_index": 0},
-                    headers={"Authorization": AUTH},
-                )
-        assert resp.status_code == 200
-        assert item.isequipped is False
-        assert player.eq_weapon is player.fists
+        body = resp.get_json()
+        assert body["success"] is True
+        assert body["message"] == "Helmet unequipped"
+        app.game_service.unequip_item.assert_called_once_with(player, item)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validators_and_sanitizer.py
+++ b/tests/test_validators_and_sanitizer.py
@@ -10,17 +10,7 @@ import pytest
 from src.api.services.validators import (
     validate_required_fields,
     validate_direction,
-    validate_coordinates,
-    validate_item_slot,
-    validate_combat_action,
-    validate_save_name,
-    validate_string_field,
-    validate_positive_integer,
-    validate_range,
     validate_item_index,
-    validate_equipment_slot,
-    validate_weight_limit,
-    validate_currency_amount,
     validate_npc_id,
 )
 from src.api.utils.input_sanitizer import sanitize_event_input
@@ -72,13 +62,25 @@ class TestValidateRequiredFields:
 
 
 class TestValidateDirection:
-    @pytest.mark.parametrize("d", ["north", "south", "east", "west"])
+    @pytest.mark.parametrize(
+        "d",
+        [
+            "north",
+            "south",
+            "east",
+            "west",
+            "northeast",
+            "northwest",
+            "southeast",
+            "southwest",
+        ],
+    )
     def test_valid_directions(self, d):
         ok, err = validate_direction(d)
         assert ok is True
         assert err is None
 
-    @pytest.mark.parametrize("d", ["North", "SOUTH", "East"])
+    @pytest.mark.parametrize("d", ["North", "SOUTH", "East", "NorthEast"])
     def test_case_insensitive(self, d):
         ok, err = validate_direction(d)
         assert ok is True
@@ -90,235 +92,6 @@ class TestValidateDirection:
 
     def test_empty_string(self):
         ok, err = validate_direction("")
-        assert ok is False
-
-
-# ---------------------------------------------------------------------------
-# validate_coordinates
-# ---------------------------------------------------------------------------
-
-
-class TestValidateCoordinates:
-    def test_valid_zero_zero(self):
-        ok, err = validate_coordinates(0, 0)
-        assert ok is True
-
-    def test_valid_positive(self):
-        ok, err = validate_coordinates(50, 50)
-        assert ok is True
-
-    def test_valid_negative(self):
-        ok, err = validate_coordinates(-99, -100)
-        assert ok is True
-
-    def test_out_of_range_positive(self):
-        ok, err = validate_coordinates(101, 0)
-        assert ok is False
-        assert "100" in err
-
-    def test_out_of_range_negative(self):
-        ok, err = validate_coordinates(0, -101)
-        assert ok is False
-
-    def test_string_coercible_to_int(self):
-        ok, err = validate_coordinates("5", "10")
-        assert ok is True
-
-    def test_non_numeric(self):
-        ok, err = validate_coordinates("abc", 0)
-        assert ok is False
-        assert "integer" in err
-
-    def test_none_values(self):
-        ok, err = validate_coordinates(None, None)
-        assert ok is False
-
-
-# ---------------------------------------------------------------------------
-# validate_item_slot
-# ---------------------------------------------------------------------------
-
-
-class TestValidateItemSlot:
-    @pytest.mark.parametrize(
-        "slot",
-        [
-            "head",
-            "chest",
-            "hands",
-            "legs",
-            "feet",
-            "main_hand",
-            "off_hand",
-            "accessory1",
-            "accessory2",
-        ],
-    )
-    def test_all_valid_slots(self, slot):
-        ok, err = validate_item_slot(slot)
-        assert ok is True
-
-    def test_case_insensitive(self):
-        ok, err = validate_item_slot("HEAD")
-        assert ok is True
-
-    def test_invalid_slot(self):
-        ok, err = validate_item_slot("waist")
-        assert ok is False
-        assert "waist" in err
-
-
-# ---------------------------------------------------------------------------
-# validate_combat_action
-# ---------------------------------------------------------------------------
-
-
-class TestValidateCombatAction:
-    @pytest.mark.parametrize("action", ["attack", "defend", "cast", "item", "flee"])
-    def test_valid_actions(self, action):
-        ok, err = validate_combat_action(action)
-        assert ok is True
-
-    def test_case_insensitive(self):
-        ok, err = validate_combat_action("ATTACK")
-        assert ok is True
-
-    def test_invalid_action(self):
-        ok, err = validate_combat_action("dodge")
-        assert ok is False
-
-
-# ---------------------------------------------------------------------------
-# validate_save_name
-# ---------------------------------------------------------------------------
-
-
-class TestValidateSaveName:
-    def test_valid_name(self):
-        ok, err = validate_save_name("my_save_01")
-        assert ok is True
-
-    def test_empty_string(self):
-        ok, err = validate_save_name("")
-        assert ok is False
-
-    def test_none_value(self):
-        ok, err = validate_save_name(None)
-        assert ok is False
-
-    def test_name_too_long(self):
-        ok, err = validate_save_name("a" * 51)
-        assert ok is False
-        assert "50" in err
-
-    def test_exactly_50_chars(self):
-        ok, err = validate_save_name("a" * 50)
-        assert ok is True
-
-    @pytest.mark.parametrize("bad_char", ["/", "\\", ":", "*", "?", '"', "<", ">", "|"])
-    def test_invalid_characters(self, bad_char):
-        ok, err = validate_save_name(f"save{bad_char}name")
-        assert ok is False
-        assert "invalid" in err.lower()
-
-
-# ---------------------------------------------------------------------------
-# validate_string_field
-# ---------------------------------------------------------------------------
-
-
-class TestValidateStringField:
-    def test_valid_string(self):
-        ok, err = validate_string_field("username", "Jean")
-        assert ok is True
-
-    def test_non_string(self):
-        ok, err = validate_string_field("username", 123)
-        assert ok is False
-        assert "string" in err
-
-    def test_too_short(self):
-        ok, err = validate_string_field("username", "", min_length=1)
-        assert ok is False
-
-    def test_too_long(self):
-        ok, err = validate_string_field("bio", "x" * 11, max_length=10)
-        assert ok is False
-        assert "10" in err
-
-    def test_exactly_max_length(self):
-        ok, err = validate_string_field("bio", "x" * 10, max_length=10)
-        assert ok is True
-
-    def test_custom_min_length(self):
-        ok, err = validate_string_field("code", "ab", min_length=3)
-        assert ok is False
-
-
-# ---------------------------------------------------------------------------
-# validate_positive_integer
-# ---------------------------------------------------------------------------
-
-
-class TestValidatePositiveInteger:
-    def test_valid_positive(self):
-        ok, err = validate_positive_integer("count", 5)
-        assert ok is True
-
-    def test_minimum_one_passes(self):
-        ok, err = validate_positive_integer("count", 1)
-        assert ok is True
-
-    def test_below_minimum(self):
-        ok, err = validate_positive_integer("count", 0)
-        assert ok is False
-
-    def test_string_coercible(self):
-        ok, err = validate_positive_integer("count", "3")
-        assert ok is True
-
-    def test_non_numeric(self):
-        ok, err = validate_positive_integer("count", "abc")
-        assert ok is False
-
-    def test_custom_min_value(self):
-        ok, err = validate_positive_integer("count", 4, min_value=5)
-        assert ok is False
-        assert "5" in err
-
-
-# ---------------------------------------------------------------------------
-# validate_range
-# ---------------------------------------------------------------------------
-
-
-class TestValidateRange:
-    def test_in_range(self):
-        ok, err = validate_range("speed", 50, 0, 100)
-        assert ok is True
-
-    def test_at_min(self):
-        ok, err = validate_range("speed", 0, 0, 100)
-        assert ok is True
-
-    def test_at_max(self):
-        ok, err = validate_range("speed", 100, 0, 100)
-        assert ok is True
-
-    def test_below_min(self):
-        ok, err = validate_range("speed", -1, 0, 100)
-        assert ok is False
-
-    def test_above_max(self):
-        ok, err = validate_range("speed", 101, 0, 100)
-        assert ok is False
-
-    def test_float_value(self):
-        ok, err = validate_range("ratio", 0.5, 0.0, 1.0)
-        assert ok is True
-
-    def test_non_numeric(self):
-        ok, err = validate_range("speed", "fast", 0, 100)
         assert ok is False
 
 
@@ -350,96 +123,6 @@ class TestValidateItemIndex:
 
     def test_non_numeric(self):
         ok, err = validate_item_index("abc", 5)
-        assert ok is False
-
-
-# ---------------------------------------------------------------------------
-# validate_equipment_slot
-# ---------------------------------------------------------------------------
-
-
-class TestValidateEquipmentSlot:
-    @pytest.mark.parametrize(
-        "slot",
-        [
-            "weapon",
-            "shield",
-            "head",
-            "body",
-            "legs",
-            "hands",
-            "feet",
-            "accessory_1",
-            "accessory_2",
-        ],
-    )
-    def test_valid_slots(self, slot):
-        ok, err = validate_equipment_slot(slot)
-        assert ok is True
-
-    def test_invalid_slot(self):
-        ok, err = validate_equipment_slot("chest")
-        assert ok is False
-
-    def test_case_sensitive(self):
-        # validate_equipment_slot does NOT call .lower() — it's case-sensitive
-        ok, err = validate_equipment_slot("Head")
-        assert ok is False
-
-
-# ---------------------------------------------------------------------------
-# validate_weight_limit
-# ---------------------------------------------------------------------------
-
-
-class TestValidateWeightLimit:
-    def test_under_limit(self):
-        ok, err = validate_weight_limit(5.0, 3.0, 10.0)
-        assert ok is True
-
-    def test_exactly_at_limit(self):
-        ok, err = validate_weight_limit(7.0, 3.0, 10.0)
-        assert ok is True
-
-    def test_over_limit(self):
-        ok, err = validate_weight_limit(8.0, 3.0, 10.0)
-        assert ok is False
-        assert "11.0" in err
-
-    def test_zero_current_weight(self):
-        ok, err = validate_weight_limit(0.0, 10.0, 10.0)
-        assert ok is True
-
-
-# ---------------------------------------------------------------------------
-# validate_currency_amount
-# ---------------------------------------------------------------------------
-
-
-class TestValidateCurrencyAmount:
-    def test_valid_amount(self):
-        ok, err = validate_currency_amount(10, 100)
-        assert ok is True
-
-    def test_zero_amount(self):
-        ok, err = validate_currency_amount(0, 100)
-        assert ok is False
-
-    def test_negative_amount(self):
-        ok, err = validate_currency_amount(-5, 100)
-        assert ok is False
-
-    def test_exceeds_available(self):
-        ok, err = validate_currency_amount(200, 100)
-        assert ok is False
-        assert "200" in err
-
-    def test_exactly_available(self):
-        ok, err = validate_currency_amount(100, 100)
-        assert ok is True
-
-    def test_non_numeric(self):
-        ok, err = validate_currency_amount("much", 100)
         assert ok is False
 
 

--- a/tests/test_world_routes_coverage.py
+++ b/tests/test_world_routes_coverage.py
@@ -89,6 +89,7 @@ def _make_game_service():
         "success": True,
         "output_text": "Event processed.",
     }
+    gs.is_player_dead.return_value = False
     return gs
 
 
@@ -341,6 +342,7 @@ class TestSubmitEventInput:
 
     def test_player_death_sets_game_over(self, app):
         app._test_player.hp = 0
+        app._test_gs.is_player_dead.return_value = True
         with patch(
             self._SANITIZER_PATH,
             return_value=("ok", None),
@@ -689,7 +691,7 @@ class TestTriggerRoomEvents:
         tile.x = 0
         tile.y = 0
         tile.block_exit = []
-        app._test_player.universe.get_tile.return_value = tile
+        app._test_gs.get_current_tile_object.return_value = tile
         with app.test_client() as c:
             rv = c.post("/world/events", headers=AUTH)
         assert rv.status_code == 200
@@ -697,7 +699,7 @@ class TestTriggerRoomEvents:
         assert data["success"] is True
 
     def test_tile_not_found(self, app):
-        app._test_player.universe.get_tile.return_value = None
+        app._test_gs.get_current_tile_object.return_value = None
         with app.test_client() as c:
             rv = c.post("/world/events", headers=AUTH)
         assert rv.status_code == 404
@@ -707,7 +709,7 @@ class TestTriggerRoomEvents:
         assert rv.status_code == 401
 
     def test_exception_returns_500(self, app):
-        app._test_player.universe.get_tile.side_effect = RuntimeError("crash")
+        app._test_gs.get_current_tile_object.side_effect = RuntimeError("crash")
         with app.test_client() as c:
             rv = c.post("/world/events", headers=AUTH)
         assert rv.status_code == 500


### PR DESCRIPTION
Resolves the boundary violations and dead-code items from issue #260.

Engine/service consolidation:
- Add Player.unequip_item (engine source of truth for unequip, mirrors equip)
- GameService gains canonical equip_item (toggle + merchandise guard, delegates
  core mechanics to the engine), unequip_item, and object-based drop_item;
  remove the orphaned index-based use_item/drop_item stubs
- Add GameService helpers get_current_tile_object, is_player_dead,
  set_suggestions_paused

Routes now delegate instead of mutating player internals:
- inventory drop/equip/unequip call GameService and only serialize
- world move wires validate_direction (expanded to all 8 directions); tile
  lookup and death detection go through GameService
- combat toggle_suggestions_pause delegates; dead GET /combat/log removed

Validators: delete the 10 unused validators, keep the 4 in use.

Tests: add real-Player/real-item characterization suite for the equip/unequip/
drop path; update route/service/validator tests to the delegated architecture.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CNHhj1crKt9SiRuAuwATFQ