### PR TITLE
feat(npc): static ally NPC progression — exp mirroring, deterministic growth, skill schedules, signature moves

### DIFF
--- a/docs/development/ally-progression-design.md
+++ b/docs/development/ally-progression-design.md
@@ -1,7 +1,29 @@
 # Ally NPC Progression — Design Document
 
-**Status:** Proposed (not yet implemented)
+**Status:** Implemented (signature moves pending collaborative design)
 **Branch:** `claude/ally-npc-progression-eooks1`
+
+> Implementation notes (deltas from the original proposal below):
+> - **No UI surface.** Per user decision, ally growth is surfaced through the
+>   LLM ally chat instead of exp bars/level badges: progressing allies get a
+>   `COMBAT SELF-KNOWLEDGE` block in their chat system prompt
+>   (`HumanNPCLLMMixin._build_combat_knowledge_block`) so the player can ask
+>   them about their techniques in character. Combat-log lines
+>   ("Gorran reached level 5!", "Gorran has learned X!") still appear.
+> - **KO policy confirmed:** KO'd allies keep their full exp share.
+> - `NPCCombatMixin.refresh_moves()` now syncs targeted moves to the NPC's
+>   current target before viability filtering — fixes a latent bug where
+>   target-dependent moves (Bull Charge, Flanking Maneuver) were never viable
+>   at selection time and went stale between fights.
+> - Session setup ordering fix: `_apply_player_stats_from_config` now runs
+>   *before* `_apply_starting_party_members` so allies level-sync against
+>   Jean's configured level (found by the harness scenario).
+> - Signature moves are stubbed as `TODO(signature)` in the Gorran/Mara
+>   schedules — to be designed move-by-move with the user.
+> - Test surface: `tests/test_ally_progression.py` (unit),
+>   `tests/acceptance/ally-progression/` (config + run.sh), and the
+>   `ally_progression` bug-hunt scenario (debug endpoints
+>   `GET /api/debug/allies`, `POST /api/debug/allies/progression`).
 
 ## Goals
 

--- a/docs/development/ally-progression-design.md
+++ b/docs/development/ally-progression-design.md
@@ -18,8 +18,26 @@
 > - Session setup ordering fix: `_apply_player_stats_from_config` now runs
 >   *before* `_apply_starting_party_members` so allies level-sync against
 >   Jean's configured level (found by the harness scenario).
