### PR TITLE
Fix CombatMovePanel scrolling and layout overflow

### DIFF
--- a/frontend/src/components/CombatMovePanel.jsx
+++ b/frontend/src/components/CombatMovePanel.jsx
@@ -30,6 +30,9 @@ const CombatMovePanel = ({ moves, category, onMoveClick, onClose, onTargetHover 
                 zIndex: 100,
                 minWidth: '320px',
                 maxWidth: '450px',
+                maxHeight: '80vh',
+                display: 'flex',
+                flexDirection: 'column',
                 backgroundColor: colors.bg.panelDeep,
             }}
         >
@@ -40,6 +43,7 @@ const CombatMovePanel = ({ moves, category, onMoveClick, onClose, onTargetHover 
                 marginBottom: spacing.md,
                 borderBottom: `1px solid ${colors.border.light}`,
                 paddingBottom: spacing.sm,
+                flexShrink: 0,
             }}>
                 <GameText variant="secondary" weight="bold" style={{ textTransform: 'uppercase' }}>
                     {category} MOVES
@@ -59,7 +63,7 @@ const CombatMovePanel = ({ moves, category, onMoveClick, onClose, onTargetHover 
                 </button>
             </div>
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: spacing.sm }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: spacing.sm, overflowY: 'auto', flex: 1, minHeight: 0, paddingRight: spacing.sm, marginRight: -spacing.sm }}>
                 {filteredMoves.length === 0 ? (
                     <GameText variant="muted" align="center" style={{ fontStyle: 'italic', padding: spacing.md }}>
                         No moves available in this category.

--- a/frontend/src/components/CombatMovePanel.jsx
+++ b/frontend/src/components/CombatMovePanel.jsx
@@ -63,7 +63,7 @@ const CombatMovePanel = ({ moves, category, onMoveClick, onClose, onTargetHover 
                 </button>
             </div>
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: spacing.sm, overflowY: 'auto', flex: 1, minHeight: 0, paddingRight: spacing.sm, marginRight: -spacing.sm }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: spacing.sm, overflowY: 'auto', flex: 1, minHeight: 0 /* Critical: flex children need minHeight:0 to shrink below content size and enable scrolling */, paddingRight: spacing.sm, marginRight: -spacing.sm }}>
                 {filteredMoves.length === 0 ? (
                     <GameText variant="muted" align="center" style={{ fontStyle: 'italic', padding: spacing.md }}>
                         No moves available in this category.


### PR DESCRIPTION
## Summary
Fixed layout issues in the CombatMovePanel component where the moves list could overflow the panel boundaries. The panel now properly constrains its height and implements scrolling for the moves list when content exceeds available space.

## Changes
- Added `maxHeight: '80vh'`, `display: 'flex'`, and `flexDirection: 'column'` to the main panel container to establish a flex layout with viewport-constrained height
- Added `flexShrink: 0` to the header section to prevent it from shrinking when the moves list overflows
- Updated the moves list container with:
  - `overflowY: 'auto'` to enable vertical scrolling
  - `flex: 1` to consume available space
  - `minHeight: 0` to allow flex shrinking below content size
  - `paddingRight` and negative `marginRight` to accommodate scrollbar without layout shift

## Implementation Details
The fix uses CSS flexbox to create a proper layout hierarchy:
1. Panel container becomes a flex column with max height constraint
2. Header is fixed (non-shrinking) at the top
3. Moves list grows to fill remaining space and scrolls independently when needed

This prevents the panel from expanding beyond the viewport and ensures the header remains visible while scrolling through moves.

https://claude.ai/code/session_017eCRDrzQiPrncyVhvG6UdB