-> - Signature moves are stubbed as `TODO(signature)` in the Gorran/Mara
->   schedules — to be designed move-by-move with the user.
+> - Signature moves implemented (src/moves/_npc.py, states in src/states.py):
+>   - **Gorran L9 — Seismic Slam**: telegraphed radial ground slam (prep 4 /
+>     recoil 6), ~0.7× damage (crushing) to every enemy within 6 ft, 25%
+>     Stagger chance per target rolled through `inflict()` (respects stun
+>     resistance, same profile as the Heavy Handed passive).
+>   - **Gorran L12 — Stone Bulwark**: self-cast (`targeted=False`, honoring
+>     the refresh_moves single-target contract) party ward — every ally gains
+>     `StoneBulwarkState` (+6 + 50% of Gorran's protection, 20 beats); won't
+>     recast while any ward is up; 25-beat cooldown.
+>   - **Mara L9 — Marked Quarry**: applies `Quarried` to one enemy (−25%
+>     protection, 15 beats) with `force=True` — a perception mark, not a
+>     resistible status. The whole party benefits via the stat machinery
+>     (chosen over the original party-accuracy sketch, which would have
+>     required touching the to-hit path of every attack move).
+>   - **Mara L12 — Twin Fangs**: fast close-range finisher (range 0–3,
+>     prep 1), 1.2× damage, ×1.5 more against a Quarried target — her kit
+>     is a deliberate hunt: mark, then execute.
+>   - Verified live in the arena: Gorran L12's AI selected and resolved
+>     Seismic Slam mid-fight through the full stage pipeline; a Crucible
+>     boss fight ran 47–87 rounds with the new moves in the pool, no errors.
 > - Test surface: `tests/test_ally_progression.py` (unit),
 >   `tests/acceptance/ally-progression/` (config + run.sh), and the
 >   `ally_progression` bug-hunt scenario (debug endpoints

--- a/docs/development/ally-progression-design.md
+++ b/docs/development/ally-progression-design.md
@@ -1,0 +1,368 @@
+# Ally NPC Progression — Design Document
+
+**Status:** Proposed (not yet implemented)
+**Branch:** `claude/ally-npc-progression-eooks1`
+
+## Goals
+
+- Ally NPCs (party members in `player.combat_list_allies`) gain experience from
+  battles they participate in and grow stronger over time.
+- The **player never controls** ally growth: no attribute-point allocation, no
+  skill menu. Stat gains and skill acquisitions are statically determined per
+  ally class.
+- Allies grow at **roughly the same rate as Jean** — never dead weight, never
+  outshining him.
+- Growth is visible: level-ups and learned skills are narrated in combat results.
+
+## Non-goals
+
+- No ally equipment/inventory management (allies keep using the flat `damage`
+  stat, not weapons).
+- No respec, no player-facing ally skill tree UI.
+- Enemy NPCs do not level (only `Friend` subclasses that opt in).
+
+---
+
+## 1. Current state of the engine (facts this design builds on)
+
+| Concern | Where it lives today |
+|---|---|
+| Party membership | `player.combat_list_allies` (index 0 is the player himself). Story code appends/removes Friend instances (`ch01.py:733`, `ch02.py:646`). Allies follow Jean via `Player.recall_friends()` (`src/player/_movement.py:111`). |
+| Ally combat AI | `NPCCombatMixin.select_move()` (`src/npc/_combat.py`) — weighted random pick from `known_moves`; weights set at construction via `add_move(move, weight)`. Mara overrides `select_move()` entirely. |
+| Ally damage | Flat `self.damage` stat (`NpcAttack`: `user.damage * uniform(0.8, 1.2)`), **not** derived from strength or weapons. `protection` subtracts from incoming damage. |
+| NPC stats | Flat attributes with `_base` twins: `maxhp`, `damage`, `protection`, `speed`, `finesse`, `endurance`, `strength`, `charisma`, `intelligence`, `faith`, `maxfatigue`, `awareness` (`src/npc/_base.py`). `functions.refresh_stat_bonuses()` recomputes live values from `_base` + states. |
+| Player exp | Moves bank `player.combat_exp[subtype]` during combat. On victory, `ApiCombatAdapter._handle_victory()` (`src/api/combat_adapter.py:1781`) calls `player.gain_exp(pool, exp_type=subtype)` per subtype; each call adds the amount to `player.exp`. |
+| Player leveling | `exp_to_level = level * max(1, 165 - intelligence)` (`src/player/_leveling.py:73`). Per level: +0–2 random to each of 7 base stats (~7 avg) plus 6–9 allocatable points (~7.5 avg). |
+| Player skills | Bought manually from `skill_exp` pools via the skill menu (`game_service.learn_skill`). Allies get nothing analogous. |
+| Persistence | Whole-player pickle (`game_service.save_game`); allies ride along inside `combat_list_allies` and `npcs_here`. Legacy-save resilience via `getattr` defaults and `_patch_player_integrity`-style patches (`src/functions.py:657`). |
+| KO state | `Friend.knocked_out` exists (`src/npc/_base.py:186`) but is barely used. |
+
+**Key insight:** `_handle_victory()` is the single choke point where combat exp
+becomes level exp. Ally progression hooks there and nowhere else (same
+discipline as the cooldown-drain rule in CLAUDE.md: progression only advances
+on real combat victories).
+
+---
+
+## 2. Design overview
+
+Three pieces, all on the `Friend` class (new mixin `src/npc/_progression.py`):
+
+1. **Exp track** — `level`, `exp`, `exp_to_level` on every progressing ally.
+   On victory, each ally in the party receives the **same total exp Jean banked
+   to his level track that fight**. Same income + same curve ⇒ same pace.
+2. **Static growth profile** — a per-class table of deterministic per-level
+   stat increments. No randomness, no allocation.
+3. **Skill schedule** — a per-class table of `level → moves/weight changes`.
+   Applied automatically on level-up via the existing `add_move()` mechanism.
+
+Progression is **opt-in**: a `Friend` subclass with no `growth_profile` never
+levels (this keeps TheAdjutant, Grondite citizens, merchants, and other
+flavor-Friends inert without any flags).
+
+---
+
+## 3. Data model
+
+```python
+class Friend(NPC):
+    # class-level declarations, overridden per companion
+    growth_profile: dict | None = None   # {"maxhp": 14.0, "damage": 3.0, ...} per-level rates
+    skill_schedule: dict | None = None   # {level: [SkillGrant(...), ...]}
+
+    def __init__(self, ...):
+        ...
+        self.level = 1
+        self.exp = 0
+        self.knocked_out = False
+```
+
+`exp_to_level` is a computed property reusing the **player's exact formula**
+with the ally's own (static) intelligence:
+
+```python
+@property
+def exp_to_level(self):
+    return self.level * max(1, 165 - self.intelligence)
+```
+
+One curve definition in the codebase's terms; at intelligence 10 (all current
+companions) this is `155 × level`, identical to Jean at parity.
+
+### SkillGrant
+
+A schedule entry is one of:
+
+- `("NewMove", MoveClass, weight)` — instantiate `MoveClass(self)` and
+  `add_move(move, weight)`; narrate *"Gorran has learned Boulder Heave!"*
+- `("WeightUp", "MoveName", new_weight)` — find the move in `known_moves` by
+  name and raise its weight (the ally "favors" a technique more as they grow).
+  Silent (no narration) — it's a tuning knob, not a story beat.
+
+Represent as a tiny frozen dataclass or plain tuples; tuples are fine given the
+codebase's style.
+
+---
+
+## 4. Exp flow and pacing math
+
+### Award point
+
+In `ApiCombatAdapter._handle_victory()`, immediately after the player exp loop:
+
+```python
+total_gained = sum(exp_gained.values())
+ally_progression = []
+for ally in self.player.combat_list_allies[1:]:
+    if getattr(ally, "growth_profile", None):
+        events = ally.gain_exp(total_gained, player_level=self.player.level)
+        ally_progression.extend(events)
+self.player.combat_end_summary["ally_progression"] = ally_progression
+```
+
+### Why "Jean's total" and not a share of `exp_award`
+
+`exp_gained` (what Jean banks toward his level) is exactly the sum of the
+per-subtype `combat_exp` pools — the fight's true difficulty/length signal.
+Enemy `exp_award` is a separate legacy stat that is `0` on many NPCs and
+unused by the victory path. Mirroring Jean's income guarantees "same rate"
+**by construction** with zero new tuning surface.
+
+### Pacing analysis
+
+- Same income, same curve, same starting level ⇒ allies level in lockstep at
+  intelligence parity.
+- Divergence source: Jean's `exp_to_level` shrinks as his intelligence grows;
+  allies' intelligence is static. Jean will slowly out-pace allies at high
+  intelligence builds. This is bounded by two mechanisms below and is
+  acceptable ("roughly the same rate").
+
+### Level band: clamp + catch-up
+
+- **Hard cap:** an ally never levels past `player.level`. `gain_exp` loops
+  `while self.exp >= self.exp_to_level and self.level < player_level`. Banked
+  exp is retained, so a capped ally pops its pending level the first victory
+  after Jean levels.
+- **Catch-up:** if `ally.level < player.level - 1` (joined late, or lagged from
+  Jean's intelligence growth), exp gains are multiplied ×1.5 until the ally is
+  within 1 level. Keeps the party in a `[player-1, player]` band without ever
+  feeling scripted.
+- **Join-level sync:** when a story event adds an ally to the party for the
+  first time, it should call `ally.sync_level(player.level)` — deterministic
+  level-ups applied silently up to Jean's level. Late-game companions arrive
+  battle-ready; the catch-up multiplier alone would take too long.
+
+### Ally `gain_exp` (mirrors `PlayerLevelingMixin.gain_exp`, minus menus)
+
+```python
+def gain_exp(self, amt, player_level):
+    """Deterministic ally exp gain. Returns a list of level-up event dicts."""
+    if self.level >= min(player_level, 100):
+        # still bank exp so a pending level resolves after Jean levels
+        self.exp += amt
+        return []
+    if self.level < player_level - 1:
+        amt = int(amt * 1.5)          # catch-up band
+    self.exp += amt
+    events = []
+    while self.exp >= self.exp_to_level and self.level < min(player_level, 100):
+        events.append(self._level_up())
+    return events
+```
+
+### KO policy
+
+KO'd/dead-at-victory allies still receive the full award. Rationale: docking
+exp for KOs makes a struggling ally *weaker* relative to the party (snowball),
+and the band clamp makes over-reward impossible anyway. Tunable later if it
+feels wrong.
+
+---
+
+## 5. Static stat growth
+
+### Mechanism: recompute-from-spawn, never accumulate
+
+On first level-up, snapshot spawn bases; every level recomputes absolutely so
+fractional rates never drift and the math is save/load-proof:
+
+```python
+def _apply_growth(self):
+    if not hasattr(self, "_spawn_bases"):
+        self._spawn_bases = {
+            stat: getattr(self, f"{stat}_base") for stat in self.growth_profile
+        }
+    for stat, rate in self.growth_profile.items():
+        new_base = self._spawn_bases[stat] + int(rate * (self.level - 1))
+        old_base = getattr(self, f"{stat}_base")
+        setattr(self, f"{stat}_base", new_base)
+        setattr(self, stat, getattr(self, stat) + (new_base - old_base))
+    functions.refresh_stat_bonuses(self)
+```
+
+- Fractional rates (e.g. `"protection": 0.5`) give a point every other level
+  via the `int()` floor — designer-legible without float stats.
+- `maxhp` growth also raises current `hp` by the delta (leveling never leaves
+  an ally proportionally more wounded); no full heal, matching Jean.
+
+### Anchoring the numbers to Jean's growth
+
+Jean gains ~14.5 attribute points per level (7 random + 7.5 allocated) on a
+~70-point starting pool — roughly **+2% effective power per level**, amplified
+by weapon upgrades. Allies have no equipment ladder, so their per-level rates
+should carry the whole curve: **~6–8% of spawn stats per level** keeps an ally
+at a stable fraction of Jean's power through the campaign. Playtest via the
+combat-testing arena and adjust per class.
+
+### Proposed profiles for current companions
+
+**Gorran** (tank/bruiser — spawn: 200 hp, 55 dmg, 0 prot, 5 spd, 10 fin, 100 fat):
+
+```python
+growth_profile = {
+    "maxhp": 14,        # 7% of spawn
+    "damage": 3,        # 5.5%
+    "protection": 0.5,  # +1 every 2 levels
+    "speed": 0.25,      # slow forever, but not static
+    "finesse": 0.5,
+    "maxfatigue": 5,
+}
+```
+
+**Mara** (skirmisher — spawn: 95 hp, 38 dmg, 12 prot, 8 spd, 8 fin):
+
+```python
+growth_profile = {
+    "maxhp": 6,
+    "damage": 2.5,
+    "protection": 0.5,
+    "speed": 0.75,
+    "finesse": 1,
+    "maxfatigue": 6,
+}
+```
+
+At level 10: Gorran ≈ 326 hp / 82 dmg / +4 prot; Mara ≈ 149 hp / 60 dmg —
+both roughly ×1.6 spawn power, tracking Jean's unmodified stat growth.
+
+---
+
+## 6. Skill schedules
+
+Applied inside `_level_up()` after stat growth:
+
+```python
+def _apply_skill_schedule(self):
+    for grant in (self.skill_schedule or {}).get(self.level, []):
+        kind = grant[0]
+        if kind == "NewMove":
+            _, move_cls, weight = grant
+            if not any(m.name == move_cls(self).name for m in self.known_moves):
+                self.add_move(move_cls(self), weight)
+                cprint(f"{self.name} has learned {self.known_moves[-1].name}!", "magenta")
+        elif kind == "WeightUp":
+            _, move_name, new_weight = grant
+            for m in self.known_moves:
+                if m.name == move_name:
+                    m.weight = new_weight
+```
+
+### Example schedules (mechanism-proof; final content TBD)
+
+```python
+# Gorran — deepens what he already does
+skill_schedule = {
+    3: [("WeightUp", "Parry", 3)],
+    5: [("NewMove", moves.GorranSlam, 3)],       # NEW move: AoE ground slam, long recoil
+    8: [("WeightUp", "Gorran Club", 4)],
+    12: [("NewMove", moves.StoneBulwark, 2)],    # NEW move: brief party protection buff
+}
+
+# Mara — sharpens precision and mobility
+skill_schedule = {
+    3: [("WeightUp", "Dodge", 4)],
+    5: [("NewMove", moves.AimedShot, 2)],        # existing move, works for NPCs w/ combat_range
+    9: [("NewMove", moves.FeintAndPivot, 2)],
+}
+```
+
+Reuse existing move classes where they already support NPC users; net-new
+moves (`GorranSlam`, `StoneBulwark`) are ordinary content additions in
+`src/moves/_npc.py`. **Compatibility note:** Mara's custom `select_move()`
+reads `known_moves`, so scheduled grants flow into her AI automatically.
+
+---
+
+## 7. Surfacing progression (API + frontend)
+
+- `combat_end_summary` gains an `ally_progression` key:
+  `[{"name": "Gorran", "old_level": 4, "new_level": 5, "skills_learned": ["Gorran Slam"]}]`.
+  The frontend combat-summary modal renders these under the player's level-up
+  block.
+- `CombatantSerializer.serialize_combatant()` adds `"level"` for allies
+  (`getattr(combatant, "level", None)`) so the battlefield/party UI can show it.
+- Level-up and skill-learn narration goes through `cprint(..., "magenta")` —
+  the same channel as Jean's — so the combat log picks it up with zero extra
+  plumbing.
+- No new routes needed. If a party panel later wants exp bars, add a
+  `GameService.get_party_status(player)` method (per the "routes don't reach
+  into player internals" rule).
+
+---
+
+## 8. Persistence & backward compatibility
+
+- Saves are whole-player pickles: `level`, `exp`, `_spawn_bases`, and granted
+  moves persist automatically on the ally instances.
+- **Old saves** lack the new attributes. Guard every read with `getattr`
+  defaults (`getattr(ally, "level", 1)`) and add the fields to an
+  ally-integrity pass alongside `_patch_player_integrity` in
+  `src/functions.py` (iterate `combat_list_allies[1:]`, backfill
+  `level=1, exp=0`).
+- Story code that removes/re-adds the **same instance** (Gorran in ch01/ch02)
+  keeps progression for free. Any event that spawns a *fresh* instance of a
+  returning companion must copy or re-sync level — prefer `sync_level(player.level)`
+  at join time, which also covers this case.
+
+---
+
+## 9. Edge cases
+
+| Case | Handling |
+|---|---|
+| Ally at cap when Jean levels mid-fight | Banked exp resolves at next victory's `gain_exp` call. Acceptable one-fight latency. |
+| Multiple level-ups from one big fight | `while` loop in `gain_exp`, same as Jean. |
+| Level 100 | Same terminal cap as the player (`min(player_level, 100)`). |
+| TheAdjutant / merchants / citizens | No `growth_profile` ⇒ opted out automatically. |
+| Testing | Add a `set_ally_level` operation to the Adjutant debug endpoint (`/api/debug`) mirroring `set_level`; Ally Courtyard `(0,1)` in the arena is the venue. |
+| Non-combat exp (`gain_exp` from events/quests to Jean) | Not mirrored — ally progression is combat-only by design ("gain exp in battle"). Story rewards that should touch allies can call `ally.gain_exp` explicitly. |
+
+---
+
+## 10. Implementation checklist
+
+1. `src/npc/_progression.py` — `AllyProgressionMixin` (`gain_exp`,
+   `_level_up`, `_apply_growth`, `_apply_skill_schedule`, `sync_level`,
+   `exp_to_level` property). Mix into `Friend` in `_base.py`; init
+   `level`/`exp` in `Friend.__init__`.
+2. `growth_profile` + `skill_schedule` on `Gorran` and `Mara`
+   (`src/npc/_friends.py`); new NPC moves in `src/moves/_npc.py` as needed.
+3. Hook in `ApiCombatAdapter._handle_victory()` + `ally_progression` in
+   `combat_end_summary`.
+4. `sync_level` calls at party-join points (`story/ch01.py` Gorran joins).
+5. Serializer: `level` on ally combatants; frontend combat-summary rendering.
+6. Adjutant debug op `set_ally_level`; legacy-save integrity backfill.
+7. Tests: unit (curve parity with player formula, clamp, catch-up multiplier,
+   deterministic growth recompute, schedule idempotence on re-grant, pickle
+   round-trip); harness scenario in the arena (ally levels after N fodder
+   fights, learns scheduled move, never exceeds Jean's level).
+
+## Open questions (need a call before/while implementing)
+
+1. **KO exp policy** — full share recommended (above); alternative is half.
+2. **Growth magnitudes** — the 6–8%/level anchor is a starting point; final
+   numbers come from arena playtests (`/combat-test scenario=ally`).
+3. **Skill schedule content** — which new NPC moves are worth authoring for
+   Gorran/Mara at which levels (narrative call as much as mechanical).
+4. **Should allies show exp bars in the UI**, or is level + "learned X"
+   narration enough? (Recommend the latter to start.)

--- a/src/animations.py
+++ b/src/animations.py
@@ -35,6 +35,13 @@ def set_api_mode(enabled: bool):
     _API_MODE = enabled
 
 
+def _terminal_available():
+    """True when stdout is a real terminal that curses can drive."""
+    import sys
+
+    return bool(getattr(sys.stdout, "isatty", lambda: False)())
+
+
 def count_gif_frames(gif_path):
     with Image.open(gif_path) as img:
         frame_count = 0
@@ -213,6 +220,14 @@ def animate_to_main_screen(animation, rawtext=""):
     """
     # Skip animations in API mode (web app)
     if _API_MODE:
+        return
+
+    # Terminal animations need a real terminal. Under pytest/CI/headless runs
+    # (no tty), asciimatics' curses.initscr() raises "setupterm: could not
+    # find terminal" — and whether _API_MODE has been flipped yet depends on
+    # which test in the process happened to build the Flask app first, so
+    # guard on the actual capability rather than the mode flag.
+    if not _terminal_available():
         return
 
     # Import here to avoid circular import: functions imports moves, and moves imports animations.

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1804,11 +1804,44 @@ class ApiCombatAdapter:
                     level_ups.extend(maybe_events)
                 self.player.combat_exp[subtype] = 0
 
+        # Ally progression: party members mirror the total exp Jean banked this
+        # fight (static, player-uncontrolled growth — see npc/_progression.py).
+        # KO'd allies keep their full share by design.
+        ally_progression: List[Dict[str, Any]] = []
+        total_gained = sum(exp_gained.values())
+        if total_gained > 0:
+            for ally in self.player.combat_list_allies[1:]:
+                try:
+                    if not getattr(ally, "growth_profile", None):
+                        continue
+                    ally_progression.extend(
+                        ally.gain_exp(total_gained, player_level=self.player.level)
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Ally progression failed for %s: %s",
+                        getattr(ally, "name", "?"),
+                        e,
+                    )
+
         victory_msg = "Victory! "
         if exp_summary:
             victory_msg += "Gained exp: " + ", ".join(exp_summary)
 
         self._add_log_entry(self.output_capture.current_round, victory_msg, "system")
+
+        for event in ally_progression:
+            self._add_log_entry(
+                self.output_capture.current_round,
+                f"{event['name']} reached level {event['new_level']}!",
+                "system",
+            )
+            for skill_name in event.get("skills_learned", []):
+                self._add_log_entry(
+                    self.output_capture.current_round,
+                    f"{event['name']} has learned {skill_name}!",
+                    "system",
+                )
 
         # Aggregate combat drops collected during the encounter (API mode)
         drops_raw = getattr(self.player, "combat_drops", []) or []
@@ -1856,6 +1889,7 @@ class ApiCombatAdapter:
             "exp_gained": exp_gained,
             "items_dropped": items_dropped,
             "level_ups": level_ups,
+            "ally_progression": ally_progression,
             "attribute_points_available": int(
                 getattr(self.player, "pending_attribute_points", 0) or 0
             ),

--- a/src/api/combat_adapter.py
+++ b/src/api/combat_adapter.py
@@ -1812,10 +1812,13 @@ class ApiCombatAdapter:
         if total_gained > 0:
             for ally in self.player.combat_list_allies[1:]:
                 try:
-                    if not getattr(ally, "growth_profile", None):
+                    gain = getattr(ally, "gain_exp", None)
+                    if gain is None:
                         continue
+                    # The mixin owns the opt-in decision: non-progressing
+                    # Friends (no growth_profile) return [] from gain_exp.
                     ally_progression.extend(
-                        ally.gain_exp(total_gained, player_level=self.player.level)
+                        gain(total_gained, player_level=self.player.level)
                     )
                 except Exception as e:
                     logger.warning(

--- a/src/api/routes/debug.py
+++ b/src/api/routes/debug.py
@@ -89,6 +89,22 @@ def list_skills():
     return _run(lambda adj, player, body: {"skills": adj.list_skills(player)})
 
 
+# --- Party ally progression ---------------------------------------------------
+
+@debug_bp.route("/allies", methods=["GET"])
+def ally_state():
+    return _run(lambda adj, player, body: adj.ally_state(player))
+
+
+@debug_bp.route("/allies/progression", methods=["POST"])
+def set_ally_progression():
+    return _run(
+        lambda adj, player, body: adj.set_ally_progression(
+            player, body["name"], body.get("level"), body.get("exp")
+        )
+    )
+
+
 # --- Arena combatant management ---------------------------------------------
 
 @debug_bp.route("/arena", methods=["GET"])

--- a/src/api/services/session_manager.py
+++ b/src/api/services/session_manager.py
@@ -751,6 +751,8 @@ class SessionManager:
                 )
                 continue
             ally.friend = True
+            if hasattr(ally, "sync_level"):
+                ally.sync_level(getattr(player, "level", 1))
             if ally not in player.combat_list_allies:
                 player.combat_list_allies.append(ally)
             if npc_type == "Gorran":
@@ -911,11 +913,12 @@ class SessionManager:
             # Apply starting equipment (equipped gear) from config
             self._apply_starting_equipment(player)
 
+            # Apply player stats from config BEFORE party members: allies
+            # level-sync to Jean on join, so his configured level must be set first.
+            self._apply_player_stats_from_config(player)
+
             # Apply starting party members (e.g. Gorran) from config
             self._apply_starting_party_members(player)
-
-            # Apply player stats from config if available
-            self._apply_player_stats_from_config(player)
 
             return player
         except Exception as e:
@@ -953,11 +956,12 @@ class SessionManager:
             # Apply starting equipment (equipped gear) from config
             self._apply_starting_equipment(player)
 
+            # Apply player stats from config BEFORE party members: allies
+            # level-sync to Jean on join, so his configured level must be set first.
+            self._apply_player_stats_from_config(player)
+
             # Apply starting party members (e.g. Gorran) from config
             self._apply_starting_party_members(player)
-
-            # Apply player stats from config if available
-            self._apply_player_stats_from_config(player)
 
             return player
 

--- a/src/combatant.py
+++ b/src/combatant.py
@@ -6,10 +6,23 @@ Provides:
     a single canonical definition so the values never drift between classes.
   - is_alive(), cycle_states(), get_equipped_items(): methods whose logic is
     identical across Player and NPC.
+  - exp_needed_for_level(): the single leveling curve shared by the Player and
+    ally NPC progression.
 
 Usage (in each subclass __init__):
     self._init_resistances()
 """
+
+
+def exp_needed_for_level(level, intelligence):
+    """Exp required to advance from `level` to the next.
+
+    Single source of the leveling curve — used by Player._level_up_api and
+    AllyProgressionMixin.exp_to_level so ally pacing always matches Jean's.
+    The per-level requirement is floored at 1 so very high intelligence
+    (>= 165) can't zero it and spin exp-gain loops forever.
+    """
+    return int(level) * max(1, 165 - int(intelligence))
 
 # ── Canonical defaults ────────────────────────────────────────────────────────
 # 1.0 = no effect, 0.5 = half damage/chance, 2.0 = double.

--- a/src/combatant.py
+++ b/src/combatant.py
@@ -24,6 +24,7 @@ def exp_needed_for_level(level, intelligence):
     """
     return int(level) * max(1, 165 - int(intelligence))
 
+
 # ── Canonical defaults ────────────────────────────────────────────────────────
 # 1.0 = no effect, 0.5 = half damage/chance, 2.0 = double.
 # Negative damage-resistance values mean the damage heals instead.

--- a/src/moves/__init__.py
+++ b/src/moves/__init__.py
@@ -95,6 +95,10 @@ from ._npc import (
     MineralSpit,
     SoulDrain,
     WailStrike,
+    SeismicSlam,
+    StoneBulwark,
+    MarkedQuarry,
+    TwinFangs,
 )
 
 __all__ = [
@@ -199,4 +203,8 @@ __all__ = [
     "MineralSpit",
     "SoulDrain",
     "WailStrike",
+    "SeismicSlam",
+    "StoneBulwark",
+    "MarkedQuarry",
+    "TwinFangs",
 ]

--- a/src/moves/_npc.py
+++ b/src/moves/_npc.py
@@ -1082,3 +1082,370 @@ class WailStrike(NpcAttack):
 # ============================================================================
 # PHASE 3: ADVANCED POSITIONING MOVES
 # ============================================================================
+
+# ============================================================================
+# ALLY SIGNATURE MOVES (granted by skill_schedule — see npc/_progression.py)
+# ============================================================================
+
+
+def _hostile_to(user, entity):
+    """True when `entity` is on the opposite side of `user` in the current fight.
+
+    Written side-relative (not friend-only) so these moves also behave if an
+    enemy NPC ever learns them.  The player has no `friend` attribute, so he
+    is hostile exactly when the user is not a friend.
+    """
+    if entity is getattr(user, "player_ref", None):
+        return not getattr(user, "friend", False)
+    return bool(getattr(entity, "friend", False)) != bool(getattr(user, "friend", False))
+
+
+class SeismicSlam(Move):
+    """Gorran's level-9 signature: a telegraphed, radial ground slam.
+
+    Long prep (the whole battlefield sees it coming) and a long recoil, but
+    it strikes every enemy within 6 ft for crushing damage with a 25% chance
+    to Stagger each one (resisted by stun status resistance, like the
+    Heavy Handed passive).
+    """
+
+    _RADIUS = 6
+    _STAGGER_CHANCE = 0.25
+
+    def __init__(self, npc):
+        description = (
+            "Slam both fists into the ground, sending a shockwave through the "
+            "stone that batters every nearby enemy and may stagger them."
+        )
+        prep = 4
+        execute = 1
+        recoil = 6
+        cooldown = 8
+        self.power = 0
+        super().__init__(
+            name="Seismic Slam",
+            description=description,
+            xp_gain=1,
+            current_stage=0,
+            stage_beat=[prep, execute, recoil, cooldown],
+            targeted=False,
+            mvrange=(0, 6),
+            stage_announce=[
+                colored(
+                    "{} raises both fists high, stone grinding against stone!".format(
+                        npc.name
+                    ),
+                    "cyan",
+                ),
+                "",
+                "{} is rooted in the cracked earth, recovering from the slam.".format(
+                    npc.name
+                ),
+                "",
+            ],
+            fatigue_cost=40,
+            beats_left=prep,
+            target=npc,
+            user=npc,
+            category="Offensive",
+        )
+        self.evaluate()
+
+    def viable(self):
+        if not hasattr(self.user, "combat_proximity"):
+            return False
+        return any(
+            e.is_alive()
+            and _hostile_to(self.user, e)
+            and distance <= self._RADIUS
+            for e, distance in self.user.combat_proximity.items()
+        )
+
+    def evaluate(self):
+        if hasattr(self.user, "damage"):
+            self.power = self.user.damage * 0.7
+
+    def execute(self, user):
+        cprint(
+            f"{user.name} slams both fists into the ground — the stone itself ripples!",
+            "cyan",
+        )
+        for enemy, distance in list(self.user.combat_proximity.items()):
+            if not enemy.is_alive() or not _hostile_to(self.user, enemy):
+                continue
+            if distance > self._RADIUS:
+                continue
+            resist = 1.0
+            if hasattr(enemy, "resistance"):
+                resist = enemy.resistance.get("crushing", 1.0)
+            damage = max(0, int(self.power * resist) - enemy.protection)
+            hit_chance = max(
+                5, int(85 - enemy.finesse + (self.user.finesse * 0.7))
+            )
+            if random.randint(0, 100) <= hit_chance:
+                if functions.check_parry(enemy):
+                    cprint(f"{enemy.name} deflects the shockwave!", "yellow")
+                    continue
+                enemy.hp = max(0, enemy.hp - damage)
+                cprint(
+                    f"{enemy.name} is battered by the shockwave for {damage} damage!",
+                    "red",
+                )
+                functions.inflict(
+                    states.Staggered(enemy), enemy, chance=self._STAGGER_CHANCE
+                )
+        self.user.fatigue -= self.fatigue_cost
+        if self.user.fatigue < 0:
+            self.user.fatigue = 0
+
+
+class StoneBulwark(Move):
+    """Gorran's level-12 signature: a party-wide protection buff.
+
+    Self-cast (targeted=False — see NPCCombatMixin.refresh_moves' single-target
+    contract): applies StoneBulwarkState to every party member, granting bonus
+    protection that scales with Gorran's own. Long cooldown; won't recast
+    while any ally still carries the ward.
+    """
+
+    def __init__(self, npc):
+        description = (
+            "Draw the strength of the earth over the whole party, shielding "
+            "everyone with a skin of living stone."
+        )
+        prep = 3
+        execute = 1
+        recoil = 2
+        cooldown = 25
+        super().__init__(
+            name="Stone Bulwark",
+            description=description,
+            xp_gain=1,
+            current_stage=0,
+            stage_beat=[prep, execute, recoil, cooldown],
+            targeted=False,
+            mvrange=(0, 9999),
+            stage_announce=[
+                colored(
+                    "{} spreads both arms wide; dust rises from the ground around the party.".format(
+                        npc.name
+                    ),
+                    "cyan",
+                ),
+                "",
+                "",
+                "",
+            ],
+            fatigue_cost=35,
+            beats_left=prep,
+            target=npc,
+            user=npc,
+            category="Defensive",
+        )
+        self.evaluate()
+
+    def _party(self):
+        allies = getattr(self.user, "combat_list_allies", None)
+        return list(allies) if allies else [self.user]
+
+    def viable(self):
+        if not getattr(self.user, "in_combat", False):
+            return False
+        # Don't recast while the ward is still up on anyone.
+        for ally in self._party():
+            for s in getattr(ally, "states", []):
+                if isinstance(s, states.StoneBulwarkState):
+                    return False
+        return True
+
+    def evaluate(self):
+        pass
+
+    def execute(self, user):
+        amount = 6 + int(getattr(user, "protection", 0) * 0.5)
+        cprint(
+            f"{user.name} drives the party's shadows into the stone — rock flows "
+            "up and over them like a second skin!",
+            "cyan",
+        )
+        for ally in self._party():
+            if not ally.is_alive():
+                continue
+            ally.states = [
+                s
+                for s in getattr(ally, "states", [])
+                if not isinstance(s, states.StoneBulwarkState)
+            ]
+            functions.inflict(
+                states.StoneBulwarkState(ally, amount), ally, force=True
+            )
+        self.user.fatigue -= self.fatigue_cost
+        if self.user.fatigue < 0:
+            self.user.fatigue = 0
+
+
+class MarkedQuarry(Move):
+    """Mara's level-9 signature: she studies one target and calls out its
+    weak points, applying the Quarried state (-25% protection for 15 beats).
+
+    The whole party benefits automatically through the stat machinery.
+    Applied with force=True — a perception mark can't be resisted.
+    """
+
+    def __init__(self, npc):
+        description = (
+            "Study a target and call out the gaps in its defenses — everyone's "
+            "attacks against it bite deeper while the mark lasts."
+        )
+        prep = 2
+        execute = 1
+        recoil = 1
+        cooldown = 12
+        super().__init__(
+            name="Marked Quarry",
+            description=description,
+            xp_gain=1,
+            current_stage=0,
+            stage_beat=[prep, execute, recoil, cooldown],
+            targeted=True,
+            mvrange=(0, 25),
+            stage_announce=[
+                colored("{} goes still, reading her target.".format(npc.name), "cyan"),
+                "",
+                "",
+                "",
+            ],
+            fatigue_cost=15,
+            beats_left=prep,
+            target=npc.target,
+            user=npc,
+            category="Tactical",
+        )
+        self.evaluate()
+
+    def viable(self):
+        if not hasattr(self.user, "combat_proximity"):
+            return False
+        target = getattr(self.user, "target", None)
+        if target is not None and target in self.user.combat_proximity:
+            if not target.is_alive():
+                return False
+            # Don't re-mark a target that's already Quarried.
+            if any(isinstance(s, states.Quarried) for s in getattr(target, "states", [])):
+                return False
+            return self.user.combat_proximity[target] <= self.mvrange[1]
+        return False
+
+    def evaluate(self):
+        pass
+
+    def execute(self, user):
+        target = self.target
+        if target is None or not target.is_alive():
+            return
+        target.states = [
+            s for s in getattr(target, "states", []) if not isinstance(s, states.Quarried)
+        ]
+        functions.inflict(states.Quarried(target), target, force=True)
+        cprint(
+            f'{user.name} marks {target.name}: "There — where the hide is thin."',
+            "cyan",
+        )
+        self.user.fatigue -= self.fatigue_cost
+        if self.user.fatigue < 0:
+            self.user.fatigue = 0
+
+
+class TwinFangs(Move):
+    """Mara's level-12 signature: a fast close-range finisher — bow snap-shot
+    into dagger slash in one motion. Deals 1.2x damage, +50% more against a
+    Quarried target (her kit becomes a deliberate hunt: mark, then execute).
+    """
+
+    _QUARRY_BONUS = 1.5
+
+    def __init__(self, npc):
+        description = (
+            "A snap-shot at point blank flowing into a dagger slash — one fast, "
+            "brutal exchange. Far deadlier against a marked quarry."
+        )
+        prep = 1
+        execute = 1
+        recoil = 3
+        cooldown = 6
+        self.power = 0
+        super().__init__(
+            name="Twin Fangs",
+            description=description,
+            xp_gain=1,
+            current_stage=0,
+            stage_beat=[prep, execute, recoil, cooldown],
+            targeted=True,
+            mvrange=(0, 3),
+            stage_announce=[
+                colored("{} shifts her grip, bow and blade both ready.".format(npc.name), "cyan"),
+                "",
+                "{} resets her stance.".format(npc.name),
+                "",
+            ],
+            fatigue_cost=30,
+            beats_left=prep,
+            target=npc.target,
+            user=npc,
+            category="Offensive",
+        )
+        self.evaluate()
+
+    def viable(self):
+        if not hasattr(self.user, "combat_proximity"):
+            return False
+        target = getattr(self.user, "target", None)
+        if target is not None and target in self.user.combat_proximity:
+            return (
+                target.is_alive()
+                and self.mvrange[0]
+                <= self.user.combat_proximity[target]
+                <= self.mvrange[1]
+            )
+        return False
+
+    def evaluate(self):
+        if hasattr(self.user, "damage"):
+            self.power = self.user.damage * 1.2
+
+    def execute(self, user):
+        target = self.target
+        if target is None or not target.is_alive():
+            return
+        quarried = any(
+            isinstance(s, states.Quarried) for s in getattr(target, "states", [])
+        )
+        power = self.power * (self._QUARRY_BONUS if quarried else 1.0)
+        resist = 1.0
+        if hasattr(target, "resistance"):
+            resist = target.resistance.get("piercing", 1.0)
+        damage = max(0, int(power * resist) - target.protection)
+        hit_chance = max(
+            5, int(90 - target.finesse + (self.user.finesse * 0.8))
+        )
+        roll = random.randint(0, 100)
+        if hit_chance >= roll:
+            if functions.check_parry(target):
+                cprint(f"{target.name} turns aside the twin strike!", "yellow")
+            else:
+                if hit_chance - roll < 10:  # glancing
+                    damage //= 2
+                target.hp = max(0, target.hp - damage)
+                flavor = (
+                    " — straight through the marked gap!" if quarried else "!"
+                )
+                cprint(
+                    f"{user.name}'s arrow and blade land as one on {target.name} "
+                    f"for {damage} damage{flavor}",
+                    "red",
+                )
+        else:
+            cprint(f"{user.name}'s twin strike whistles past {target.name}.", "yellow")
+        self.user.fatigue -= self.fatigue_cost
+        if self.user.fatigue < 0:
+            self.user.fatigue = 0

--- a/src/moves/_npc.py
+++ b/src/moves/_npc.py
@@ -1092,12 +1092,18 @@ def _hostile_to(user, entity):
     """True when `entity` is on the opposite side of `user` in the current fight.
 
     Written side-relative (not friend-only) so these moves also behave if an
-    enemy NPC ever learns them.  The player has no `friend` attribute, so he
-    is hostile exactly when the user is not a friend.
+    enemy NPC ever learns them.  The player is the one combatant without a
+    `friend` attribute — detect him by that absence (NOT via user.player_ref,
+    which is never assigned on ally NPCs) so an ally's AoE can never
+    friendly-fire Jean: coordinate-based proximity sync puts every combatant,
+    Jean included, into each ally's combat_proximity dict.
     """
-    if entity is getattr(user, "player_ref", None):
+    if entity is user:
+        return False
+    if not hasattr(entity, "friend"):
+        # The player: hostile exactly when the user fights against his side.
         return not getattr(user, "friend", False)
-    return bool(getattr(entity, "friend", False)) != bool(getattr(user, "friend", False))
+    return bool(entity.friend) != bool(getattr(user, "friend", False))
 
 
 class SeismicSlam(Move):

--- a/src/npc/_adjutant.py
+++ b/src/npc/_adjutant.py
@@ -215,6 +215,70 @@ class TheAdjutant(Friend):
         ]
 
     # ------------------------------------------------------------------
+    # Party ally progression (see npc/_progression.py)
+    # ------------------------------------------------------------------
+
+    def _find_party_ally(self, player, name):
+        """Return the party ally matching an instance name or class name."""
+        for ally in getattr(player, "combat_list_allies", [])[1:]:
+            if getattr(ally, "name", None) == name or type(ally).__name__ == name:
+                return ally
+        return None
+
+    def ally_state(self, player):
+        """Return progression state for every party ally (excludes Jean)."""
+        allies = []
+        for ally in getattr(player, "combat_list_allies", [])[1:]:
+            allies.append(
+                {
+                    "name": getattr(ally, "name", "?"),
+                    "class": type(ally).__name__,
+                    "progression_enabled": bool(getattr(ally, "growth_profile", None)),
+                    "level": int(getattr(ally, "level", 1) or 1),
+                    "exp": int(getattr(ally, "exp", 0) or 0),
+                    "exp_to_level": int(getattr(ally, "exp_to_level", 0) or 0),
+                    "hp": int(getattr(ally, "hp", 0) or 0),
+                    "maxhp": int(getattr(ally, "maxhp", 0) or 0),
+                    "damage": int(getattr(ally, "damage", 0) or 0),
+                    "protection": int(getattr(ally, "protection", 0) or 0),
+                    "known_moves": [
+                        {
+                            "name": getattr(m, "name", "?"),
+                            "weight": int(getattr(m, "weight", 1) or 1),
+                        }
+                        for m in getattr(ally, "known_moves", [])
+                    ],
+                }
+            )
+        return {"success": True, "allies": allies}
+
+    def set_ally_progression(self, player, name, level=None, exp=None):
+        """Set a party ally's level and/or banked exp.
+
+        Level moves upward only (via sync_level — deterministic growth can't
+        be unwound; respawn the ally to reset).  Exp is set verbatim, which
+        lets tests prime an ally just below a level threshold.
+        """
+        ally = self._find_party_ally(player, name)
+        if ally is None:
+            return {"success": False, "error": f"No party ally named '{name}'."}
+        if level is not None:
+            if not hasattr(ally, "sync_level"):
+                return {
+                    "success": False,
+                    "error": f"'{name}' does not support progression.",
+                }
+            ally.sync_level(int(level))
+        if exp is not None:
+            ally.exp = max(0, int(exp))
+        return {
+            "success": True,
+            "name": getattr(ally, "name", "?"),
+            "level": int(getattr(ally, "level", 1) or 1),
+            "exp": int(getattr(ally, "exp", 0) or 0),
+        }
+
+    # ------------------------------------------------------------------
     # Arena combatant management
     # ------------------------------------------------------------------
 

--- a/src/npc/_base.py
+++ b/src/npc/_base.py
@@ -18,6 +18,7 @@ from items import Item  # type: ignore
 
 from ._combat import NPCCombatMixin
 from ._loot import NPCLootMixin, loot
+from ._progression import AllyProgressionMixin
 from src.narration import narrate
 
 
@@ -126,7 +127,7 @@ class NPC(NPCCombatMixin, NPCLootMixin, Combatant):
         self.ai_config = None  # Initialized during combat
 
 
-class Friend(NPC):
+class Friend(AllyProgressionMixin, NPC):
     def __init__(
         self,
         name,
@@ -184,6 +185,10 @@ class Friend(NPC):
             friend=friend,
         )
         self.knocked_out = False  # True while sitting out a fight after being KO'd
+        # Ally progression (see _progression.py). Static growth; only classes
+        # that declare a growth_profile ever gain exp or level.
+        self.level = 1
+        self.exp = 0
 
     def wounded_flavor(self):
         """Return a one-line flavor string shown periodically when this ally is

--- a/src/npc/_chat_llm.py
+++ b/src/npc/_chat_llm.py
@@ -412,12 +412,53 @@ class HumanNPCLLMMixin:
                 "Keep responses to 1-3 sentences."
             )
 
+        # Combat self-knowledge block (progressing allies only) — the chat is
+        # the sole surface for ally growth (no UI elements by design), so the
+        # NPC must be able to speak about its own techniques and experience.
+        combat_block = self._build_combat_knowledge_block()
+        if combat_block:
+            blocks.append(combat_block)
+
         # Jean instruction block
         blocks.append(
             "Jean is he/him. Do not write Jean's dialogue. Do not describe Jean's internal state."
         )
 
         return "\n\n".join(blocks)
+
+    def _build_combat_knowledge_block(self) -> str:
+        """Describe this ally's combat experience and techniques for the system prompt.
+
+        Empty string for NPCs without ally progression (no growth_profile) —
+        generic nomads and non-combat NPCs get no combat block.
+        """
+        if not getattr(self, "growth_profile", None):
+            return ""
+        level = int(getattr(self, "level", 1) or 1)
+        if level < 3:
+            tier = "a capable fighter, still early in the journey"
+        elif level < 7:
+            tier = "a seasoned fighter, noticeably hardened by recent battles"
+        elif level < 13:
+            tier = "a veteran of many battles at Jean's side"
+        else:
+            tier = "a master combatant, honed by long campaigning with Jean"
+        techniques = []
+        for m in getattr(self, "known_moves", []):
+            name = getattr(m, "name", "")
+            if name in ("NPC_Attack", "Idle", "Rest"):
+                continue  # internal/basic actions, not nameable techniques
+            desc = getattr(m, "description", "")
+            techniques.append(f"{name} ({desc})" if desc else name)
+        technique_text = "; ".join(techniques) if techniques else "none beyond basic fighting"
+        return (
+            f"COMBAT SELF-KNOWLEDGE: You fight alongside Jean and you are {tier}. "
+            f"Techniques you have mastered: {technique_text}. "
+            "If Jean asks about your combat abilities, how you have grown, or your "
+            "techniques, answer naturally from this list in your own voice. Never "
+            "use game terms like 'level', 'experience points', or 'stats' — speak "
+            "of your craft the way a fighter would."
+        )
 
     def _ensure_personality(self, player):
         """For generics: generate personality on first talk, or use fallback."""

--- a/src/npc/_chat_llm.py
+++ b/src/npc/_chat_llm.py
@@ -446,10 +446,14 @@ class HumanNPCLLMMixin:
         techniques = []
         for m in getattr(self, "known_moves", []):
             name = getattr(m, "name", "")
-            if name in ("NPC_Attack", "Idle", "Rest"):
-                continue  # internal/basic actions, not nameable techniques
             desc = getattr(m, "description", "")
-            techniques.append(f"{name} ({desc})" if desc else name)
+            # Internal AI actions (NpcAttack/NpcRest/NpcIdle/GorranClub, ...)
+            # all ship empty descriptions — a described move is by contract a
+            # nameable technique, so new internal moves stay hidden without
+            # maintaining a name list here.
+            if not name or not desc:
+                continue
+            techniques.append(f"{name} ({desc})")
         technique_text = "; ".join(techniques) if techniques else "none beyond basic fighting"
         return (
             f"COMBAT SELF-KNOWLEDGE: You fight alongside Jean and you are {tier}. "

--- a/src/npc/_combat.py
+++ b/src/npc/_combat.py
@@ -32,6 +32,12 @@ class NPCCombatMixin:
         move.target *after* selection.  Without this sync, target-dependent
         moves (Bull Charge, Flanking Maneuver) are never viable on first
         selection and go stale between fights.
+
+        Contract note: this assumes the NPC single-target model the adapter
+        already enforces (it stamps npc.target onto the selected move in
+        _process_npc).  A future friendly-target move (heal/buff with
+        targeted=True) must pick its own target in cast()/beat_update()
+        rather than trust move.target, or be excluded here.
         """
         target = getattr(self, "target", None)
         if target is not None and target is not self:

--- a/src/npc/_combat.py
+++ b/src/npc/_combat.py
@@ -24,6 +24,22 @@ import moves  # type: ignore
 class NPCCombatMixin:
     """Combat AI and engagement behaviour for NPC."""
 
+    def refresh_moves(self):
+        """Sync targeted moves to this NPC's current target, then filter by viability.
+
+        Move instances are long-lived on known_moves and many viable()
+        implementations read move.target — but the combat adapter only assigns
+        move.target *after* selection.  Without this sync, target-dependent
+        moves (Bull Charge, Flanking Maneuver) are never viable on first
+        selection and go stale between fights.
+        """
+        target = getattr(self, "target", None)
+        if target is not None and target is not self:
+            for move in self.known_moves:
+                if getattr(move, "targeted", False):
+                    move.target = target
+        return super().refresh_moves()
+
     def select_move(self):
         available_moves = self.refresh_moves()
 

--- a/src/npc/_friends.py
+++ b/src/npc/_friends.py
@@ -134,13 +134,14 @@ class Gorran(Friend):  # The "rock-man" that helps Jean at the beginning of the 
     }
     # Deterministic skill acquisition. Early levels deepen what he already
     # does; Bull Charge is Jean-learnable and fits a charging rock-man.
-    # TODO(signature): design 2-3 signature moves with the user, e.g.
-    #   L9  "Seismic Slam"  — AoE ground slam, long recoil
-    #   L12 "Stone Bulwark" — brief party-wide protection buff
+    # Signatures: Seismic Slam (radial AoE + stagger chance, long recoil)
+    # and Stone Bulwark (party protection ward scaling with his own).
     skill_schedule = {
         3: [("WeightUp", "Parry", 3)],
         5: [("NewMove", moves.BullCharge, 2)],
         7: [("WeightUp", moves.GorranClub, 4)],
+        9: [("NewMove", moves.SeismicSlam, 2)],
+        12: [("NewMove", moves.StoneBulwark, 2)],
     }
 
     def __init__(self):
@@ -635,13 +636,15 @@ class Mara(HumanNPCLLMMixin, Friend):
     }
     # Early levels sharpen evasion and kiting; Tactical Retreat is
     # Jean-learnable (Bow tree) and anchors her bow-mode range control.
-    # TODO(signature): design 2-3 signature moves with the user, e.g.
-    #   L9  "Marked Quarry" — she studies a target; party hits on it gain accuracy
-    #   L12 "Twin Fangs"    — instant bow shot + dagger slash on an adjacent foe
+    # Signatures form a deliberate hunt: Marked Quarry (Quarried state,
+    # -25% target protection for the whole party) into Twin Fangs (fast
+    # close-range finisher, +50% against a Quarried target).
     skill_schedule = {
         3: [("WeightUp", "Dodge", 4)],
         5: [("NewMove", moves.TacticalRetreat, 2)],
         7: [("WeightUp", "Flanking Maneuver", 3)],
+        9: [("NewMove", moves.MarkedQuarry, 2)],
+        12: [("NewMove", moves.TwinFangs, 3)],
     }
 
     def __init__(self):

--- a/src/npc/_friends.py
+++ b/src/npc/_friends.py
@@ -122,6 +122,27 @@ class Mynx(MynxLLMMixin, Friend):
 
 
 class Gorran(Friend):  # The "rock-man" that helps Jean at the beginning of the game.
+    # Static per-level growth (see npc/_progression.py). Tank/bruiser: heavy
+    # HP and damage scaling, slowly hardening armor, forever slow on his feet.
+    growth_profile = {
+        "maxhp": 14,
+        "damage": 3,
+        "protection": 0.5,
+        "speed": 0.25,
+        "finesse": 0.5,
+        "maxfatigue": 5,
+    }
+    # Deterministic skill acquisition. Early levels deepen what he already
+    # does; Bull Charge is Jean-learnable and fits a charging rock-man.
+    # TODO(signature): design 2-3 signature moves with the user, e.g.
+    #   L9  "Seismic Slam"  — AoE ground slam, long recoil
+    #   L12 "Stone Bulwark" — brief party-wide protection buff
+    skill_schedule = {
+        3: [("WeightUp", "Parry", 3)],
+        5: [("NewMove", moves.BullCharge, 2)],
+        7: [("WeightUp", moves.GorranClub, 4)],
+    }
+
     def __init__(self):
         description = """
 A massive creature that somewhat resembles a man,
@@ -601,6 +622,27 @@ class Mara(HumanNPCLLMMixin, Friend):
     positioning, and tactical awareness. Fights with the same observant efficiency as
     she moves through the world.
     """
+
+    # Static per-level growth (see npc/_progression.py). Skirmisher: modest
+    # HP, sharp gains in speed and finesse — she survives by not being hit.
+    growth_profile = {
+        "maxhp": 6,
+        "damage": 2.5,
+        "protection": 0.5,
+        "speed": 0.75,
+        "finesse": 1,
+        "maxfatigue": 6,
+    }
+    # Early levels sharpen evasion and kiting; Tactical Retreat is
+    # Jean-learnable (Bow tree) and anchors her bow-mode range control.
+    # TODO(signature): design 2-3 signature moves with the user, e.g.
+    #   L9  "Marked Quarry" — she studies a target; party hits on it gain accuracy
+    #   L12 "Twin Fangs"    — instant bow shot + dagger slash on an adjacent foe
+    skill_schedule = {
+        3: [("WeightUp", "Dodge", 4)],
+        5: [("NewMove", moves.TacticalRetreat, 2)],
+        7: [("WeightUp", "Flanking Maneuver", 3)],
+    }
 
     def __init__(self):
         description = (

--- a/src/npc/_progression.py
+++ b/src/npc/_progression.py
@@ -1,0 +1,170 @@
+"""
+AllyProgressionMixin — static, player-uncontrolled leveling for ally NPCs.
+
+Mixed into Friend (_base.py).  Companion classes opt in by declaring a
+``growth_profile`` (per-level stat increments) and, optionally, a
+``skill_schedule`` (level → move grants).  A Friend subclass without a
+growth_profile never levels, which keeps flavor NPCs (merchants, citizens,
+TheAdjutant) inert with no extra flags.
+
+Design notes (docs/development/ally-progression-design.md):
+  - Allies receive the same total exp Jean banks to his level track per
+    victory; the award is made by ApiCombatAdapter._handle_victory().
+  - exp_to_level reuses the player's formula with the ally's own (static)
+    intelligence, so pacing matches Jean at intelligence parity.
+  - Ally level is hard-capped at Jean's level; banked exp resolves after
+    Jean levels.  Allies 2+ levels behind gain exp at 1.5x until caught up.
+  - Stat growth recomputes absolutely from spawn-time bases so fractional
+    rates never drift across save/load.
+  - This mixin emits no narration; the combat adapter logs level-ups and
+    skill learns from the event dicts returned here (mirrors the player's
+    _level_up_api contract).
+
+Attributes expected on the host class (provided by NPC/Friend.__init__):
+    self.name, self.intelligence, stat attributes with ``_base`` twins,
+    self.known_moves, self.add_move (NPCCombatMixin)
+"""
+
+LEVEL_CAP = 100
+CATCH_UP_MULTIPLIER = 1.5
+
+
+class AllyProgressionMixin:
+    """Deterministic exp/level growth for ally NPCs."""
+
+    # Per-level stat increments, e.g. {"maxhp": 14, "damage": 3, "protection": 0.5}.
+    # Fractional rates grant a point every 1/rate levels via the int() floor.
+    # None (the default) disables progression entirely for the class.
+    growth_profile = None
+
+    # Level → list of grants, each one of:
+    #   ("NewMove", MoveClass, weight)   — learn MoveClass at the given AI weight
+    #   ("WeightUp", selector, n)        — raise a known move's weight to n;
+    #     selector is a move name string or a move class (class form matters
+    #     for moves that share display names, e.g. GorranClub is "NPC_Attack")
+    skill_schedule = None
+
+    @property
+    def exp_to_level(self):
+        """Exp needed for the next level — the player's curve with this ally's intelligence."""
+        level = int(getattr(self, "level", 1) or 1)
+        intelligence = int(getattr(self, "intelligence", 10) or 10)
+        return level * max(1, 165 - intelligence)
+
+    def gain_exp(self, amt, player_level):
+        """Bank combat exp and resolve any level-ups, capped at the player's level.
+
+        Returns a list of level-up event dicts for the combat adapter to log
+        and surface (empty for non-progressing allies).
+        """
+        if not self.growth_profile:
+            return []
+        self._ensure_progression_attrs()
+        cap = min(int(player_level), LEVEL_CAP)
+        if self.level < cap - 1:
+            amt = int(amt * CATCH_UP_MULTIPLIER)
+        self.exp += int(amt)
+        events = []
+        while self.level < cap and self.exp >= self.exp_to_level:
+            events.append(self._level_up())
+        return events
+
+    def sync_level(self, target_level):
+        """Silently bring a joining ally up to target_level (skills included).
+
+        Story join-points call this so late companions arrive battle-ready
+        and returning companions spawned as fresh instances don't reset.
+        """
+        if not self.growth_profile:
+            return
+        self._ensure_progression_attrs()
+        while self.level < min(int(target_level), LEVEL_CAP):
+            self._level_up()
+        self.exp = max(0, self.exp)
+
+    def _ensure_progression_attrs(self):
+        """Backfill level/exp for instances from saves predating progression."""
+        if getattr(self, "level", None) is None:
+            self.level = 1
+        if getattr(self, "exp", None) is None:
+            self.exp = 0
+
+    def _level_up(self):
+        """Advance one level: deterministic stat growth + scheduled skills.
+
+        Returns an event dict shaped like the player's _level_up_api result.
+        """
+        old_level = self.level
+        self.exp -= self.exp_to_level
+        if self.exp < 0:
+            self.exp = 0
+        self.level += 1
+        self._apply_growth()
+        learned = self._apply_skill_schedule()
+        return {
+            "ally_level_up": True,
+            "name": self.name,
+            "old_level": int(old_level),
+            "new_level": int(self.level),
+            "skills_learned": learned,
+        }
+
+    def _apply_growth(self):
+        """Recompute grown stats absolutely from spawn-time bases.
+
+        Recompute-from-spawn (rather than accumulate) keeps fractional rates
+        drift-free and is idempotent across save/load.  Current hp/fatigue
+        rise by the max-pool deltas so leveling never leaves an ally
+        proportionally more wounded.
+        """
+        import functions  # local import: functions imports npc classes indirectly
+
+        if not hasattr(self, "_spawn_bases"):
+            self._spawn_bases = {
+                stat: getattr(self, f"{stat}_base", getattr(self, stat, 0))
+                for stat in self.growth_profile
+            }
+        pool_deltas = {}
+        for stat, rate in self.growth_profile.items():
+            base_attr = f"{stat}_base"
+            new_base = self._spawn_bases[stat] + int(rate * (self.level - 1))
+            old_base = getattr(self, base_attr, self._spawn_bases[stat])
+            delta = new_base - old_base
+            if delta == 0:
+                continue
+            setattr(self, base_attr, new_base)
+            # Mirror onto the live stat for attributes reset_stats doesn't
+            # cover (damage, protection); covered ones are recomputed below.
+            setattr(self, stat, getattr(self, stat, new_base) + delta)
+            if stat in ("maxhp", "maxfatigue"):
+                pool_deltas[stat] = delta
+        try:
+            functions.refresh_stat_bonuses(self)
+        except Exception:
+            pass  # stat refresh must never crash a level-up mid-combat
+        if pool_deltas.get("maxhp"):
+            self.hp = min(self.maxhp, self.hp + pool_deltas["maxhp"])
+        if pool_deltas.get("maxfatigue"):
+            self.fatigue = min(self.maxfatigue, self.fatigue + pool_deltas["maxfatigue"])
+
+    def _apply_skill_schedule(self):
+        """Apply this level's scheduled grants. Returns names of newly learned moves."""
+        learned = []
+        for grant in (self.skill_schedule or {}).get(self.level, []):
+            kind = grant[0]
+            if kind == "NewMove":
+                _, move_cls, weight = grant
+                move = move_cls(self)
+                if not any(m.name == move.name for m in self.known_moves):
+                    self.add_move(move, weight)
+                    learned.append(move.name)
+            elif kind == "WeightUp":
+                _, selector, new_weight = grant
+                for m in self.known_moves:
+                    if (
+                        m.name == selector
+                        if isinstance(selector, str)
+                        else isinstance(m, selector)
+                    ):
+                        m.weight = new_weight
+        return learned

--- a/src/npc/_progression.py
+++ b/src/npc/_progression.py
@@ -10,12 +10,13 @@ TheAdjutant) inert with no extra flags.
 Design notes (docs/development/ally-progression-design.md):
   - Allies receive the same total exp Jean banks to his level track per
     victory; the award is made by ApiCombatAdapter._handle_victory().
-  - exp_to_level reuses the player's formula with the ally's own (static)
-    intelligence, so pacing matches Jean at intelligence parity.
+  - exp_to_level uses the shared curve (combatant.exp_needed_for_level) with
+    the ally's own (static) intelligence, so pacing matches Jean at
+    intelligence parity by construction.
   - Ally level is hard-capped at Jean's level; banked exp resolves after
     Jean levels.  Allies 2+ levels behind gain exp at 1.5x until caught up.
-  - Stat growth recomputes absolutely from spawn-time bases so fractional
-    rates never drift across save/load.
+  - Stat growth applies deterministic per-level deltas; the int() floors are
+    computed against the cumulative curve so fractional rates never drift.
   - This mixin emits no narration; the combat adapter logs level-ups and
     skill learns from the event dicts returned here (mirrors the player's
     _level_up_api contract).
@@ -24,6 +25,12 @@ Attributes expected on the host class (provided by NPC/Friend.__init__):
     self.name, self.intelligence, stat attributes with ``_base`` twins,
     self.known_moves, self.add_move (NPCCombatMixin)
 """
+
+import logging
+
+from combatant import exp_needed_for_level  # type: ignore
+
+logger = logging.getLogger(__name__)
 
 LEVEL_CAP = 100
 CATCH_UP_MULTIPLIER = 1.5
@@ -46,10 +53,10 @@ class AllyProgressionMixin:
 
     @property
     def exp_to_level(self):
-        """Exp needed for the next level — the player's curve with this ally's intelligence."""
-        level = int(getattr(self, "level", 1) or 1)
-        intelligence = int(getattr(self, "intelligence", 10) or 10)
-        return level * max(1, 165 - intelligence)
+        """Exp needed for the next level — the shared curve with this ally's intelligence."""
+        return exp_needed_for_level(
+            getattr(self, "level", 1) or 1, getattr(self, "intelligence", 10) or 10
+        )
 
     def gain_exp(self, amt, player_level):
         """Bank combat exp and resolve any level-ups, capped at the player's level.
@@ -78,8 +85,14 @@ class AllyProgressionMixin:
         if not self.growth_profile:
             return
         self._ensure_progression_attrs()
+        leveled = False
         while self.level < min(int(target_level), LEVEL_CAP):
-            self._level_up()
+            self._level_up(refresh_stats=False)
+            leveled = True
+        if leveled:
+            # One stat refresh for the whole climb — growth deltas are already
+            # applied per level; the refresh only re-derives live stats.
+            self._refresh_stats()
         self.exp = max(0, self.exp)
 
     def _ensure_progression_attrs(self):
@@ -89,7 +102,7 @@ class AllyProgressionMixin:
         if getattr(self, "exp", None) is None:
             self.exp = 0
 
-    def _level_up(self):
+    def _level_up(self, refresh_stats=True):
         """Advance one level: deterministic stat growth + scheduled skills.
 
         Returns an event dict shaped like the player's _level_up_api result.
@@ -99,7 +112,7 @@ class AllyProgressionMixin:
         if self.exp < 0:
             self.exp = 0
         self.level += 1
-        self._apply_growth()
+        self._apply_growth(refresh_stats=refresh_stats)
         learned = self._apply_skill_schedule()
         return {
             "ally_level_up": True,
@@ -109,43 +122,47 @@ class AllyProgressionMixin:
             "skills_learned": learned,
         }
 
-    def _apply_growth(self):
-        """Recompute grown stats absolutely from spawn-time bases.
+    def _apply_growth(self, refresh_stats=True):
+        """Apply this level's deterministic stat deltas.
 
-        Recompute-from-spawn (rather than accumulate) keeps fractional rates
-        drift-free and is idempotent across save/load.  Current hp/fatigue
-        rise by the max-pool deltas so leveling never leaves an ally
-        proportionally more wounded.
+        Each delta is the difference between the cumulative curve at this
+        level and the previous one (int floors included), so fractional rates
+        never drift and no spawn-stat snapshot needs to be carried in saves.
+        Current hp/fatigue rise by the max-pool deltas so leveling never
+        leaves an ally proportionally more wounded.
         """
-        import functions  # local import: functions imports npc classes indirectly
-
-        if not hasattr(self, "_spawn_bases"):
-            self._spawn_bases = {
-                stat: getattr(self, f"{stat}_base", getattr(self, stat, 0))
-                for stat in self.growth_profile
-            }
         pool_deltas = {}
         for stat, rate in self.growth_profile.items():
-            base_attr = f"{stat}_base"
-            new_base = self._spawn_bases[stat] + int(rate * (self.level - 1))
-            old_base = getattr(self, base_attr, self._spawn_bases[stat])
-            delta = new_base - old_base
+            delta = int(rate * (self.level - 1)) - int(rate * (self.level - 2))
             if delta == 0:
                 continue
-            setattr(self, base_attr, new_base)
+            base_attr = f"{stat}_base"
+            setattr(self, base_attr, getattr(self, base_attr, 0) + delta)
             # Mirror onto the live stat for attributes reset_stats doesn't
-            # cover (damage, protection); covered ones are recomputed below.
-            setattr(self, stat, getattr(self, stat, new_base) + delta)
+            # cover (damage, protection); covered ones are re-derived by the
+            # stat refresh below.
+            setattr(self, stat, getattr(self, stat, 0) + delta)
             if stat in ("maxhp", "maxfatigue"):
                 pool_deltas[stat] = delta
-        try:
-            functions.refresh_stat_bonuses(self)
-        except Exception:
-            pass  # stat refresh must never crash a level-up mid-combat
+        if refresh_stats:
+            self._refresh_stats()
         if pool_deltas.get("maxhp"):
             self.hp = min(self.maxhp, self.hp + pool_deltas["maxhp"])
         if pool_deltas.get("maxfatigue"):
             self.fatigue = min(self.maxfatigue, self.fatigue + pool_deltas["maxfatigue"])
+
+    def _refresh_stats(self):
+        """Re-derive live stats from bases + equipment/state bonuses."""
+        import functions  # local import: functions imports npc classes indirectly
+
+        try:
+            functions.refresh_stat_bonuses(self)
+        except Exception as exc:
+            # Never crash a level-up mid-combat over a stat refresh; log so
+            # a systematic failure leaves a diagnostic trail.
+            logger.warning(
+                "Ally stat refresh failed for %s: %s", getattr(self, "name", "?"), exc
+            )
 
     def _apply_skill_schedule(self):
         """Apply this level's scheduled grants. Returns names of newly learned moves."""
@@ -160,11 +177,20 @@ class AllyProgressionMixin:
                     learned.append(move.name)
             elif kind == "WeightUp":
                 _, selector, new_weight = grant
+                matched = False
                 for m in self.known_moves:
-                    if (
-                        m.name == selector
-                        if isinstance(selector, str)
-                        else isinstance(m, selector)
-                    ):
+                    if isinstance(selector, str):
+                        is_match = m.name == selector
+                    else:
+                        is_match = isinstance(m, selector)
+                    if is_match:
                         m.weight = new_weight
+                        matched = True
+                if not matched:
+                    logger.warning(
+                        "%s level %s WeightUp grant matched no known move: %r",
+                        getattr(self, "name", "?"),
+                        self.level,
+                        selector,
+                    )
         return learned

--- a/src/player/_leveling.py
+++ b/src/player/_leveling.py
@@ -2,6 +2,7 @@
 
 import random
 
+from combatant import exp_needed_for_level  # type: ignore
 from src.narration import cprint
 
 
@@ -67,10 +68,7 @@ class PlayerLevelingMixin:
         # Level up bookkeeping (match terminal behavior)
         self.level += 1
         self.exp -= self.exp_to_level
-        # Floor the per-level requirement at 1 per level so very high
-        # intelligence (>=165) can't drive exp_to_level <= 0 and spin the
-        # `while exp >= exp_to_level` loop in gain_exp() forever.
-        self.exp_to_level = self.level * max(1, (165 - self.intelligence))
+        self.exp_to_level = exp_needed_for_level(self.level, self.intelligence)
 
         # Apply random bonus increases to base stats
         bonuses = {}

--- a/src/states.py
+++ b/src/states.py
@@ -716,3 +716,58 @@ class BloodOfMartyrsState(State):
 
     def on_removal(self, target):
         self._absorbing = False
+
+
+class Quarried(State):
+    """Applied by Marked Quarry (Mara's ally signature move). The target's
+    weak points are called out: protection reduced by 25% for 15 beats.
+
+    A perception mark rather than a mental/physical status — applied with
+    force=True, bypassing status resistance (there is no resisting being
+    seen clearly)."""
+
+    def __init__(self, target):
+        super().__init__(
+            name="Quarried",
+            target=target,
+            beats_max=15,
+            compounding=False,
+            combat=True,
+            world=False,
+            statustype="generic",
+            persistent=False,
+            description="Weak points exposed — protection reduced by 25%.",
+        )
+        self.add_protection = -int(target.protection * 0.25)
+
+    def on_application(self, target):
+        functions.refresh_stat_bonuses(target)
+
+    def on_removal(self, target):
+        functions.refresh_stat_bonuses(target)
+
+
+class StoneBulwarkState(State):
+    """Applied by Stone Bulwark (Gorran's ally signature move) to each party
+    member: bonus protection scaling with Gorran's own for 20 beats."""
+
+    def __init__(self, target, amount):
+        super().__init__(
+            name="Stone Bulwark",
+            target=target,
+            beats_max=20,
+            compounding=False,
+            combat=True,
+            world=False,
+            statustype="generic",
+            persistent=False,
+            description="Shielded by living stone — bonus protection.",
+        )
+        self.add_protection = int(amount)
+
+    def on_application(self, target):
+        functions.refresh_stat_bonuses(target)
+
+    def on_removal(self, target):
+        functions.refresh_stat_bonuses(target)
+        cprint(f"The stone shielding {target.name} crumbles away.", "cyan")

--- a/src/story/ch01.py
+++ b/src/story/ch01.py
@@ -731,6 +731,7 @@ class Ch01PostRumbler3(Event):
         if gorran is None:
             gorran = self.tile.spawn_npc("Gorran", delay=0)
             self.player.combat_list_allies.append(gorran)
+        gorran.sync_level(getattr(self.player, "level", 1))
         gorran.in_combat = True
         gorran.reset_combat_moves()
 
@@ -857,6 +858,7 @@ class AfterGorranIntro(Event):
             if gorran.name == "Gorran":
                 self.player.combat_list_allies.append(gorran)
                 gorran.friend = True
+                gorran.sync_level(getattr(self.player, "level", 1))
                 # Reset moves if joining mid-combat
                 if self.player.in_combat:
                     gorran.reset_combat_moves()

--- a/tests/acceptance/ally-progression/README.md
+++ b/tests/acceptance/ally-progression/README.md
@@ -1,0 +1,35 @@
+# Ally Progression — Acceptance Test
+
+Validates the static ally-progression system end-to-end
+(design: `docs/development/ally-progression-design.md`).
+
+## Run
+
+```bash
+./run.sh
+```
+
+Runs two layers:
+
+1. **Unit tests** (`tests/test_ally_progression.py`) — exp curve parity with
+   the player formula, level cap at Jean's level, catch-up multiplier,
+   deterministic stat growth, skill schedule grants, sync_level, legacy-save
+   backfill, pickle round-trip.
+2. **Harness scenario** (`tools/harness/scenarios/ally_progression.py`) —
+   boots the real Flask app with this directory's `config.ini`
+   (`startmap=combat-testing-arena`, `starting_party_members=Gorran`),
+   verifies Gorran level-syncs on join, primes his exp via the test-only
+   debug endpoint (`/api/debug/allies*`), wins a Fodder Pit fight, and
+   asserts he banked/leveled, never exceeds Jean's level, and the level-3
+   skill grant applied.
+
+## Manual dev session
+
+```bash
+CONFIG_FILE=tests/acceptance/ally-progression/config.ini python tools/run_api.py
+```
+
+Jean spawns in the Proving Grounds at level 2 with Gorran in the party.
+`GET /api/debug/allies` shows ally level/exp/moves;
+`POST /api/debug/allies/progression {"name": "Gorran", "level": N, "exp": M}`
+adjusts them (level moves upward only).

--- a/tests/acceptance/ally-progression/config.ini
+++ b/tests/acceptance/ally-progression/config.ini
@@ -1,0 +1,64 @@
+# =============================================================================
+# Heart of Virtue — Ally Progression Testing Configuration
+# =============================================================================
+# Drives the ally_progression harness scenario in the combat-testing arena.
+#
+# Usage (in-process, no servers or browser needed):
+#   CONFIG_FILE=tests/acceptance/ally-progression/config.ini \
+#     python tools/bug_hunt.py --scenario ally_progression
+#
+# Setup this config produces:
+#   - Jean spawns in the Proving Grounds (0, 0) at level 2.
+#   - Gorran starts in the party (starting_party_members) and is level-synced
+#     to Jean on join — the scenario asserts this.
+#   - The Fodder Pit (1, 0) provides Slime + CaveBat for a quick victory.
+# =============================================================================
+
+[game]
+testmode            = True
+skipdialog          = True
+skipintro           = True
+startmap            = combat-testing-arena
+startposition       = 0, 0
+use_colour          = True
+enable_animations   = False
+
+# Gorran joins the party at spawn (exercises the sync_level join path).
+starting_party_members = Gorran
+
+# Strong basic attacks so the fodder fight ends in a handful of turns.
+learn_all_skills    = False
+starting_items      = Shortsword
+
+
+[player]
+
+hp              = 200
+maxhp           = 200
+
+strength        = 35
+finesse         = 35
+speed           = 15
+endurance       = 10
+charisma        = 10
+intelligence    = 10
+faith           = 10
+
+# Level 2 so the scenario can raise Jean via the debug endpoint and verify
+# both the ally level cap and the catch-up band.
+level           = 2
+exp             = 0
+
+heat            = 1.0
+
+
+[scenario]
+
+active_scenario = fodder
+max_rounds      = 50
+
+
+[debug]
+
+debug_mode              = True
+log_combat_moves        = True

--- a/tests/acceptance/ally-progression/run.sh
+++ b/tests/acceptance/ally-progression/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Ally progression acceptance test — in-process, no servers or browser needed.
+set -e
+cd "$(dirname "$0")/../../.."
+
+echo "=== Ally progression unit tests ==="
+python -m pytest tests/test_ally_progression.py -q
+
+echo ""
+echo "=== Ally progression harness scenario (end-to-end via Flask test client) ==="
+CONFIG_FILE=tests/acceptance/ally-progression/config.ini \
+  python tools/bug_hunt.py --scenario ally_progression

--- a/tests/test_ally_progression.py
+++ b/tests/test_ally_progression.py
@@ -1,0 +1,257 @@
+"""Unit tests for ally NPC static progression (npc/_progression.py).
+
+Covers the AllyProgressionMixin contract: exp curve parity with the player
+formula, level cap at Jean's level, catch-up multiplier, deterministic stat
+growth (recompute-from-spawn), skill schedule grants, sync_level, legacy-save
+backfill, and pickle round-trip.
+"""
+
+import pickle
+from types import SimpleNamespace
+
+import moves
+from npc._base import Friend
+from npc._friends import Gorran
+from npc._progression import CATCH_UP_MULTIPLIER, LEVEL_CAP
+
+
+def _gorran():
+    g = Gorran()
+    # Detach from world lookups (name property probes current_room/universe)
+    g.current_room = None
+    g.player_ref = None
+    return g
+
+
+def _plain_friend():
+    return Friend(
+        name="Extra",
+        description="A friend with no growth profile.",
+        damage=10,
+        aggro=False,
+        exp_award=0,
+    )
+
+
+# --- Opt-in and defaults ------------------------------------------------------
+
+
+def test_friend_defaults_inert_without_growth_profile():
+    f = _plain_friend()
+    assert f.growth_profile is None
+    assert f.level == 1
+    assert f.exp == 0
+    events = f.gain_exp(10_000, player_level=50)
+    assert events == []
+    assert f.level == 1
+
+
+def test_sync_level_noop_without_growth_profile():
+    f = _plain_friend()
+    f.sync_level(10)
+    assert f.level == 1
+
+
+# --- Exp curve ----------------------------------------------------------------
+
+
+def test_exp_curve_matches_player_formula():
+    g = _gorran()
+    # Player formula: level * max(1, 165 - intelligence); Gorran int is 10.
+    assert g.exp_to_level == 1 * (165 - g.intelligence)
+    g.level = 7
+    assert g.exp_to_level == 7 * (165 - g.intelligence)
+
+
+def test_gain_exp_banks_and_levels():
+    g = _gorran()
+    need = g.exp_to_level
+    events = g.gain_exp(need - 1, player_level=2)
+    assert events == []
+    assert g.exp == need - 1
+    events = g.gain_exp(1, player_level=2)
+    assert len(events) == 1
+    assert events[0]["old_level"] == 1
+    assert events[0]["new_level"] == 2
+    assert g.level == 2
+    assert g.exp == 0
+
+
+def test_level_capped_at_player_level_and_exp_banked():
+    g = _gorran()
+    events = g.gain_exp(1_000_000, player_level=3)
+    assert g.level == 3
+    assert len(events) == 2
+    banked = g.exp
+    assert banked > 0  # overflow retained
+    # Once Jean levels, the banked exp resolves on the next award.
+    events = g.gain_exp(0, player_level=4)
+    # gain_exp(0) doesn't loop unless exp >= threshold — force via a real award
+    events = g.gain_exp(1, player_level=4)
+    assert g.level == 4 or g.exp >= 0  # levels if the bank covers the threshold
+    assert g.level <= 4
+
+
+def test_catch_up_multiplier_when_two_levels_behind():
+    g = _gorran()
+    g.gain_exp(100, player_level=5)  # level 1 vs 5 → catch-up zone
+    assert g.exp == int(100 * CATCH_UP_MULTIPLIER)
+
+
+def test_no_catch_up_within_one_level():
+    g = _gorran()
+    g.sync_level(4)
+    g.gain_exp(100, player_level=5)  # exactly one behind → no multiplier
+    assert g.exp == 100
+
+
+def test_level_hard_cap_100():
+    g = _gorran()
+    g.sync_level(LEVEL_CAP + 50)
+    assert g.level == LEVEL_CAP
+
+
+# --- Deterministic stat growth --------------------------------------------------
+
+
+def test_growth_recomputes_from_spawn_bases():
+    g = _gorran()
+    spawn_maxhp = g.maxhp_base
+    spawn_damage = g.damage_base
+    spawn_speed = g.speed_base
+    g.sync_level(5)
+    assert g.maxhp_base == spawn_maxhp + 14 * 4
+    assert g.damage_base == spawn_damage + 3 * 4
+    assert g.protection_base == int(0.5 * 4)  # +1 every 2 levels
+    assert g.speed_base == spawn_speed + int(0.25 * 4)
+    # Live stats track base (no equipment/states on a fresh Gorran)
+    assert g.maxhp == g.maxhp_base
+    assert g.damage == g.damage_base
+
+
+def test_growth_is_deterministic_and_drift_free():
+    a, b = _gorran(), _gorran()
+    a.sync_level(9)
+    # Reaching 9 one level at a time must produce identical stats.
+    for target in range(2, 10):
+        b.sync_level(target)
+    assert a.maxhp_base == b.maxhp_base
+    assert a.damage_base == b.damage_base
+    assert a.protection_base == b.protection_base
+    assert a.speed_base == b.speed_base
+
+
+def test_level_up_raises_current_hp_by_maxhp_delta():
+    g = _gorran()
+    g.hp = 50  # wounded
+    g.gain_exp(g.exp_to_level, player_level=2)
+    assert g.level == 2
+    assert g.hp == 50 + 14  # topped up by the maxhp delta, not fully healed
+    assert g.hp < g.maxhp
+
+
+# --- Skill schedule -------------------------------------------------------------
+
+
+def test_skill_schedule_weight_up_and_new_move():
+    g = _gorran()
+    g.sync_level(5)
+    parry = next(m for m in g.known_moves if m.name == "Parry")
+    assert parry.weight == 3  # L3 grant
+    bull = next((m for m in g.known_moves if m.name == "Bull Charge"), None)
+    assert bull is not None  # L5 grant
+    assert bull.weight == 2
+
+
+def test_skill_schedule_class_selector_hits_gorran_club_only():
+    g = _gorran()
+    g.sync_level(7)
+    club = next(m for m in g.known_moves if isinstance(m, moves.GorranClub))
+    basic = next(m for m in g.known_moves if isinstance(m, moves.NpcAttack))
+    assert club.weight == 4  # L7 grant targets the class, not the shared name
+    assert basic.weight == 4  # unchanged (spawn weight)
+
+
+def test_new_move_grant_is_idempotent():
+    g = _gorran()
+    g.sync_level(5)
+    count = len(g.known_moves)
+    learned = g._apply_skill_schedule()  # re-apply the level-5 grants
+    assert learned == []
+    assert len(g.known_moves) == count
+
+
+def test_level_up_event_reports_learned_skills():
+    g = _gorran()
+    g.sync_level(4)
+    g.exp = g.exp_to_level
+    events = g.gain_exp(0, player_level=6) or g.gain_exp(1, player_level=6)
+    level5 = [e for e in events if e["new_level"] == 5]
+    assert level5 and level5[0]["skills_learned"] == ["Bull Charge"]
+
+
+# --- sync_level -----------------------------------------------------------------
+
+
+def test_sync_level_matches_player_and_keeps_exp_clean():
+    g = _gorran()
+    g.sync_level(6)
+    assert g.level == 6
+    assert g.exp >= 0
+
+
+def test_sync_level_never_lowers():
+    g = _gorran()
+    g.sync_level(6)
+    g.sync_level(3)
+    assert g.level == 6
+
+
+# --- Persistence / legacy saves ---------------------------------------------------
+
+
+def test_legacy_save_backfill():
+    g = _gorran()
+    del g.level
+    del g.exp
+    events = g.gain_exp(10, player_level=3)
+    assert events == []
+    assert g.level == 1
+    assert g.exp == int(10 * CATCH_UP_MULTIPLIER)
+
+
+def test_pickle_roundtrip_preserves_progression():
+    g = _gorran()
+    g.sync_level(5)
+    clone = pickle.loads(pickle.dumps(g))
+    assert clone.level == 5
+    assert clone.maxhp_base == g.maxhp_base
+    assert clone._spawn_bases == g._spawn_bases
+    assert any(m.name == "Bull Charge" for m in clone.known_moves)
+    # Progression continues on the restored instance
+    clone.gain_exp(1_000_000, player_level=6)
+    assert clone.level == 6
+
+
+# --- LLM chat surface --------------------------------------------------------------
+
+
+def test_combat_knowledge_block_empty_without_profile():
+    from npc._chat_llm import HumanNPCLLMMixin
+
+    bare = SimpleNamespace()
+    assert HumanNPCLLMMixin._build_combat_knowledge_block(bare) == ""
+
+
+def test_combat_knowledge_block_describes_techniques():
+    from npc._chat_llm import HumanNPCLLMMixin
+    from npc._friends import Mara
+
+    mara = Mara()
+    mara.sync_level(5)
+    block = HumanNPCLLMMixin._build_combat_knowledge_block(mara)
+    assert "COMBAT SELF-KNOWLEDGE" in block
+    assert "seasoned" in block
+    assert "Dodge" in block
+    assert "Tactical Retreat" in block  # L5 grant
+    assert "NPC_Attack" not in block  # internal names filtered

--- a/tests/test_ally_progression.py
+++ b/tests/test_ally_progression.py
@@ -82,14 +82,11 @@ def test_level_capped_at_player_level_and_exp_banked():
     events = g.gain_exp(1_000_000, player_level=3)
     assert g.level == 3
     assert len(events) == 2
-    banked = g.exp
-    assert banked > 0  # overflow retained
-    # Once Jean levels, the banked exp resolves on the next award.
-    events = g.gain_exp(0, player_level=4)
-    # gain_exp(0) doesn't loop unless exp >= threshold — force via a real award
-    events = g.gain_exp(1, player_level=4)
-    assert g.level == 4 or g.exp >= 0  # levels if the bank covers the threshold
-    assert g.level <= 4
+    assert g.exp > 0  # overflow retained
+    # Once Jean levels, the banked exp resolves on the next award (the
+    # million-exp bank always covers the level-4 threshold).
+    g.gain_exp(1, player_level=4)
+    assert g.level == 4
 
 
 def test_catch_up_multiplier_when_two_levels_behind():
@@ -184,8 +181,7 @@ def test_new_move_grant_is_idempotent():
 def test_level_up_event_reports_learned_skills():
     g = _gorran()
     g.sync_level(4)
-    g.exp = g.exp_to_level
-    events = g.gain_exp(0, player_level=6) or g.gain_exp(1, player_level=6)
+    events = g.gain_exp(g.exp_to_level, player_level=6)
     level5 = [e for e in events if e["new_level"] == 5]
     assert level5 and level5[0]["skills_learned"] == ["Bull Charge"]
 
@@ -226,7 +222,6 @@ def test_pickle_roundtrip_preserves_progression():
     clone = pickle.loads(pickle.dumps(g))
     assert clone.level == 5
     assert clone.maxhp_base == g.maxhp_base
-    assert clone._spawn_bases == g._spawn_bases
     assert any(m.name == "Bull Charge" for m in clone.known_moves)
     # Progression continues on the restored instance
     clone.gain_exp(1_000_000, player_level=6)

--- a/tests/test_ally_signature_moves.py
+++ b/tests/test_ally_signature_moves.py
@@ -161,6 +161,40 @@ def test_seismic_slam_not_viable_without_hostiles_in_radius():
     assert not move.viable()
 
 
+def test_seismic_slam_never_hits_the_player(monkeypatch, player):
+    """Regression: coordinate proximity sync puts Jean in every ally's
+    combat_proximity dict, and ally.player_ref is never assigned — the
+    side check must recognize the player by his missing `friend` attribute,
+    not via player_ref, or Gorran's slam friendly-fires Jean."""
+    monkeypatch.setattr("moves._npc.random.randint", lambda a, b: 0)  # always hit
+
+    g = _gorran(9)
+    assert g.player_ref is None  # the trap this test guards against
+    enemy = _dummy_enemy()
+    g.combat_proximity = {player: 1, enemy: 4}
+
+    move = next(mv for mv in g.known_moves if mv.name == "Seismic Slam")
+    move.evaluate()
+    move.execute(g)
+    assert player.hp == player.maxhp  # Jean untouched
+    assert enemy.hp < enemy.maxhp
+
+    # Jean alone in range must not make the slam viable either.
+    g.combat_proximity = {player: 1}
+    assert not move.viable()
+
+
+def test_hostile_to_side_classification(player):
+    from moves._npc import _hostile_to
+
+    ally = _gorran(1)  # friend=True
+    enemy = _dummy_enemy()  # friend=False
+    assert not _hostile_to(ally, player)  # ally never hostile to Jean
+    assert _hostile_to(enemy, player)  # enemy is hostile to Jean
+    assert _hostile_to(ally, enemy) and _hostile_to(enemy, ally)
+    assert not _hostile_to(enemy, _dummy_enemy())  # same side
+
+
 # --- Stone Bulwark -----------------------------------------------------------------
 
 

--- a/tests/test_ally_signature_moves.py
+++ b/tests/test_ally_signature_moves.py
@@ -1,0 +1,217 @@
+"""Unit tests for ally signature moves (Seismic Slam, Stone Bulwark,
+Marked Quarry, Twin Fangs) and their skill-schedule grants.
+
+Kit design: docs/development/ally-progression-design.md (signature notes).
+"""
+
+import moves
+import states
+from npc._base import NPC
+from npc._friends import Gorran, Mara
+
+
+def _gorran(level=1):
+    g = Gorran()
+    g.current_room = None
+    g.player_ref = None
+    if level > 1:
+        g.sync_level(level)
+    return g
+
+
+def _mara(level=1):
+    m = Mara()
+    m.current_room = None
+    m.player_ref = None
+    if level > 1:
+        m.sync_level(level)
+    return m
+
+
+def _dummy_enemy(protection=0, finesse=10, maxhp=500):
+    e = NPC(
+        name="Target",
+        description="test target",
+        damage=1,
+        aggro=True,
+        exp_award=0,
+        maxhp=maxhp,
+        protection=protection,
+        finesse=finesse,
+    )
+    e.in_combat = True
+    return e
+
+
+# --- Schedule grants ------------------------------------------------------------
+
+
+def test_gorran_learns_signatures_at_9_and_12():
+    g = _gorran(12)
+    names = [m.name for m in g.known_moves]
+    assert "Seismic Slam" in names
+    assert "Stone Bulwark" in names
+
+
+def test_mara_learns_signatures_at_9_and_12():
+    m = _mara(12)
+    names = [mv.name for mv in m.known_moves]
+    assert "Marked Quarry" in names
+    assert "Twin Fangs" in names
+
+
+def test_signature_moves_appear_in_chat_knowledge():
+    from npc._chat_llm import HumanNPCLLMMixin
+
+    m = _mara(12)
+    block = HumanNPCLLMMixin._build_combat_knowledge_block(m)
+    assert "Marked Quarry" in block
+    assert "Twin Fangs" in block
+
+
+# --- Marked Quarry ----------------------------------------------------------------
+
+
+def test_marked_quarry_reduces_target_protection():
+    m = _mara(9)
+    enemy = _dummy_enemy(protection=12)
+    m.target = enemy
+    move = next(mv for mv in m.known_moves if mv.name == "Marked Quarry")
+    move.target = enemy
+    move.execute(m)
+    assert any(isinstance(s, states.Quarried) for s in enemy.states)
+    assert enemy.protection == 12 - int(12 * 0.25)
+
+
+def test_marked_quarry_not_viable_when_already_marked():
+    m = _mara(9)
+    enemy = _dummy_enemy(protection=12)
+    m.target = enemy
+    m.combat_proximity = {enemy: 10}
+    move = next(mv for mv in m.known_moves if mv.name == "Marked Quarry")
+    assert move.viable()
+    move.target = enemy
+    move.execute(m)
+    assert not move.viable()  # already Quarried
+
+
+# --- Twin Fangs --------------------------------------------------------------------
+
+
+def test_twin_fangs_hits_harder_against_quarried_target(monkeypatch):
+    monkeypatch.setattr("moves._npc.random.randint", lambda a, b: 0)  # always hit, no glance
+
+    m = _mara(12)
+    move = next(mv for mv in m.known_moves if mv.name == "Twin Fangs")
+
+    plain = _dummy_enemy()
+    move.target = plain
+    move.evaluate()
+    move.execute(m)
+    plain_damage = plain.maxhp - plain.hp
+    assert plain_damage > 0
+
+    marked = _dummy_enemy()
+    marked.states.append(states.Quarried(marked))
+    m.fatigue = m.maxfatigue
+    move.target = marked
+    move.execute(m)
+    marked_damage = marked.maxhp - marked.hp
+    assert marked_damage == int(plain_damage * move._QUARRY_BONUS)
+
+
+def test_twin_fangs_viable_only_in_close_range():
+    m = _mara(12)
+    enemy = _dummy_enemy()
+    m.target = enemy
+    move = next(mv for mv in m.known_moves if mv.name == "Twin Fangs")
+    m.combat_proximity = {enemy: 2}
+    move.target = enemy
+    assert move.viable()
+    m.combat_proximity = {enemy: 10}
+    assert not move.viable()
+
+
+# --- Seismic Slam --------------------------------------------------------------------
+
+
+def test_seismic_slam_hits_all_hostiles_in_radius(monkeypatch):
+    monkeypatch.setattr("moves._npc.random.randint", lambda a, b: 0)  # always hit
+
+    g = _gorran(9)
+    near = _dummy_enemy()
+    far = _dummy_enemy()
+    friend = Gorran()  # same side — must not be hit
+    friend.current_room = None
+    g.combat_proximity = {near: 4, far: 30, friend: 2}
+    move = next(mv for mv in g.known_moves if mv.name == "Seismic Slam")
+    move.evaluate()
+    assert move.viable()
+    move.execute(g)
+    assert near.hp < near.maxhp
+    assert far.hp == far.maxhp  # out of radius
+    assert friend.hp == friend.maxhp  # same side
+
+
+def test_seismic_slam_not_viable_without_hostiles_in_radius():
+    g = _gorran(9)
+    far = _dummy_enemy()
+    g.combat_proximity = {far: 30}
+    move = next(mv for mv in g.known_moves if mv.name == "Seismic Slam")
+    assert not move.viable()
+
+
+# --- Stone Bulwark -----------------------------------------------------------------
+
+
+def test_stone_bulwark_buffs_whole_party():
+    g = _gorran(12)
+    m = _mara(1)
+    g.combat_list_allies = [m, g]
+    g.in_combat = True
+    m.in_combat = True
+    enemy = _dummy_enemy()
+    g.combat_proximity = {enemy: 5}
+
+    move = next(mv for mv in g.known_moves if mv.name == "Stone Bulwark")
+    assert move.viable()
+
+    base_m, base_g = m.protection, g.protection
+    move.execute(g)
+    amount = 6 + int(g.protection_base * 0.5)
+    assert any(isinstance(s, states.StoneBulwarkState) for s in m.states)
+    assert any(isinstance(s, states.StoneBulwarkState) for s in g.states)
+    assert m.protection == base_m + amount
+
+    # Won't recast while the ward is up on anyone.
+    assert not move.viable()
+
+
+def test_stone_bulwark_not_viable_out_of_combat():
+    g = _gorran(12)
+    g.in_combat = False
+    move = next(mv for mv in g.known_moves if mv.name == "Stone Bulwark")
+    assert not move.viable()
+
+
+def test_stone_bulwark_full_stage_cycle_applies_ward():
+    """Drive the move through the real advance() stage machinery (as the
+    combat adapter does per beat), not just a direct execute() call."""
+    g = _gorran(12)
+    m = _mara(1)
+    g.combat_list_allies = [m, g]
+    g.in_combat = True
+    m.in_combat = True
+    enemy = _dummy_enemy()
+    g.combat_proximity = {enemy: 5}
+
+    move = next(mv for mv in g.known_moves if mv.name == "Stone Bulwark")
+    move.current_stage = 0
+    move.beats_left = move.stage_beat[0]
+    g.current_move = move
+    for _ in range(12):  # prep 3 + execute 1 + recoil 2, with margin
+        move.advance(g)
+        if any(isinstance(s, states.StoneBulwarkState) for s in m.states):
+            break
+    assert any(isinstance(s, states.StoneBulwarkState) for s in m.states)
+    assert any(isinstance(s, states.StoneBulwarkState) for s in g.states)

--- a/tests/test_animations_gaps.py
+++ b/tests/test_animations_gaps.py
@@ -62,13 +62,26 @@ def test_animate_to_main_screen_api_mode_returns_early():
 # ---------------------------------------------------------------------------
 
 
+def test_animate_to_main_screen_no_terminal_returns_early():
+    """animate_to_main_screen skips when stdout is not a real terminal
+    (pytest/CI/headless) — curses would raise 'setupterm' otherwise."""
+    import src.animations as animations
+
+    animations.set_api_mode(False)
+    with patch.object(animations, "_terminal_available", return_value=False):
+        with patch.object(animations.Screen, "wrapper") as mock_wrapper:
+            animations.animate_to_main_screen("flash.gif", "rawtext")
+    mock_wrapper.assert_not_called()
+
+
 def test_animate_to_main_screen_gif_path_detail():
     """animate_to_main_screen with .gif uses play_gif as the func argument."""
     import src.animations as animations
 
     animations.set_api_mode(False)
-    with patch.object(animations.Screen, "wrapper") as mock_wrapper:
-        animations.animate_to_main_screen("flash.gif", "rawtext")
+    with patch.object(animations, "_terminal_available", return_value=True):
+        with patch.object(animations.Screen, "wrapper") as mock_wrapper:
+            animations.animate_to_main_screen("flash.gif", "rawtext")
 
     mock_wrapper.assert_called_once()
     _, kwargs = mock_wrapper.call_args
@@ -80,8 +93,9 @@ def test_animate_to_main_screen_gif_path_via_mock():
     import src.animations as animations
 
     animations.set_api_mode(False)
-    with patch.object(animations.Screen, "wrapper") as mock_wrapper:
-        animations.animate_to_main_screen("flash.gif", "")
+    with patch.object(animations, "_terminal_available", return_value=True):
+        with patch.object(animations.Screen, "wrapper") as mock_wrapper:
+            animations.animate_to_main_screen("flash.gif", "")
     mock_wrapper.assert_called_once()
 
 
@@ -96,8 +110,9 @@ def test_animate_to_main_screen_existing_function():
 
     animations.set_api_mode(False)
     # 'demo' is a known function in the module
-    with patch.object(animations.Screen, "wrapper") as mock_wrapper:
-        animations.animate_to_main_screen("demo", "")
+    with patch.object(animations, "_terminal_available", return_value=True):
+        with patch.object(animations.Screen, "wrapper") as mock_wrapper:
+            animations.animate_to_main_screen("demo", "")
     mock_wrapper.assert_called_once()
 
 
@@ -106,8 +121,9 @@ def test_animate_to_main_screen_function_with_text():
     import src.animations as animations
 
     animations.set_api_mode(False)
-    with patch.object(animations.Screen, "wrapper") as mock_wrapper:
-        animations.animate_to_main_screen("demo", "some text here")
+    with patch.object(animations, "_terminal_available", return_value=True):
+        with patch.object(animations.Screen, "wrapper") as mock_wrapper:
+            animations.animate_to_main_screen("demo", "some text here")
     mock_wrapper.assert_called_once()
     # Verify arguments were passed
     _, kwargs = mock_wrapper.call_args
@@ -119,7 +135,8 @@ def test_animate_to_main_screen_not_found(capsys):
     import src.animations as animations
 
     animations.set_api_mode(False)
-    animations.animate_to_main_screen("nonexistent_function_xyz", "")
+    with patch.object(animations, "_terminal_available", return_value=True):
+        animations.animate_to_main_screen("nonexistent_function_xyz", "")
     out = capsys.readouterr().out
     assert "Animation not found" in out
 

--- a/tools/harness/scenarios/__init__.py
+++ b/tools/harness/scenarios/__init__.py
@@ -14,6 +14,7 @@ from .inventory_actions import InventoryActionsScenario
 from .ch01_events import Ch01EventsScenario
 from .ch01_wrong_choice import Ch01WrongChoiceScenario
 from .grondia_happy_path import GroniaHappyPathScenario
+from .ally_progression import AllyProgressionScenario
 
 _ALL_SCENARIOS = [
     HealthScenario(),
@@ -30,6 +31,7 @@ _ALL_SCENARIOS = [
     Ch01EventsScenario(),
     Ch01WrongChoiceScenario(),
     GroniaHappyPathScenario(),
+    AllyProgressionScenario(),
 ]
 
 

--- a/tools/harness/scenarios/ally_progression.py
+++ b/tools/harness/scenarios/ally_progression.py
@@ -33,29 +33,30 @@ class AllyProgressionScenario(Scenario):
 
         bugs = []
 
-        # This scenario needs its dedicated config (starting_party_members =
-        # Gorran on the arena map).  In a full-suite run without it, skip
-        # cleanly rather than reporting setup noise as bugs.
-        config_path = os.environ.get("CONFIG_FILE", "")
-        if "ally-progression" not in config_path:
-            print(
-                "[AllyProgressionScenario] Skipped — set "
-                "CONFIG_FILE=tests/acceptance/ally-progression/config.ini to run."
-            )
-            return bugs
-
         # 1. Party + sync-level checks -----------------------------------
+        # Capability probe: this scenario needs a Gorran party ally
+        # (starting_party_members in the dedicated config).  If he's absent,
+        # decide by intent: the ally config being active means broken setup
+        # (real bug); any other config means this scenario simply isn't
+        # provisioned in this run — skip cleanly.
         gorran = self._get_gorran(client)
         if gorran is None:
-            bugs.append(self._bug(
-                title="Gorran not in party — run with CONFIG_FILE=tests/acceptance/ally-progression/config.ini",
-                severity=BugSeverity.HIGH,
-                category=BugCategory.WRONG_RESPONSE,
-                endpoint="/api/debug/allies",
-                method="GET",
-                expected="Gorran present in combat_list_allies (starting_party_members)",
-                actual="No party ally of class Gorran",
-            ))
+            config_path = os.environ.get("CONFIG_FILE", "")
+            if "ally-progression" in config_path:
+                bugs.append(self._bug(
+                    title="Gorran not in party despite ally-progression config (starting_party_members broken)",
+                    severity=BugSeverity.HIGH,
+                    category=BugCategory.WRONG_RESPONSE,
+                    endpoint="/api/debug/allies",
+                    method="GET",
+                    expected="Gorran present in combat_list_allies (starting_party_members)",
+                    actual="No party ally of class Gorran",
+                ))
+            else:
+                print(
+                    "[AllyProgressionScenario] Skipped — no Gorran party ally; run with "
+                    "CONFIG_FILE=tests/acceptance/ally-progression/config.ini."
+                )
             return bugs
 
         if not gorran.get("progression_enabled"):
@@ -238,17 +239,7 @@ class AllyProgressionScenario(Scenario):
                 return bugs, True
         return bugs, False
 
-    def _find_enemy(self, client: GameClient) -> Optional[str]:
-        resp = client.get("/api/world")
-        if resp.status_code != 200:
-            return None
-        room = client.parse(resp).get("room", {})
-        for npc in room.get("npcs", []):
-            if isinstance(npc, dict):
-                if npc.get("friend") or npc.get("is_ally"):
-                    continue
-                return npc.get("id") or npc.get("npc_id") or npc.get("name")
-        return None
+    # _find_enemy is inherited from Scenario (base.py).
 
     def _execute_move(self, client: GameClient) -> bool:
         """Execute the best available move. Returns True when combat ended."""

--- a/tools/harness/scenarios/ally_progression.py
+++ b/tools/harness/scenarios/ally_progression.py
@@ -1,0 +1,331 @@
+"""Ally NPC static progression — exp mirroring, level cap, skill schedule.
+
+Requires the ally-progression config so Gorran starts in the party:
+
+    CONFIG_FILE=tests/acceptance/ally-progression/config.ini \
+      python tools/bug_hunt.py --scenario ally_progression
+
+Flow:
+  1. Verify Gorran is a party ally with progression enabled and level-synced
+     to Jean (the starting_party_members join path calls sync_level).
+  2. Raise Jean's level via the debug endpoint and prime Gorran's exp just
+     below his next threshold.
+  3. Fight to victory in the Fodder Pit.
+  4. Assert Gorran banked exp / leveled, never exceeds Jean's level, and the
+     level-3 skill-schedule grant (Parry weight 3) applied.
+"""
+
+from typing import List, Optional, Tuple
+
+from .base import Scenario
+from ..client import GameClient
+from ..reporter import BugReport, BugSeverity, BugCategory
+
+_MAX_ROUNDS = 50
+
+
+class AllyProgressionScenario(Scenario):
+    name = "ally_progression"
+    description = "Ally static progression: exp mirror on victory, level cap, skill schedule."
+
+    def run(self, client: GameClient) -> List[BugReport]:
+        import os
+
+        bugs = []
+
+        # This scenario needs its dedicated config (starting_party_members =
+        # Gorran on the arena map).  In a full-suite run without it, skip
+        # cleanly rather than reporting setup noise as bugs.
+        config_path = os.environ.get("CONFIG_FILE", "")
+        if "ally-progression" not in config_path:
+            print(
+                "[AllyProgressionScenario] Skipped — set "
+                "CONFIG_FILE=tests/acceptance/ally-progression/config.ini to run."
+            )
+            return bugs
+
+        # 1. Party + sync-level checks -----------------------------------
+        gorran = self._get_gorran(client)
+        if gorran is None:
+            bugs.append(self._bug(
+                title="Gorran not in party — run with CONFIG_FILE=tests/acceptance/ally-progression/config.ini",
+                severity=BugSeverity.HIGH,
+                category=BugCategory.WRONG_RESPONSE,
+                endpoint="/api/debug/allies",
+                method="GET",
+                expected="Gorran present in combat_list_allies (starting_party_members)",
+                actual="No party ally of class Gorran",
+            ))
+            return bugs
+
+        if not gorran.get("progression_enabled"):
+            bugs.append(self._bug(
+                title="Gorran progression disabled (growth_profile missing)",
+                severity=BugSeverity.HIGH,
+                category=BugCategory.WRONG_RESPONSE,
+                endpoint="/api/debug/allies",
+                method="GET",
+                expected="progression_enabled=True for Gorran",
+                actual=str(gorran),
+            ))
+            return bugs
+
+        resp = client.get("/api/debug/player")
+        player = client.parse(resp)
+        jean_level = int(player.get("level", 0))
+        if gorran["level"] != jean_level:
+            bugs.append(self._bug(
+                title="Gorran did not level-sync to Jean on party join",
+                severity=BugSeverity.HIGH,
+                category=BugCategory.WRONG_RESPONSE,
+                endpoint="/api/debug/allies",
+                method="GET",
+                expected=f"Gorran level == Jean level ({jean_level})",
+                actual=f"Gorran level {gorran['level']}",
+            ))
+
+        # 2. Prime: Jean 2 levels ahead, Gorran one landed hit from leveling.
+        body = {"level": jean_level + 2, "exp": 0}
+        resp = client.post("/api/debug/player/level", json=body)
+        bug = self._check_status(resp, 200, "/api/debug/player/level", "POST",
+                                 "Raise Jean's level", request_body=body)
+        if bug:
+            bugs.append(bug)
+            return bugs
+
+        primed_exp = max(0, int(gorran["exp_to_level"]) - 5)
+        body = {"name": "Gorran", "exp": primed_exp}
+        resp = client.post("/api/debug/allies/progression", json=body)
+        bug = self._check_status(resp, 200, "/api/debug/allies/progression", "POST",
+                                 "Prime Gorran's exp", request_body=body)
+        if bug:
+            bugs.append(bug)
+            return bugs
+        pre_fight = self._get_gorran(client)
+
+        # 3. Fight to victory in the Fodder Pit ---------------------------
+        fight_bugs, won = self._fight_in_fodder_pit(client)
+        bugs += fight_bugs
+        if not won:
+            bugs.append(self._bug(
+                title="Ally progression fight did not reach victory",
+                severity=BugSeverity.MEDIUM,
+                category=BugCategory.WRONG_RESPONSE,
+                endpoint="/api/combat/move",
+                method="POST",
+                expected=f"Victory within {_MAX_ROUNDS} rounds in the Fodder Pit",
+                actual="Combat still active or errored — progression asserts skipped",
+            ))
+            return bugs
+
+        # 4. Post-victory assertions --------------------------------------
+        post_fight = self._get_gorran(client)
+        if post_fight is None:
+            bugs.append(self._bug(
+                title="Gorran missing from party after victory",
+                severity=BugSeverity.HIGH,
+                category=BugCategory.WRONG_RESPONSE,
+                endpoint="/api/debug/allies",
+                method="GET",
+                expected="Gorran still in combat_list_allies",
+                actual="Gorran absent",
+            ))
+            return bugs
+
+        progressed = (
+            post_fight["level"] > pre_fight["level"]
+            or post_fight["exp"] > pre_fight["exp"]
+        )
+        if not progressed:
+            bugs.append(self._bug(
+                title="Gorran gained no exp from a victory he fought in",
+                severity=BugSeverity.HIGH,
+                category=BugCategory.WRONG_RESPONSE,
+                endpoint="/api/debug/allies",
+                method="GET",
+                expected=f"level > {pre_fight['level']} or exp > {pre_fight['exp']}",
+                actual=f"level {post_fight['level']}, exp {post_fight['exp']}",
+            ))
+
+        resp = client.get("/api/debug/player")
+        jean_level = int(client.parse(resp).get("level", 0))
+        if post_fight["level"] > jean_level:
+            bugs.append(self._bug(
+                title="Ally leveled past Jean (level cap violated)",
+                severity=BugSeverity.HIGH,
+                category=BugCategory.WRONG_RESPONSE,
+                endpoint="/api/debug/allies",
+                method="GET",
+                expected=f"Gorran level <= Jean level ({jean_level})",
+                actual=f"Gorran level {post_fight['level']}",
+            ))
+
+        # Skill schedule: at level >= 3 Gorran's Parry weight is raised to 3.
+        if post_fight["level"] >= 3:
+            parry = next(
+                (m for m in post_fight.get("known_moves", []) if m["name"] == "Parry"),
+                None,
+            )
+            if not parry or parry.get("weight") != 3:
+                bugs.append(self._bug(
+                    title="Gorran's level-3 skill grant (Parry weight 3) not applied",
+                    severity=BugSeverity.MEDIUM,
+                    category=BugCategory.WRONG_RESPONSE,
+                    endpoint="/api/debug/allies",
+                    method="GET",
+                    expected="Parry present with weight 3 at level >= 3",
+                    actual=str(parry),
+                ))
+
+        return bugs
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_gorran(self, client: GameClient) -> Optional[dict]:
+        resp = client.get("/api/debug/allies")
+        if resp.status_code != 200:
+            return None
+        data = client.parse(resp)
+        for ally in data.get("allies", []):
+            if ally.get("class") == "Gorran":
+                return ally
+        return None
+
+    def _fight_in_fodder_pit(self, client: GameClient) -> Tuple[List[BugReport], bool]:
+        """Move east to the Fodder Pit, fight the first enemy to victory."""
+        bugs = []
+        body = {"direction": "east"}
+        resp = client.post("/api/world/move", json=body)
+        bug = self._check_status(resp, 200, "/api/world/move", "POST",
+                                 "Move to Fodder Pit", request_body=body)
+        if bug:
+            return [bug], False
+
+        enemy_id = self._find_enemy(client)
+        if not enemy_id:
+            bugs.append(self._bug(
+                title="No enemy found in the Fodder Pit",
+                severity=BugSeverity.MEDIUM,
+                category=BugCategory.WRONG_RESPONSE,
+                endpoint="/api/world",
+                method="GET",
+                expected="Slime/CaveBat present at (1, 0)",
+                actual="No hostile NPCs in room",
+            ))
+            return bugs, False
+
+        body = {"enemy_id": enemy_id}
+        resp = client.post("/api/combat/start", json=body)
+        bug = self._check_status(resp, 201, "/api/combat/start", "POST",
+                                 "Start combat", request_body=body)
+        if bug:
+            return [bug], False
+
+        for round_num in range(1, _MAX_ROUNDS + 1):
+            resp = client.get("/api/combat/status")
+            if resp.status_code != 200:
+                bugs.append(self._check_status(
+                    resp, 200, "/api/combat/status", "GET",
+                    f"Combat status (round {round_num})"))
+                return bugs, False
+            data = client.parse(resp)
+            if not data.get("combat_active"):
+                return bugs, True
+            ended = self._execute_move(client)
+            if ended:
+                return bugs, True
+        return bugs, False
+
+    def _find_enemy(self, client: GameClient) -> Optional[str]:
+        resp = client.get("/api/world")
+        if resp.status_code != 200:
+            return None
+        room = client.parse(resp).get("room", {})
+        for npc in room.get("npcs", []):
+            if isinstance(npc, dict):
+                if npc.get("friend") or npc.get("is_ally"):
+                    continue
+                return npc.get("id") or npc.get("npc_id") or npc.get("name")
+        return None
+
+    def _execute_move(self, client: GameClient) -> bool:
+        """Execute the best available move. Returns True when combat ended."""
+        resp = client.get("/api/combat/status")
+        if resp.status_code != 200:
+            return True
+        battle = client.parse(resp).get("battle_state", {})
+        options = battle.get("available_options", [])
+        input_type = battle.get("input_type", "move_selection")
+
+        # Multi-step prompts: a previously chosen move may be awaiting a
+        # number (Wait duration — options is a dict), a direction (options is
+        # a list of strings), or a target (options is a list of target dicts).
+        if input_type == "number_input":
+            default = options.get("default", 5) if isinstance(options, dict) else 5
+            resp = client.post(
+                "/api/combat/move",
+                json={"move_type": "number", "move_id": str(default)},
+            )
+            return self._response_ended(client, resp)
+        if input_type == "direction_selection":
+            direction = options[0] if options else "north"
+            resp = client.post(
+                "/api/combat/move",
+                json={"move_type": "direction", "direction": direction},
+            )
+            return self._response_ended(client, resp)
+        if input_type == "target_selection":
+            targets = [o for o in options if isinstance(o, dict) and o.get("id")]
+            if not targets:
+                return False
+            resp = client.post(
+                "/api/combat/move",
+                json={"move_type": "target", "target_id": targets[0]["id"]},
+            )
+            return self._response_ended(client, resp)
+
+        options = [o for o in options if isinstance(o, dict)]
+        move_index = None
+        target_id = None
+        advance_opt = None
+        wait_opt = None
+        for opt in options:
+            if not opt.get("available"):
+                continue
+            if opt.get("category") == "Offensive" and opt.get("viable_targets"):
+                move_index = opt.get("index")
+                target_id = opt["viable_targets"][0]["id"]
+                break
+            if opt.get("name") == "Advance" and advance_opt is None:
+                advance_opt = opt
+            if opt.get("name") == "Wait" and wait_opt is None:
+                wait_opt = opt
+
+        if move_index is None:
+            chosen = advance_opt or wait_opt
+            if chosen is None:
+                return False
+            move_index = chosen.get("index")
+            targets = chosen.get("viable_targets", [])
+            if targets:
+                target_id = targets[0]["id"]
+
+        body: dict = {"move_type": "move", "move_id": str(move_index)}
+        if target_id:
+            body["target_id"] = target_id
+        resp = client.post("/api/combat/move", json=body)
+        return self._response_ended(client, resp)
+
+    def _response_ended(self, client: GameClient, resp) -> bool:
+        """True when the move response signals combat has ended (or errored)."""
+        if resp.status_code != 200:
+            return True
+        data = client.parse(resp)
+        return bool(
+            not data.get("combat_active", True)
+            or data.get("combat_ended")
+            or data.get("victory")
+            or data.get("defeated")
+        )

--- a/tools/harness/scenarios/base.py
+++ b/tools/harness/scenarios/base.py
@@ -20,6 +20,23 @@ class Scenario(ABC):
     # Helpers
     # ------------------------------------------------------------------
 
+    def _find_enemy(self, client: "GameClient"):
+        """Return the first hostile NPC ID from the current room, or None."""
+        resp = client.get("/api/world")
+        if resp.status_code != 200:
+            return None
+        data = client.parse(resp)
+        room = data.get("room", {})
+        npcs = room.get("npcs", [])
+        for npc in npcs:
+            if isinstance(npc, dict):
+                # Skip friendly/ally NPCs
+                if npc.get("friend") or npc.get("is_ally"):
+                    continue
+                return npc.get("id") or npc.get("npc_id") or npc.get("name")
+            return str(npc)
+        return None
+
     def _bug(
         self,
         title: str,

--- a/tools/harness/scenarios/combat.py
+++ b/tools/harness/scenarios/combat.py
@@ -157,22 +157,7 @@ class CombatScenario(Scenario):
                 break  # stop on first nav failure
         return bugs
 
-    def _find_enemy(self, client: GameClient) -> Optional[str]:
-        """Return the first hostile NPC ID from the current room, or None."""
-        resp = client.get("/api/world")
-        if resp.status_code != 200:
-            return None
-        data = client.parse(resp)
-        room = data.get("room", {})
-        npcs = room.get("npcs", [])
-        for npc in npcs:
-            if isinstance(npc, dict):
-                # Skip friendly/ally NPCs
-                if npc.get("friend") or npc.get("is_ally"):
-                    continue
-                return npc.get("id") or npc.get("npc_id") or npc.get("name")
-            return str(npc)
-        return None
+    # _find_enemy is inherited from Scenario (base.py).
 
     def _check_invalid_start(self, client: GameClient) -> List[BugReport]:
         """Verify the API gracefully handles a non-existent enemy_id."""


### PR DESCRIPTION
Ally NPCs now grow stronger from the battles they fight in, with zero player micromanagement: stat gains and skill acquisitions are statically determined per companion class, and pacing tracks Jean's by construction.

## Progression system (`AllyProgressionMixin` on `Friend`)

- **Exp**: on every combat victory, each party ally receives the same total exp Jean banked that fight (`ApiCombatAdapter._handle_victory`). KO'd allies keep their full share.
- **Curve**: allies level on the player's exact formula via a new shared helper `combatant.exp_needed_for_level` (single source for both Player and ally leveling).
- **Pacing guardrails**: hard cap at Jean's level (banked exp resolves after he levels), ×1.5 catch-up when 2+ levels behind, and `sync_level(player.level)` at party-join points (ch01 joins, `starting_party_members` config).
- **Growth**: per-class `growth_profile` of deterministic per-level increments (drift-free telescoping deltas, no randomness, no allocation). Gorran grows as a tank, Mara as a skirmisher.
- **Skills**: per-class `skill_schedule` (`level → grants`) — new moves or AI weight bumps, applied automatically on level-up. Opt-in by design: a `Friend` without a `growth_profile` never levels (merchants, citizens, TheAdjutant stay inert).

## Signature moves (`moves/_npc.py`, states in `states.py`)

- **Gorran L9 — Seismic Slam**: telegraphed radial ground slam; ~0.7× damage (crushing) to every enemy within 6 ft, 25% Stagger chance per target (resistance-respecting), long recoil.
- **Gorran L12 — Stone Bulwark**: self-cast party ward; every ally gains protection scaling with Gorran's own for 20 beats; won't recast while a ward is up.
- **Mara L9 — Marked Quarry**: marks one enemy with the `Quarried` state (−25% protection, 15 beats, force-applied) — the whole party benefits through existing stat machinery.
- **Mara L12 — Twin Fangs**: fast close-range finisher, 1.2× damage, ×1.5 more against a Quarried target. Her kit is a deliberate hunt: mark, then execute.
- Earlier schedule levels draw from Jean-learnable moves (Parry/Dodge weight-ups, Bull Charge, Tactical Retreat, Flanking Maneuver).

## Surfacing (no UI elements by design)

Ally growth is exposed through the LLM ally chat: progressing allies get a `COMBAT SELF-KNOWLEDGE` block in their system prompt (experience tier + technique list) so the player can ask them about their combat abilities in character. Level-ups and learned skills are also narrated in the combat log, and `combat_end_summary` gains an `ally_progression` key.

## Engine fixes found along the way

- `NPCCombatMixin.refresh_moves` now syncs targeted moves to the NPC's current target before viability filtering — previously, target-dependent moves (Bull Charge, Flanking Maneuver) were never viable at selection time and went stale between fights. Single-target contract documented.
- Session setup now applies configured player stats *before* starting party members, so join-time level sync sees Jean's real level.

## Testing

- 33 new unit tests (`test_ally_progression.py`, `test_ally_signature_moves.py`), including pickle round-trip, legacy-save backfill, and a full `advance()` stage-cycle test. Full suite: 7,128 passed.
- New in-process harness scenario `ally_progression` + acceptance config (`tests/acceptance/ally-progression/`), driven by new test-only debug endpoints (`GET /api/debug/allies`, `POST /api/debug/allies/progression`). Skips cleanly when its config isn't active.
- Live-fire verification in the combat arena: Gorran synced to L12 cast Seismic Slam mid-boss-fight through the real AI selection and stage pipeline with no errors.

Design document: `docs/development/ally-progression-design.md` (includes implementation deltas and tuning notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTLijN7dUi31YvHaTt7EvM